### PR TITLE
Updates for orix-0.2.0

### DIFF
--- a/orix/objects.py
+++ b/orix/objects.py
@@ -17,4 +17,4 @@
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
 from orix.quaternion.orientation import Orientation, Misorientation
-from orix.vector.neo_euler import *
+from orix.vector.neo_euler import NeoEuler, Homochoric, Rodrigues, AxAngle

--- a/orix/symmetry.py
+++ b/orix/symmetry.py
@@ -16,5 +16,5 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-from orix.quaternion.symmetry import *
+from orix.quaternion.symmetry import Symmetry, get_distinguished_points
 from orix.quaternion.orientation_region import OrientationRegion

--- a/orix/symmetry.py
+++ b/orix/symmetry.py
@@ -16,5 +16,5 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-from orix.quaternion.symmetry import Symmetry, get_distinguished_points
+from orix.quaternion.symmetry import *
 from orix.quaternion.orientation_region import OrientationRegion

--- a/orix/tests/test_vector3d.py
+++ b/orix/tests/test_vector3d.py
@@ -135,6 +135,16 @@ def test_cross_error(vector, number):
     with pytest.raises(AttributeError):
         vector.cross(number)
 
+
+@pytest.mark.parametrize('theta, phi, r, expected', [
+    (np.pi / 4, np.pi / 4, 1, Vector3d((0.5, 0.5, 0.707107))),
+    (2 * np.pi / 3, 7 * np.pi / 6, 1, Vector3d((-0.75, -0.433013, -0.5))),
+])
+def test_polar(theta, phi, r, expected):
+    assert np.allclose(Vector3d.from_polar(theta, phi, r).data,
+                                           expected.data, atol=1e-5)
+
+
 @pytest.mark.parametrize('shape', [
     (1,),
     (2, 2),

--- a/orix/vector/__init__.py
+++ b/orix/vector/__init__.py
@@ -249,6 +249,28 @@ class Vector3d(Object3d):
         return other.__class__(np.cross(self.data, other.data))
 
     @classmethod
+    def from_polar(cls, theta, phi, r=1):
+        """Creates a Vector3d object from polar data.
+        Parameters
+        ----------
+        theta : array_like
+            The polar angle, in radians.
+        phi : array_like
+            The azimuthal angle, in radians.
+        r : array_like
+            The radial distance. Defaults to 1 to produce unit vectors.
+        Returns
+        -------
+        Vector3d
+        """
+        theta = np.atleast_1d(theta)
+        phi = np.atleast_1d(phi)
+        z = np.cos(theta)
+        y = np.sin(phi) * np.sin(theta)
+        x = np.cos(phi) * np.sin(theta)
+        return r * cls(np.stack((x, y, z), axis=-1))
+
+    @classmethod
     def zero(cls, shape=(1,)):
         """Returns zero vectors in the specified shape.
 


### PR DESCRIPTION
The following updates are associated with v0.2.0 of orix:

- [x] restored from_polar method to Vector3D
- [ ] test coverage complete #22 
- [x] namespace clarity #13 
- [ ] Misorientation.equivalent() bugfix #21 