### PR TITLE
Coverage PR the third.

### DIFF
--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -192,7 +192,7 @@ class Orientation(Misorientation):
     def __sub__(self, other):
         if isinstance(other, Orientation):
             misorientation = Misorientation(self * ~other)
-            m_inside = misorientation.set_symmetry((self.symmetry, other.symmetry)).squeeze()
+            m_inside = misorientation.set_symmetry(self.symmetry, other.symmetry).squeeze()
             return m_inside
         return NotImplemented
 

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -221,7 +221,7 @@ def _distance_1(misorientation, verbose):
 
 
 def _distance_2(misorientation, verbose):
-    if misorientation.size > 1e4:
+    if misorientation.size > 1e4: #pragma no cover
         confirm = input('Large datasets may crash your RAM.\nAre you sure? (y/n) ')
         if confirm != 'y':
             raise InterruptedError('Aborted')

--- a/orix/quaternion/symmetry.py
+++ b/orix/quaternion/symmetry.py
@@ -60,13 +60,6 @@ class Symmetry(Rotation):
     def __and__(self, other):
         return Symmetry.from_generators(*[g for g in self.subgroups if g in other.subgroups])
 
-    # def __eq__(self, other):
-    #     if isinstance(other, Symmetry):
-    #         if self._tuples == other._tuples:
-    #             return True
-    #         return False
-    #     return NotImplemented
-
     @property
     def order(self):
         """int : The number of elements of the group."""

--- a/orix/tests/test_orientation.py
+++ b/orix/tests/test_orientation.py
@@ -124,3 +124,15 @@ def test_equivalent(Gl):
     m.set_symmetry(Gl,C4,verbose=True)
     m.symmetry
     _m = m.equivalent
+
+def test_repr():
+    m = Misorientation([1,1,1,1]) # any will do
+    print(m) #hits __repr__
+    return None
+
+@pytest.mark.skip(reason="Currently under investigation")
+def test_sub():
+    m = Orientation([1,1,1,1]) # any will do
+    m.set_symmetry(C4) #only one as it a O
+    mis = m - m #this should give a set of zeroes
+    return None

--- a/orix/tests/test_orientation.py
+++ b/orix/tests/test_orientation.py
@@ -130,7 +130,6 @@ def test_repr():
     print(m) #hits __repr__
     return None
 
-@pytest.mark.skip(reason="Currently under investigation")
 def test_sub():
     m = Orientation([1,1,1,1]) # any will do
     m.set_symmetry(C4) #only one as it a O

--- a/orix/tests/test_orientation_region.py
+++ b/orix/tests/test_orientation_region.py
@@ -100,4 +100,3 @@ def test_get_proper_point_groups(Gl,Gr):
 def test_get_proper_point_group_not_implemented():
     """ Double inversion case not yet implemented """
     get_proper_groups(Csz,Csz)
-    return None

--- a/orix/tests/test_scalar.py
+++ b/orix/tests/test_scalar.py
@@ -9,12 +9,6 @@ from orix.vector import Vector3d
 def scalar(request):
     return Scalar(request.param)
 
-
-@pytest.fixture(params=[(1, 1, 1)])
-def vector(request):
-    return Vector3d(request.param)
-
-
 @pytest.mark.parametrize('data, expected', [
     ((5, 3), (5, 3)),
     ([[1], [2]], [[1], [2]]),

--- a/orix/tests/test_vector3d.py
+++ b/orix/tests/test_vector3d.py
@@ -39,12 +39,6 @@ numbers = [-12, 0.5, -0.333333333, 4]
 def vector(request):
     return Vector3d(request.param)
 
-
-@pytest.fixture(params=numbers)
-def scalar(request):
-    return Scalar(request.param)
-
-
 @pytest.fixture(params=singles)
 def something(request):
     return Vector3d(request.param)


### PR DESCRIPTION
Replaces and closes #27 so that coveralls will play nicely 

To do
-------

- [x] Make sure each test file has perfect coverge (3 are currently not there)
- [x] Add a `#pragma : no cover` on the high RAM usage code
- [ ] Decide how to deal with the `n==0` case of `get_plot_data` in `orientation_region`
- [x] Delete the commented code in `symmetry`
- [ ] Test the final case for fundamental zone formation

(More to be added)