### PR TITLE
Pinning "coverage" to below v5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 env:
   global:
     - DEPS="ipython tqdm autodocsumm"
-    - TEST_DEPS="pytest pytest-cov coveralls"
+    - TEST_DEPS="pytest pytest-cov coveralls<5"
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 env:
   global:
     - DEPS="ipython tqdm autodocsumm"
-    - TEST_DEPS="pytest pytest-cov coveralls<5"
+    - TEST_DEPS="pytest pytest-cov coveralls coverage<5"
 
 matrix:
   include:


### PR DESCRIPTION
This is a short term fix that will allow coveralls to run while I boost the coverage. In the medium term we will need to find an org-wide solution.