### PR TITLE
Dependency shortening

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: shell
 
 env:
   global:
-    - DEPS="ipython tqdm"
     - TEST_DEPS="pytest>=5.0 pytest-cov>=2.8.1 coveralls>=1.10 coverage>=5.0"
 
 matrix:
@@ -53,7 +52,7 @@ install:
       . activate testenv;
     fi
   - conda activate testenv;
-  - conda install -y $DEPS $TEST_DEPS;
+  - conda install -y $TEST_DEPS;
   - pip install .
 
 script:

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "numpy",
         "scipy",
         "matplotlib",
+        "tqdm"
     ],
     package_data={
         "": ["LICENSE", "readme.rst"],


### PR DESCRIPTION
Previously we left `tqdm` off the dependancy list and added it in the test `env` so that the testing would pass, it seems sensible to just put it as a dependancy. Also the stray `ipython` may be cuttable.