### PR TITLE
Creation of CrystalMap class 

### DIFF
--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -1,5 +1,5 @@
 __name__ = "orix"
-__version__ = "0.2.2"
+__version__ = "0.3.0dev"
 __author__ = "Ben Martineau, Phillip Crout"
 __author_email__ = "pyxem.team@gmail.com"
 __description__ = (

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -1,7 +1,14 @@
 __name__ = "orix"
-__version__ = "0.2.2dev"
+__version__ = "0.3.0dev"
 __author__ = "Ben Martineau, Phillip Crout"
 __author_email__ = "pyxem.team@gmail.com"
 __description__ = (
     "Orientation, rotation, quaternion, and crystal symmetry handling in Python."
 )
+__credits__ = [
+    "Ben Martineau",
+    "Phillip Crout",
+    "Duncan Johnstone",
+    "Håkon Wiik Ånes",
+    "Simon Høgås",
+]

--- a/orix/crystal_map/__init__.py
+++ b/orix/crystal_map/__init__.py
@@ -17,3 +17,4 @@
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
 from .crystal_map import CrystalMap
+from .phase_list import Phase, PhaseList

--- a/orix/crystal_map/__init__.py
+++ b/orix/crystal_map/__init__.py
@@ -33,6 +33,6 @@ Submodules
     phase_list
 """
 
-from .crystal_map import CrystalMap
-from .phase_list import Phase, PhaseList
-from .crystal_map_properties import CrystalMapProperties
+from orix.crystal_map.crystal_map import CrystalMap
+from orix.crystal_map.phase_list import Phase, PhaseList
+from orix.crystal_map.crystal_map_properties import CrystalMapProperties

--- a/orix/crystal_map/__init__.py
+++ b/orix/crystal_map/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2019 The pyXem developers
+# Copyright 2018-2020 The pyXem developers
 #
 # This file is part of orix.
 #

--- a/orix/crystal_map/__init__.py
+++ b/orix/crystal_map/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2019 The pyXem developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+from .crystal_map import CrystalMap

--- a/orix/crystal_map/__init__.py
+++ b/orix/crystal_map/__init__.py
@@ -16,5 +16,38 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
+"""
+Crystallographic map of rotations, crystal phases and key properties associated with
+every spatial coordinate in a 1D, 2D or 3D space.
+
+All properties are stored as 1D arrays, and reshaped when necessary.
+
+This module uses logging at the DEBUG level to keep track of manipulation and plotting
+of CrystalMap objects where the underlying behaviour might not be straight forward to
+analyse. Use the following in a script to see this logging:
+
+.. code-block:: python
+
+    >>> import logging
+    >>> logging.basicConfig(level=logging.DEBUG)
+
+And ensure matplotlib (and any other packages) doesn't clutter the debug log:
+
+.. code-block:: python
+
+    >>> logging.getLogger("matplotlib").setLevel(logging.WARNING)
+
+Submodules
+==========
+
+.. autosummary::
+    :toctree: _autosummary
+
+    crystal_map
+    crystal_map_properties
+    phase_list
+"""
+
 from .crystal_map import CrystalMap
 from .phase_list import Phase, PhaseList
+from .crystal_map_properties import CrystalMapProperties

--- a/orix/crystal_map/__init__.py
+++ b/orix/crystal_map/__init__.py
@@ -20,22 +20,7 @@
 Crystallographic map of rotations, crystal phases and key properties associated with
 every spatial coordinate in a 1D, 2D or 3D space.
 
-All properties are stored as 1D arrays, and reshaped when necessary.
-
-This module uses logging at the DEBUG level to keep track of manipulation and plotting
-of CrystalMap objects where the underlying behaviour might not be straight forward to
-analyse. Use the following in a script to see this logging:
-
-.. code-block:: python
-
-    >>> import logging
-    >>> logging.basicConfig(level=logging.DEBUG)
-
-And ensure matplotlib (and any other packages) doesn't clutter the debug log:
-
-.. code-block:: python
-
-    >>> logging.getLogger("matplotlib").setLevel(logging.WARNING)
+All map properties with a value in each data point are stored as 1D arrays.
 
 Submodules
 ==========

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -17,7 +17,6 @@
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
 import copy
-import logging
 
 import numpy as np
 
@@ -25,8 +24,6 @@ from orix.quaternion.rotation import Rotation
 from orix.quaternion.orientation import Orientation
 from .phase_list import PhaseList
 from .crystal_map_properties import CrystalMapProperties
-
-_log = logging.getLogger(__name__)
 
 
 class CrystalMap:
@@ -79,6 +76,7 @@ class CrystalMap:
     get_map_data(item, decimals=3, fill_value=None)
         Return an array of a class instance attribute, with masked values
         set to `fill_value`, of map shape.
+
     """
 
     def __init__(
@@ -121,8 +119,8 @@ class CrystalMap:
             Point group of crystal symmetries of phases in the map.
         prop : dict of numpy.ndarray, optional
             Dictionary of properties of each data point.
-        """
 
+        """
         # Set rotations
         if not isinstance(rotations, Rotation):
             raise ValueError(
@@ -186,6 +184,8 @@ class CrystalMap:
         self.scan_unit = "px"
 
         # Set properties
+        if prop is None:
+            prop = {}
         self._prop = CrystalMapProperties(prop, id=point_id)
 
         # Set original data shape (needed if data shape changes in__getitem__())
@@ -255,6 +255,7 @@ class CrystalMap:
 
         This is needed because it can be useful to have phases not in the
         data but in `self.phases`.
+
         """
         unique_ids = np.unique(self.phase_id)
         return self.phases[np.intersect1d(unique_ids, self.phases.phase_ids)]
@@ -302,6 +303,7 @@ class CrystalMap:
     def prop(self):
         """Return a :class:`~orix.crystal_map.CrystalMapProperties`
         dictionary with data properties.
+
         """
         self._prop.is_in_data = self.is_in_data
         self._prop.id = self.id
@@ -325,6 +327,7 @@ class CrystalMap:
 
         Called when the default attribute access fails with an
         AttributeError.
+
         """
         if item in self.__getattribute__("_prop"):
             return self.prop[item]  # Calls CrystalMapProperties.__getitem__()
@@ -412,6 +415,7 @@ class CrystalMap:
             1  1890 (100.0%)  austenite       432  tab:blue
         Properties: iq, dp
         Scan unit: um
+
         """
         # Initiate a mask to be added to the returned copy of the CrystalMap object, to
         # ensure that only the unmasked values are in the data of the copy (True in
@@ -467,7 +471,6 @@ class CrystalMap:
         new_map = copy.copy(self)
         new_map.is_in_data = new_is_in_data
 
-        _log.debug(f"getitem: Return a shallow copy with updated is_in_data")
         return new_map
 
     def __repr__(self):
@@ -547,6 +550,7 @@ class CrystalMap:
         output_array : numpy.ndarray
             Array of the class instance attribute with points not in data
             set to `fill_value`, of float data type.
+
         """
         # Get full map shape
         map_shape = self._original_shape
@@ -624,6 +628,7 @@ class CrystalMap:
         -------
         step_size : float
             Step size in `coordinates` array.
+
         """
         unique_sorted = np.sort(np.unique(coordinates))
         step_size = 0
@@ -640,6 +645,7 @@ class CrystalMap:
         slices : tuple of slices
             Data slice in each existing dimension, in (z, y, x) order. If
             data is not masked, the tuple is empty.
+
         """
         slices = []
 
@@ -664,6 +670,7 @@ class CrystalMap:
         -------
         data_shape : tuple of ints
             Shape of data in all existing dimensions, in (z, y, x) order.
+
         """
         data_shape = []
         for dim_slice in self._data_slices_from_coordinates():

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -390,6 +390,7 @@ class CrystalMap:
             1   5657 (48.4%)  austenite       432    tab:blue
             2   6043 (51.6%)    ferrite       432  tab:orange
         Properties: iq, dp
+        Scan unit: um
         >>> cm.shape
         (100, 117)
 

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2019 The pyXem developers
+# Copyright 2018-2020 The pyXem developers
 #
 # This file is part of orix.
 #

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -657,7 +657,7 @@ class CrystalMap:
                 slices.append(
                     slice(
                         int(np.min(coordinates) / step),
-                        int(1 + np.max(coordinates) // step),
+                        int(np.ceil((np.max(coordinates) / step) + 1)),
                     )
                 )
 

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -63,7 +63,7 @@ class CrystalMap:
     rotations : orix.quaternion.rotation.Rotation
         Rotations of each pixel. Always 1D.
     scan_unit : str
-        Length unit of map, default is 'um'.
+        Length unit of map, default is 'px'.
     shape : tuple
         Shape of map in pixels.
     size : int
@@ -104,7 +104,7 @@ class CrystalMap:
         """
         Parameters
         ----------
-        rotations : numpy.ndarray
+        rotations : orix.quaternion.rotation.Rotation
             Rotation of each pixel.
         phase_id : numpy.ndarray
             Phase ID of each pixel. The map shape is set to this array's
@@ -123,12 +123,8 @@ class CrystalMap:
 
         # Set rotations (always 1D, needed for masking)
         if not isinstance(rotations, Rotation):
-            try:
-                rotations = Rotation.from_euler(rotations)
-            except (IndexError, TypeError):
-                raise ValueError(
-                    f"rotations must be of type {np.ndarray} or {Rotation}, "
-                    f"not {type(rotations)}."
+            raise ValueError(
+                f"rotations must be of type {Rotation}, not {type(rotations)}."
                 )
         self._rotations = rotations.reshape(np.prod(rotations.shape))
 
@@ -170,7 +166,7 @@ class CrystalMap:
             self._indexed = indexed
 
         # Set scan unit
-        self._scan_unit = 'um'
+        self._scan_unit = 'px'
 
         # Set properties (calling prop.setter ensures reshaping to map shape)
         self.prop = {}
@@ -430,6 +426,7 @@ class CrystalMap:
             indexed=mask[slices],
             step_sizes=self.step_sizes,  # TODO: Slice when dimensions are lost
         )
+        new_map.scan_unit = self.scan_unit
 
         # Get new phase list
         new_phase_ids = np.unique(self.phase_id[mask])

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2019 The pyXem developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+
+from orix.quaternion.rotation import Rotation
+from orix.quaternion.orientation import Orientation
+from orix.quaternion.symmetry import _groups
+
+
+class CrystalMap:
+    """A crystallographic map storing measurement pixels as a 2D array with
+    rows containing the orientation, the spatial coordinates, the phase and
+    potential properties of each individual pixel.
+
+    Attributes
+    ----------
+    id : numpy.ndarray
+        Unique ID of each pixel.
+    rotations : orix.quaternion.rotation.Rotation
+        Rotation of each pixel.
+    orientations : orix.quaternion.orientation.Orientation
+        Orientation of each pixel.
+    mineral : list of str
+        Name of phases.
+    phase_id : numpy.ndarray
+        Phase ID of each pixel.
+    phase : numpy.ndarray
+        Phase ID of each pixel as imported.
+    props : dict
+        Dictionary of numpy arrays of quality metrics or other auxiliary
+        properties of each pixel.
+    x, y, z : numpy.ndarray
+        Coordinates of the centre of each pixel.
+    crystal_symmetries : list of orix.symmetry.Symmetry
+        Crystal symmetries of phases in the map. Symmetries in this list
+        map directly to phases in the phase_id list.
+    """
+    def __init__(
+            self,
+            rotations,
+            phase_id=None,
+            phase=None,
+            x=None,
+            y=None,
+            z=None,
+            properties=None,
+            crystal_symmetries=None,
+    ):
+        self.id = np.arange(len(rotations))
+        self.rotations = Rotation.from_euler(rotations)
+
+        # Set auxiliary properties
+        self.props = properties
+
+        # Set pixel coordinates
+        if x is None:
+            x = np.arange(len(rotations))
+        if y is None:
+            y = np.zeros_like(x)
+        if z is None:
+            z = np.zeros_like(x)
+        self.x = x
+        self.y = y
+        self.z = z
+
+        # Set phases as imported
+        if phase is None:
+            phase = np.zeros(len(rotations))
+        self.phase = phase
+
+        # Set phase ID, which maps to entries in crystal_symmetries
+        if phase_id is None:
+            phase_id = np.zeros(len(rotations))
+        self.phase_id = phase_id
+
+        # Set crystal symmetry
+        self.crystal_symmetries = []
+        if crystal_symmetries is not None:
+            for cs_in in crystal_symmetries:
+                if cs_in == '43':
+                    cs_in = '432'
+                for cs in _groups:
+                    if cs_in == cs.name.replace('-', ''):
+                        break
+                    else:
+                        cs = _groups[0]
+                self.crystal_symmetries.append(cs)
+
+        # Set orientations if crystal symmetries were passed
+#        self.orientations =
+#            self.orientations = Orientation.from_euler(rotations).set_symmetry(
+#                crystal_symmetry
+#            )
+#        else:
+#            self.orientations = None
+
+        # Set properties
+        self.prop = properties
+
+    def __repr__(self):
+        header = "Phase\tOrientations\tMineral\tSymmetry"
+        return header

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -16,103 +16,663 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
+import copy
+from numbers import Number
+
 import numpy as np
+import matplotlib.patches as mpatches
 
 from orix.quaternion.rotation import Rotation
 from orix.quaternion.orientation import Orientation
-from orix.quaternion.symmetry import _groups
+from .phase_list import PhaseList
+from orix.plot import _plot_crystal_map
 
 
 class CrystalMap:
-    """A crystallographic map storing measurement pixels as a 2D array with
-    rows containing the orientation, the spatial coordinates, the phase and
-    potential properties of each individual pixel.
+    """Crystallographic map storing rotations, phases and pixel properties.
+
+    Phases and pixel properties are stored in the map shape, while
+    rotations are always stored as a 1D array.
+
+    This class is inspired by the EBSD class available in MTEX
+    [Bachmann2010]_.
 
     Attributes
     ----------
-    id : numpy.ndarray
-        Unique ID of each pixel.
-    rotations : orix.quaternion.rotation.Rotation
-        Rotation of each pixel.
+    all_indexed : bool
+        Whether all pixels are indexed.
+    dx : numpy.ndarray
+        Step sizes in each map direction.
+    indexed : numpy.ndarray
+        Boolean array with True for indexed pixels.
+    ndim : int
+        Number of map dimensions.
     orientations : orix.quaternion.orientation.Orientation
-        Orientation of each pixel.
-    mineral : list of str
-        Name of phases.
+        Orientations of each pixel. Always 1D.
     phase_id : numpy.ndarray
-        Phase ID of each pixel.
-    phase : numpy.ndarray
         Phase ID of each pixel as imported.
-    props : dict
-        Dictionary of numpy arrays of quality metrics or other auxiliary
-        properties of each pixel.
-    x, y, z : numpy.ndarray
-        Coordinates of the centre of each pixel.
-    crystal_symmetries : list of orix.symmetry.Symmetry
-        Crystal symmetries of phases in the map. Symmetries in this list
-        map directly to phases in the phase_id list.
+    phases : orix.crystal_map.PhaseList
+        List of phases with their IDs, names, crystal symmetries and
+        colors (possibly more than are in the map).
+    phases_in_map : orix.crystal_map.PhaseList
+        List of phases in the map, with their IDs, names, crystal
+        symmetries and colors.
+    pixel_id : numpy.ndarray
+        ID of each map pixel.
+    prop : dict
+        Dictionary of numpy arrays of quality metrics or other properties
+        of each pixel.
+    rotations : orix.quaternion.rotation.Rotation
+        Rotations of each pixel. Always 1D.
+    scan_unit : str
+        Length unit of map, default is 'um'.
+    shape : tuple
+        Shape of map in pixels.
+    size : int
+        Number of pixels in map.
+
+    Methods
+    -------
+    deepcopy()
+        Return a deep copy using :py:func:`~copy.deepcopy` function.
+    plot_prop(
+        prop, colorbar=True, scalebar=True, padding=False, **kwargs)
+        Plot of a map property.
+    plot_phase(
+        overlay=None, legend=True, scalebar=True, padding=False,
+        **kwargs)
+        Return and plot map phases.
+
+    References
+    ----------
+    .. [Bachmann2010] F. Bachmann, R. Hielscher, H. Schaeben, "Texture\
+        Analysis with MTEX – Free and Open Source Software Toolbox," Solid
+        State Phenomena 160, 63–68, 2010.
+
     """
+
     def __init__(
             self,
-            rotations,
+            rotations=None,
             phase_id=None,
-            phase=None,
-            x=None,
-            y=None,
-            z=None,
-            properties=None,
-            crystal_symmetries=None,
+            phase_name=None,
+            symmetry=None,
+            prop=None,
+            indexed=None,
+            dx=None,
     ):
-        self.id = np.arange(len(rotations))
-        self.rotations = Rotation.from_euler(rotations)
+        """
+        Parameters
+        ----------
+        rotations : numpy.ndarray, optional
+            Rotation of each pixel.
+        phase_id : numpy.ndarray, optional
+            Phase ID of each pixel.
+        phase_name : str or list of str, optional
+            Name of phases.
+        symmetry : str or list of str, optional
+            Point group of crystal symmetries of phases in the map.
+        prop : dict of numpy.ndarray, optional
+            Dictionary of quality metrics or other properties of each
+            pixel.
+        indexed : numpy.ndarray
+            Boolean array with True for indexed pixels.
+        dx : numpy.ndarray, optional
+            Step sizes in each map direction.
+        """
 
-        # Set auxiliary properties
-        self.props = properties
-
-        # Set pixel coordinates
-        if x is None:
-            x = np.arange(len(rotations))
-        if y is None:
-            y = np.zeros_like(x)
-        if z is None:
-            z = np.zeros_like(x)
-        self.x = x
-        self.y = y
-        self.z = z
-
-        # Set phases as imported
-        if phase is None:
-            phase = np.zeros(len(rotations))
-        self.phase = phase
-
-        # Set phase ID, which maps to entries in crystal_symmetries
         if phase_id is None:
-            phase_id = np.zeros(len(rotations))
-        self.phase_id = phase_id
+            phase_id = np.arange(rotations.size, dtype=int)
 
-        # Set crystal symmetry
-        self.crystal_symmetries = []
-        if crystal_symmetries is not None:
-            for cs_in in crystal_symmetries:
-                if cs_in == '43':
-                    cs_in = '432'
-                for cs in _groups:
-                    if cs_in == cs.name.replace('-', ''):
-                        break
-                    else:
-                        cs = _groups[0]
-                self.crystal_symmetries.append(cs)
+        # Set phase ID
+        self._phase_id = phase_id.astype(int)
 
-        # Set orientations if crystal symmetries were passed
-#        self.orientations =
-#            self.orientations = Orientation.from_euler(rotations).set_symmetry(
-#                crystal_symmetry
-#            )
-#        else:
-#            self.orientations = None
+        # Set map size, shape and number of dimensions
+        map_shape = phase_id.shape
+        map_ndim = phase_id.ndim
 
-        # Set properties
-        self.prop = properties
+        # Set rotations (always 1D, needed for masking)
+        if rotations is not None and not isinstance(rotations, Rotation):
+            try:
+                rotations = Rotation.from_euler(rotations)
+            except (IndexError, TypeError):
+                # TODO: Update error message with more detailed restrictions
+                raise ValueError(
+                    f"Rotations '{rotations}' must be of type numpy.ndarray."
+                )
+        self._rotations = rotations.reshape(np.prod(rotations.shape))
+
+        # Set step sizes
+        if dx is None:
+            self._dx = np.ones(map_ndim)
+        elif isinstance(dx, Number):
+            # Assume same step size in all directions
+            self._dx = np.ones(map_ndim) * dx
+        elif len(dx) != map_ndim:
+            raise ValueError(
+                f"{dx} must have same number of entries as number of map "
+                f"dimensions {map_ndim}"
+            )
+        else:
+            self._dx = dx
+
+        # Set whether pixels are indexed
+        if indexed is None:
+            self._indexed = np.ones(map_shape, dtype=bool)
+        else:
+            self._indexed = indexed
+
+        # Create phase list
+        phase_ids = np.unique(phase_id).astype(int)
+        self._phases = PhaseList(
+            names=phase_name,
+            symmetries=symmetry,
+            phase_ids=phase_ids,
+        )
+
+        # Set scan unit
+        self._scan_unit = 'um'
+
+        # Set properties (calling prop.setter ensures reshaping to map shape)
+        self.prop = {}
+        if isinstance(prop, dict):
+            self.prop = prop
+
+    @property
+    def phase_id(self):
+        """Return numpy.ndarray of the phase ID of each map pixel."""
+        if self.all_indexed is False:
+            return np.ma.masked_array(self._phase_id, mask=~self._indexed)
+        else:
+            return self._phase_id
+
+    @property
+    def phases(self):
+        """Return a list of phases in the map (and potentially more)."""
+        return self._phases
+
+    @property
+    def phases_in_map(self):
+        """Return a list of phases in the map."""
+        # Since self.phases might contain phases not in the map
+        return self._phases[
+            np.intersect1d(np.unique(self._phase_id), self.phases.phase_ids)
+        ]
+
+    @property
+    def rotations(self):
+        """Return a Rotation object, which is always 1D.
+
+        Must always be 1D because of possible masked elements in indexed
+        attribute.
+        """
+        return self._rotations[self.indexed.ravel()]
+
+    @property
+    def orientations(self):
+        """Return an Orientation object, which is always 1D."""
+        phases = self._phases
+        if phases.size == 1:
+            phase = phases[int(phases.phase_ids[0])]
+            return Orientation(self.rotations).set_symmetry(phase.symmetry)
+        else:
+            raise ValueError(
+                f"Map contains the phases {phases.names}, however, you are"
+                " executing a command that only permits one phase."
+            )
+
+    @property
+    def scan_unit(self):
+        """Return scan unit as a string."""
+        return self._scan_unit
+
+    @scan_unit.setter
+    def scan_unit(self, value):
+        """Set scan unit as a string."""
+        self._scan_unit = str(value)
+
+    @property
+    def prop(self):
+        """Return a dict of properties of each pixel."""
+        return self._prop
+
+    @prop.setter
+    def prop(self, value):
+        """Add a dict of properties of each pixel."""
+        e = (
+            f"{value} must be a dict with strings as keys and numpy.ndarrays as"
+            f" values of same size {self.size} as the map."
+        )
+        if not isinstance(value, dict):
+            raise ValueError(e)
+
+        reshaped_values = {}
+        map_size = self.size
+        map_shape = self.shape
+        for k, v in value.items():
+            if not self.all_indexed:
+                v = np.ma.masked_array(v.ravel(), mask=~self.indexed.ravel())
+                v_size = v.compressed().size
+            else:
+                v_size = v.size
+            if isinstance(k, str) and v_size == map_size:
+                reshaped_values[k] = v.reshape(map_shape)
+            else:
+                raise ValueError(e)
+
+        self._prop = reshaped_values
+
+    @property
+    def pixel_id(self):
+        """Return map pixel IDs as a numpy.ndarray of same shape as map."""
+        pixel_id = np.arange(self.size).reshape(self.shape)
+        if self.all_indexed is False:
+            return np.ma.masked_array(pixel_id, mask=~self.indexed)
+        else:
+            return pixel_id
+
+    @property
+    def dx(self):
+        """Return pixel step size in each direction in scan units."""
+        return self._dx
+
+    @dx.setter
+    def dx(self, value):
+        """Set pixel step size in each direction in scan units."""
+        ndim = self.ndim
+        if isinstance(value, Number):
+            # Assume same step size in all directions
+            self._dx = np.zeros(ndim) * value
+        elif len(value) != ndim:
+            raise ValueError(
+                f"{value} must have same number of entries as number of map "
+                f"dimensions {ndim}."
+            )
+        else:
+            self._dx = np.array(value)
+
+    @property
+    def size(self):
+        """Return total number of map pixels."""
+        if not self.all_indexed:
+            return self.phase_id[self.indexed].size
+        else:
+            return self.phase_id.size
+
+    @property
+    def shape(self):
+        """Return shape of map in pixels."""
+        return self.phase_id.shape
+
+    @property
+    def ndim(self):
+        """Return number of map dimensions."""
+        return len(self.shape)
+
+    @property
+    def indexed(self):
+        """Return boolean numpy.ndarray with indexed pixels set to True."""
+        return self._indexed
+
+    @indexed.setter
+    def indexed(self, value):
+        """Set boolean numpy.ndarray with indexed pixels set to True."""
+        if (
+                isinstance(value, np.ndarray)
+                and value.dtype == np.bool_
+                and value.size == self.size
+        ):
+            # Reshape if not same shape as map
+            self._indexed = value.reshape(self.shape)
+        else:
+            raise ValueError(
+                f"{value} must be a boolean array of same size as the map, "
+                f"{self.size}."
+            )
+
+    @property
+    def all_indexed(self):
+        """Return whether all map pixels are indexed."""
+        return np.count_nonzero(self._indexed) == self._indexed.size
+
+    def __getattr__(self, item):
+        """Return class attribute or prop if item is in prop dict."""
+        prop = self.__getattribute__('_prop')
+        if item in prop:
+            if self.all_indexed is False:
+                return np.ma.masked_array(prop[item], mask=~self.indexed)
+            else:
+                return prop[item]
+        else:  # Default behaviour
+            return self.__getattribute__(item)
+
+    def __getitem__(self, key):
+        # Get map shape, size and ndim once
+        map_shape = self.shape
+        map_size = self.size
+        map_ndim = self.ndim
+
+        # Set up necessary slices
+        slices = list([0] * map_ndim)  # Ensure list to avoid potential errors
+
+        # Create mask
+        mask = np.zeros(map_shape, dtype=bool)
+
+        if (
+                isinstance(key, str) or
+                (isinstance(key, tuple) and isinstance(key[0], str))
+        ):
+            # Get data from phase(s)
+            if not isinstance(key, tuple):  # Make single string iterable
+                key = (key,)
+
+            for k in key:
+                match = False
+                for phase_id, phase in self.phases_in_map:
+                    if k == phase.name:
+                        mask[self.phase_id == phase_id] = True
+                        match = True
+                if match is False:
+                    raise IndexError(
+                        f"{k} is not among the available phases "
+                        f"{self.phases_in_map.names} in the map."
+                    )
+        elif isinstance(key, np.ndarray) and key.dtype == np.bool_:
+            # Get data from conditional(s)
+            if key.size == map_size:
+                key = key.reshape(map_shape)
+            else:
+                raise IndexError(
+                    f"{key} must be of the same size as the map ({map_size}), "
+                    f"but is instead {key.size}."
+                )
+            if np.count_nonzero(key) == 0:
+                raise IndexError(f"Indexing condition match no map pixels.")
+            mask = key
+        elif (
+                isinstance(key, slice)
+                or (
+                        isinstance(key, tuple)
+                        and any([(isinstance(i, slice)) for i in key])
+                )
+        ):
+            # Get data from slice(s)
+            if isinstance(key, tuple):
+                n_slices = len(key)
+                if n_slices > map_ndim:
+                    raise IndexError(
+                        f"Cannot slice {n_slices} dimensions when the map has "
+                        f"only {map_ndim}."
+                    )
+
+            # Overwrite entries in slices list
+            if isinstance(key, slice):
+                key = (key,)
+            for i, k in enumerate(key):
+                slices[i] = k
+            slices = tuple(slices)
+
+            # Slice mask
+            mask[slices] = True
+        else:
+            raise IndexError(
+                f"{key} must be a valid str, slice or boolean array."
+            )
+
+        # Create slices if not created already
+        if slices == list([0] * map_ndim):
+            for i in range(map_ndim):
+                dim_to_collapse = map_ndim - i - 1
+                collapsed_dim = np.sum(mask, axis=dim_to_collapse)
+                non_zero = np.nonzero(collapsed_dim)
+                slices[i] = slice(np.min(non_zero), np.max(non_zero) + 1, None)
+            slices = tuple(slices)
+
+        # Create new crystal map
+        new_map = CrystalMap(
+            rotations=self._rotations,  # Is sliced when calling self.rotations
+            phase_id=self.phase_id[slices],
+            prop={name: array[slices] for name, array in self.prop.items()},
+            indexed=mask[slices],
+            dx=self.dx,  # TODO: Slice when dimensions are lost
+        )
+
+        # Get new phase list
+        new_phase_ids = np.unique(self.phase_id[mask])
+        new_phase_list = self.phases[new_phase_ids]
+        new_map._phases = new_phase_list
+
+        return new_map
 
     def __repr__(self):
-        header = "Phase\tOrientations\tMineral\tSymmetry"
-        return header
+        phases = self.phases
+        phase_ids = self.phase_id[self.indexed]
+
+        # Ensure attributes set to None are treated OK
+        names = ['None' if not n else n for n in phases.names]
+        symmetry_names = [
+            'None' if not s else s.name for s in phases.symmetries]
+
+        # Determine column widths
+        unique_phases = np.unique(phase_ids)
+        p_sizes = [np.where(phase_ids == i)[0].size for i in unique_phases]
+        id_len = 5
+        ori_len = max(max([len(str(p_size)) for p_size in p_sizes]) + 9, 13)
+        name_len = max(max([len(n) for n in names]), 5)
+        sym_len = max(max([len(sn) for sn in symmetry_names]), 8)
+        col_len = max(max([len(i) for i in phases.colors]), 6)
+
+        # Header (note the two-space spacing)
+        representation = (
+                "{:<{width}}  ".format("Phase", width=id_len)
+                + "{:<{width}}  ".format("Orientations", width=ori_len)
+                + "{:<{width}}  ".format("Name", width=name_len)
+                + "{:<{width}}  ".format("Symmetry", width=sym_len)
+                + "{:<{width}}\n".format("Color", width=col_len)
+        )
+
+        # Overview of data for each phase
+        for i, phase_id in enumerate(unique_phases.astype(int)):
+            p_size = np.where(phase_ids == phase_id)[0].size
+            p_fraction = 100 * p_size / self._phase_id[self._indexed].size
+            ori_str = f"{p_size} ({p_fraction:.1f}%)"
+            representation += (
+                    f"{phase_id:<{id_len}}  "
+                    + f"{ori_str:<{ori_len}}  "
+                    + f"{names[i]:<{name_len}}  "
+                    + f"{symmetry_names[i]:<{sym_len}}  "
+                    + f"{phases.colors[i]:<{col_len}}\n"
+            )
+
+        # Properties and spatial coordinates
+        props = []
+        for k in self._prop.keys():
+            props.append(k)
+        representation += "Properties: " + ", ".join(props) + "\n"
+
+        # Scan unit
+        representation += f"Scan unit: {self._scan_unit}"
+
+        return representation
+
+    def deepcopy(self):
+        """Return a deep copy using :py:func:`~copy.deepcopy` function."""
+        return copy.deepcopy(self)
+
+    def plot_phase(
+            self,
+            overlay=None,
+            legend=True,
+            scalebar=True,
+            padding=True,
+            **kwargs,
+    ):
+        """Return and plot map phases.
+
+        Parameters
+        ----------
+        overlay : str, optional
+            Map property to use as alpha value. The property is adjusted
+            for maximum contrast.
+        legend : bool, optional
+            Whether to display a legend with phases in the map (default is
+            ``True``).
+        scalebar : bool, optional
+            Whether to add a scalebar (default is ``True``) along the last
+            map dimension.
+        padding : bool, optional
+            Whether to show white padding (default is ``True``). Setting
+            this to false removes all white padding outside of plot,
+            including pixel coordinate ticks.
+        **kwargs :
+            Optional keyword arguments passed to
+            :meth:`matplotlib.pyplot.imshow`.
+
+        Returns
+        -------
+        phase : numpy.ndarray
+            Phase array as passed to :meth:`matplotlib.pyplot.imshow` with
+            colors and potential alpha value if a valid `overlay` argument
+            was passed.
+        fig : matplotlib.figure.Figure
+            Top level container for all plot elements.
+        ax : matplotlib.axes.Axes
+            Axes object returned by :meth:`matplotlib.pyplot.subplots`.
+        im : matplotlib.image.AxesImage
+            Image object returned by :meth:`matplotlib.axes.Axes.imshow`.
+
+        Examples
+        --------
+        >>> cm
+        Phase  Orientations   Name       Symmetry  Color
+        1      5657 (48.4%)   austenite  432       tab:blue
+        2      6043 (51.6%)   ferrite    432       tab:orange
+        Properties: iq, ci, fit
+        Scan unit: um
+        >>> phase, fig, ax, im = cm.plot_phase(overlay='ci')
+        """
+
+        # Create 1D phase array and add RGB channels to each map pixel
+        n_channels = 3
+        phase = np.ones((np.prod(self.shape), n_channels))
+
+        # Color each map pixel with corresponding phase color RGB tuple
+        phase_id = self.phase_id.ravel()
+        for i, color in zip(np.unique(phase_id), self.phases.colors_rgb):
+            mask = phase_id == i
+            phase[mask] = phase[mask] * color
+
+        # Scale RGB values with gray scale from property
+        if overlay:
+            if overlay not in self.prop.keys():
+                raise ValueError(
+                    f"{overlay} is not among available properties "
+                    f"{list(self.prop.keys())}."
+                )
+            else:
+                prop = self.prop[overlay].ravel()
+
+                # Scale prop to [0, 1] to maximize image contrast
+                prop_min = prop.min()
+                prop = (prop - prop_min) / (prop.max() - prop_min)
+                for i in range(n_channels):
+                    phase[:, i] *= prop
+
+        # Create legend patches with phase color and name
+        patches = None
+        if legend:
+            patches = [
+                mpatches.Patch(color=p.color_rgb, label=p.name)
+                for _, p in self.phases_in_map
+            ]
+
+        # Reshape phase map to 2D + RGB channels
+        phase = phase.reshape(self.shape + (n_channels,))
+
+        # Set non-indexed points to white (or None for black)
+        phase[~self.indexed] = (1, 1, 1)
+
+        fig, ax, im = _plot_crystal_map(
+            crystal_map=self,
+            data=phase,
+            legend_patches=patches,
+            scalebar=scalebar,
+            padding=padding,
+            **kwargs,
+        )
+
+        # Should find some way to mute other than cm.plot_phase();
+        return phase, fig, ax, im
+
+    def plot_prop(
+            self,
+            prop,
+            colorbar=True,
+            scalebar=True,
+            padding=True,
+            **kwargs,
+    ):
+        """Plot of a map property.
+
+        Parameters
+        ----------
+        prop : str
+            The property in `prop` to plot.
+        colorbar : bool, optional
+            Whether to add a colorbar (default is ``True``).
+        scalebar : bool, optional
+            Whether to add a scalebar (default is ``True``) along the last
+            map dimension.
+        padding : bool, optional
+            Whether to show white padding (default is ``True``). Setting
+            this to ``False`` removes all white padding outside of plot,
+            including pixel coordinate ticks.
+        **kwargs :
+            Optional keyword arguments passed to
+            :meth:`matplotlib.pyplot.imshow`.
+
+        Returns
+        -------
+        fig : matplotlib.figure.Figure
+            Top level container for all plot elements.
+        ax : matplotlib.axes.Axes
+            Axes object returned by :meth:`matplotlib.pyplot.subplots`.
+        im : matplotlib.image.AxesImage
+            Image object returned by :meth:`matplotlib.axes.Axes.imshow`.
+        prop_to_plot : numpy.ndarray
+            Property array as passed to :meth:`matplotlib.pyplot.imshow`.
+
+        Examples
+        --------
+        >>> cm
+        Phase  Orientations   Name       Symmetry  Color
+        1      5657 (48.4%)   austenite  432       tab:blue
+        2      6043 (51.6%)   ferrite    432       tab:orange
+        Properties: iq, ci, fit
+        Scan unit: um
+        >>> data, fig, ax, im = cm.plot_prop('ci')
+        """
+
+        if prop not in self.prop:
+            raise ValueError(
+                f"{prop} is not among available properties "
+                f"{list(self.prop.keys())}."
+            )
+        else:
+            prop_to_plot = self.prop[prop]
+
+        fig, ax, im = _plot_crystal_map(
+            crystal_map=self,
+            data=prop_to_plot,
+            scalebar=scalebar,
+            cmap=kwargs.pop('cmap', 'gray'),
+            padding=padding,
+            **kwargs,
+        )
+
+        # Colorbar
+        if colorbar:
+            fig.colorbar(im, ax=ax)
+
+        # Should find some way to mute other than cm.plot_prop('ci');
+        return prop_to_plot, fig, ax, im

--- a/orix/crystal_map/crystal_map_properties.py
+++ b/orix/crystal_map/crystal_map_properties.py
@@ -72,7 +72,14 @@ class CrystalMapProperties(dict):
         # This ensures that existing values in the entry aren't overwritten
         array = self.setdefault(key, np.zeros(self.is_in_data.size))
 
-        array[self.id] = np.ravel(value)  # Handles integer values
+        # Determine array data type from input
+        if hasattr(value, "__iter__"):
+            value_type = type(value[0])
+        else:
+            value_type = type(value)
+        array = array.astype(value_type)
+
+        array[self.id] = value
         _log.debug(f"setitem: Set/update {key} property")
         super().__setitem__(key, array)
 

--- a/orix/crystal_map/crystal_map_properties.py
+++ b/orix/crystal_map/crystal_map_properties.py
@@ -61,7 +61,7 @@ class CrystalMapProperties(dict):
             self.is_in_data = is_in_data
 
     def __setitem__(self, key, value):
-        """Add an array to or update an existing array in the
+        """Add a 1D array to or update an existing array in the
         dictionary. If `key` is the name of an existing array, only the
         points in the data (where `self.is_in_data` is True) are set.
 

--- a/orix/crystal_map/crystal_map_properties.py
+++ b/orix/crystal_map/crystal_map_properties.py
@@ -66,7 +66,7 @@ class CrystalMapProperties(dict):
         points in the data (where `self.is_in_data` is True) are set.
 
         """
-        # This ensures that existing values in the entry aren't overwritten
+        # Get array values if `key` already present, or zeros
         array = self.setdefault(key, np.zeros(self.is_in_data.size))
 
         # Determine array data type from input
@@ -76,7 +76,7 @@ class CrystalMapProperties(dict):
             value_type = type(value)
         array = array.astype(value_type)
 
-        array[self.id] = value
+        array[self.is_in_data] = value
         super().__setitem__(key, array)
 
     def __getitem__(self, item):

--- a/orix/crystal_map/crystal_map_properties.py
+++ b/orix/crystal_map/crystal_map_properties.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 The pyXem developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+
+import numpy as np
+
+_log = logging.getLogger(__name__)
+
+
+class CrystalMapProperties(dict):
+    """A class to store properties with in a CrystalMap instance.
+
+    This class is a thin wrapper around :class:`dict`. It overrides setting
+    and getting property arrays in the `dict` to handle a data mask
+    correctly, i.e. whether data points are considered to be in the data.
+
+    Attributes
+    ----------
+    id : numpy.ndarray
+        1D integer array with the id of each point in the data.
+    is_in_data : numpy.ndarray
+        1D boolean array with True for points in the data, of the same size
+        as the data.
+    """
+
+    def __init__(self, dictionary, id, is_in_data=None):
+        """Create a `CrystalMapProperties` object.
+
+        Parameters
+        ----------
+        dictionary : dict
+            Dictionary of properties with `key` equal to the property name
+            and `value` as the numpy array.
+        id : numpy.ndarray
+            1D integer array with the id of each point in the entire data,
+            i.e. not just points in the data.
+        is_in_data : numpy.ndarray, optional
+            1D boolean array with True for points in the data. If ``None``
+            is passed (default), all points are considered to be in the
+            data.
+        """
+        _log.debug(f"init: Create dict with {dictionary.keys()}")
+        if dictionary is None:
+            dictionary = {}
+        super().__init__(**dictionary)
+        self.id = id
+        if is_in_data is None:
+            self.is_in_data = np.ones(id.size, dtype=bool)
+        else:
+            self.is_in_data = is_in_data
+
+    def __setitem__(self, key, value):
+        """Add or update an entry to the dictionary, ensuring that only the
+        points in the data are set.
+        """
+        # This ensures that existing values in the entry aren't overwritten
+        array = self.setdefault(key, np.zeros(self.is_in_data.size))
+
+        array[self.id] = np.ravel(value)  # Handles integer values
+        _log.debug(f"setitem: Set/update {key} property")
+        super().__setitem__(key, array)
+
+    def __getitem__(self, item):
+        """Return a dictionary entry, ensuring that only points in the data
+        are returned.
+        """
+        array = super().__getitem__(item)
+        _log.debug(f"getitem: Get {item} property")
+        return array[self.is_in_data]

--- a/orix/crystal_map/crystal_map_properties.py
+++ b/orix/crystal_map/crystal_map_properties.py
@@ -16,11 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-import logging
-
 import numpy as np
-
-_log = logging.getLogger(__name__)
 
 
 class CrystalMapProperties(dict):
@@ -37,6 +33,7 @@ class CrystalMapProperties(dict):
     is_in_data : numpy.ndarray
         1D boolean array with True for points in the data, of the same size
         as the data.
+
     """
 
     def __init__(self, dictionary, id, is_in_data=None):
@@ -54,10 +51,8 @@ class CrystalMapProperties(dict):
             1D boolean array with True for points in the data. If ``None``
             is passed (default), all points are considered to be in the
             data.
+
         """
-        _log.debug(f"init: Create dict with {dictionary.keys()}")
-        if dictionary is None:
-            dictionary = {}
         super().__init__(**dictionary)
         self.id = id
         if is_in_data is None:
@@ -66,8 +61,10 @@ class CrystalMapProperties(dict):
             self.is_in_data = is_in_data
 
     def __setitem__(self, key, value):
-        """Add or update an entry to the dictionary, ensuring that only the
-        points in the data are set.
+        """Add an array to or update an existing array in the
+        dictionary. If `key` is the name of an existing array, only the
+        points in the data (where `self.is_in_data` is True) are set.
+
         """
         # This ensures that existing values in the entry aren't overwritten
         array = self.setdefault(key, np.zeros(self.is_in_data.size))
@@ -80,13 +77,12 @@ class CrystalMapProperties(dict):
         array = array.astype(value_type)
 
         array[self.id] = value
-        _log.debug(f"setitem: Set/update {key} property")
         super().__setitem__(key, array)
 
     def __getitem__(self, item):
         """Return a dictionary entry, ensuring that only points in the data
         are returned.
+
         """
         array = super().__getitem__(item)
-        _log.debug(f"getitem: Get {item} property")
         return array[self.is_in_data]

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -260,7 +260,7 @@ class PhaseList:
                     color = all_colors[color_iter]
                     color_iter += 1
 
-                # Always return a unique phase_id
+                # Always return a unique phase_id_map
                 try:
                     phase_id = phase_ids[i]
                 except IndexError:
@@ -413,7 +413,7 @@ class PhaseList:
             return PhaseList(d)
 
     def __setitem__(self, key, value):
-        """Add phase to list with a key (phase_id) and value (symmetry)."""
+        """Add phase to list with a key (phase_id_map) and value (symmetry)."""
         if key not in self.names:
             # Make sure the new phase gets a new color
             color_new = None
@@ -447,16 +447,16 @@ class PhaseList:
         symmetry_names = ['None' if not i else i.name for i in self.symmetries]
 
         # Determine column widths (allowing PhaseList to be empty)
-        id_len = 3
-        name_len = 5
+        id_len = 2
+        name_len = 4
         if names:
-            name_len = max(max([len(i) for i in names]), 5)
+            name_len = max(max([len(i) for i in names]), name_len)
         sym_len = 8
         if symmetry_names:
-            sym_len = max(max([len(i) for i in symmetry_names]), 8)
-        col_len = 6
+            sym_len = max(max([len(i) for i in symmetry_names]), sym_len)
+        col_len = 5
         if self.colors:
-            col_len = max(max([len(i) for i in self.colors]), 6)
+            col_len = max(max([len(i) for i in self.colors]), col_len)
 
         # Header
         representation = (

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -52,7 +52,7 @@ class Phase:
         RGB values of phase color, obtained from the color name.
     name : str
         Phase name.
-    symmetry : orix.quaternion.symmetries.Symmetry
+    symmetry : orix.quaternion.symmetry.Symmetry
         Crystal symmetries of the phase.
 
     Methods
@@ -69,7 +69,7 @@ class Phase:
         name : str, optional
             Phase name. If ``None`` is passed (default), name is set to
             ``None``.
-        symmetry : str, optional
+        symmetry : str or orix.quaternion.symmetry.Symmetry, optional
             Point group of phase's crystal symmetry. If ``None`` is passed
             (default), it set to ``None``.
         color : str, optional
@@ -86,7 +86,7 @@ class Phase:
 
     @property
     def name(self):
-        """Return phase name."""
+        """Phase name."""
         return self._name
 
     @name.setter
@@ -96,7 +96,7 @@ class Phase:
 
     @property
     def color(self):
-        """Return phase color."""
+        """Name of phase color."""
         return self._color
 
     @color.setter
@@ -113,17 +113,17 @@ class Phase:
 
     @property
     def color_rgb(self):
-        """Return phase color as RGB tuple."""
+        """Phase color as RGB tuple."""
         return mcolors.to_rgb(self.color)
 
     @property
     def symmetry(self):
-        """Return the crystal symmetry of the phase."""
+        """Crystal symmetry of phase."""
         return self._symmetry
 
     @symmetry.setter
     def symmetry(self, value):
-        """Set the crystal symmetry of the phase."""
+        """Set crystal symmetry of phase."""
         if isinstance(value, Number):
             value = str(value)
         if isinstance(value, str):
@@ -200,7 +200,8 @@ class PhaseList:
             are ignored if this is passed.
         names : str or list of str, optional
             Phase names.
-        symmetries : str, int or list of str or int, optional
+        symmetries : str, int, orix.quaternion.symmetry.Symmetry or list\
+                of str, int or orix.quaternion.symmetry.Symmetry, optional
             Point group symmetries.
         colors : str or list of str, optional
             Phase colors.
@@ -231,7 +232,7 @@ class PhaseList:
             # Ensure possible single strings have iterables of length 1
             if isinstance(names, str):
                 names = list((names,))
-            if isinstance(symmetries, str):
+            if isinstance(symmetries, str) or isinstance(symmetries, Symmetry):
                 symmetries = list((symmetries,))
             if isinstance(colors, str) or isinstance(colors, tuple):
                 colors = list((colors,))
@@ -297,32 +298,32 @@ class PhaseList:
 
     @property
     def names(self):
-        """Return a list of phase names in the list."""
+        """List of phase names in the list."""
         return [phase.name for _, phase in self]
 
     @property
     def symmetries(self):
-        """Return a list of crystal symmetries of phases in the list."""
+        """List of crystal symmetries of phases in the list."""
         return [phase.symmetry for _, phase in self]
 
     @property
     def colors(self):
-        """Return a list of phase color names in the list."""
+        """List of phase color names in the list."""
         return [phase.color for _, phase in self]
 
     @property
     def colors_rgb(self):
-        """Return a list of phase color RGB values in the list."""
+        """List of phase color RGB values in the list."""
         return [phase.color_rgb for _, phase in self]
 
     @property
     def size(self):
-        """Return number of phases in the list."""
+        """Number of phases in the list."""
         return len(self._dict.items())
 
     @property
     def phase_ids(self):
-        """Return unique phase IDs in the list of phases."""
+        """Unique phase IDs in the list of phases."""
         return list(self._dict.keys())
 
     def __getitem__(self, key):

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -84,44 +84,43 @@ class Phase:
 
     @property
     def name(self):
+        """Return phase name."""
         return self._name
 
     @name.setter
     def name(self, value):
-        if not isinstance(value, str) and value is not None:
-            raise ValueError(f"Phase name {value} must be of type {str}.")
-        else:
-            self._name = value
+        """Set phase name as string."""
+        self._name = str(value)
 
     @property
     def color(self):
+        """Return phase color."""
         return self._color
 
     @color.setter
     def color(self, value):
-        if mcolors.is_color_like(value):
-            value_hex = mcolors.to_hex(value)
-            for name, color_hex in ALL_COLORS.items():
-                if color_hex == value_hex:
-                    self._color = name
-                    break
-        else:
-            raise ValueError(
-                f"{value} must be in the list of named Matplotlib colors or be "
-                "interpreted as an RGB(A) color by "
-                "matplotlib.colors.is_color_like()."
-            )
+        """Set phase color from something considered a valid color by
+        :func:`matplotlibcolors.is_color_like`.
+        """
+        value_hex = mcolors.to_hex(value)
+        for name, color_hex in ALL_COLORS.items():
+            if color_hex == value_hex:
+                self._color = name
+                break
 
     @property
     def color_rgb(self):
+        """Return phase color as RGB tuple."""
         return mcolors.to_rgb(self.color)
 
     @property
     def symmetry(self):
+        """Return the crystal symmetry of the phase."""
         return self._symmetry
 
     @symmetry.setter
     def symmetry(self, value):
+        """Set the crystal symmetry of the phase."""
         if isinstance(value, str):
             for correct, alias in POINT_GROUP_ALIASES.items():
                 if value == alias:
@@ -311,6 +310,7 @@ class PhaseList:
         Examples
         --------
         A PhaseList object can be indexed in multiple ways.
+
         >>> pl = PhaseList(names=['a', 'b'], symmetries=['1', '3'])
         >>> pl
         Id  Name  Symmetry  Color
@@ -366,17 +366,9 @@ class PhaseList:
                 isinstance(key_iter, tuple) and isinstance(key_iter[0], str))
         ):
             for key_name in list(set(key_iter)):  # Use set to remove duplicates
-                match = False
                 for i, phase in self._dict.items():
                     if key_name == phase.name:
                         d[i] = phase
-                        match = True
-                if not match:
-                    # Raises if any string in list of strings is not found
-                    raise IndexError(
-                        f"{key_name} is not among the available phases "
-                        f"{self.names}."
-                    )
         elif (
                 isinstance(key_iter, int)
                 or isinstance(key_iter, tuple)
@@ -384,27 +376,13 @@ class PhaseList:
                 or isinstance(key_iter, np.ndarray)
         ):
             for i in list(set(key_iter)):  # Use set to remove duplicates
-                try:
-                    d[i] = self._dict[i]
-                except KeyError:
-                    raise IndexError(
-                        f"{i} is not among the available phase IDs "
-                        f"{self.phase_ids}."
-                    )
+                d[i] = self._dict[i]
         elif isinstance(key_iter, slice):
             # Dicts cannot be sliced, hence this work-around
             id_arr = np.arange(max(self.phase_ids) + 1)
             sliced_arr = id_arr[key_iter]
             ids_in_slice = [i for i in sliced_arr if i in self.phase_ids]
-            if ids_in_slice:
-                d = {i: self._dict[i] for i in ids_in_slice}
-            else:
-                raise IndexError(
-                    f"{key} is not valid for the available phase IDs "
-                    f"{self.phase_ids}."
-                )
-        else:
-            raise IndexError(f"{key} is not a valid indexing value.")
+            d = {i: self._dict[i] for i in ids_in_slice}
 
         # Return a Phase object if only one phase was asked for
         if isinstance(key, int) or isinstance(key, str):
@@ -413,7 +391,8 @@ class PhaseList:
             return PhaseList(d)
 
     def __setitem__(self, key, value):
-        """Add phase to list with a key (phase_id_map) and value (symmetry)."""
+        """Add phase to list with a key (phase_id_map) and data (symmetry).
+        """
         if key not in self.names:
             # Make sure the new phase gets a new color
             color_new = None

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -17,7 +17,6 @@
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
 import copy
-import logging
 from itertools import islice
 from collections import OrderedDict
 
@@ -25,8 +24,6 @@ import matplotlib.colors as mcolors
 import numpy as np
 
 from orix.quaternion.symmetry import _groups, Symmetry
-
-_log = logging.getLogger(__name__)
 
 # All named Matplotlib colors (tableau and xkcd already lower case hex)
 ALL_COLORS = mcolors.TABLEAU_COLORS
@@ -61,6 +58,7 @@ class Phase:
     -------
     deepcopy()
         Return a deep copy using :py:func:`~copy.deepcopy` function.
+
     """
 
     def __init__(self, name=None, symmetry=None, color=None):
@@ -76,6 +74,7 @@ class Phase:
         color : str, optional
             Phase color. If ``None`` is passed (default), it is set to
             'tab:blue' (first among the default Matplotlib colors).
+
         """
         self.name = name
         self.symmetry = symmetry
@@ -103,6 +102,7 @@ class Phase:
     def color(self, value):
         """Set phase color from something considered a valid color by
         :func:`matplotlib.colors.is_color_like`.
+
         """
         value_hex = mcolors.to_hex(value)
         for name, color_hex in ALL_COLORS.items():
@@ -180,6 +180,7 @@ class PhaseList:
         Add a dummy phase to assign to not indexed data points.
     sort_by_id()
         Sort list according to phase ID.
+
     """
 
     def __init__(
@@ -200,6 +201,7 @@ class PhaseList:
             Phase colors.
         phase_ids : int, list of int or numpy.ndarray of int
             Phase IDs.
+
         """
         d = {}
         if isinstance(phases, list):
@@ -342,8 +344,8 @@ class PhaseList:
         Id  Name  Symmetry  Color
         0   a     1         tab:blue
         1   b     3         tab:orange
-        """
 
+        """
         # Make key iterable if it isn't already
         if (
             not isinstance(key, tuple)
@@ -393,7 +395,9 @@ class PhaseList:
             return PhaseList(d)
 
     def __setitem__(self, key, value):
-        """Add phase to list with name (`phase_id`) and data (`symmetry`).
+        """Add phase to list with name (`phase_id`) and data
+        (`symmetry`).
+
         """
         if key not in self.names:
             # Make sure the new phase gets a new color
@@ -421,6 +425,7 @@ class PhaseList:
         ----------
         key : int or str
             ID or name of a phase in the phase list.
+
         """
         if isinstance(key, int):
             self._dict.pop(key)
@@ -438,8 +443,8 @@ class PhaseList:
             raise TypeError(f"{key} is an invalid phase.")
 
     def __iter__(self):
-        """Return a tuple with the phase ID and Phase object, in that
-        order.
+        """Return a tuple with phase ID and Phase object, in that order.
+
         """
         for phase_id, phase in self._dict.items():
             yield phase_id, phase
@@ -492,12 +497,11 @@ class PhaseList:
 
         The phase, named "not_indexed", has a "symmetry" equal to None, and
         a white color when plotted.
+
         """
-        _log.debug("add_not_indexed: Add a not indexed phase.")
         self._dict[-1] = Phase(name="not_indexed", symmetry=None, color="white")
         self.sort_by_id()
 
     def sort_by_id(self):
         """Sort list according to phase ID."""
-        _log.debug("sort_by_id: Sort phases by ID.")
         self._dict = OrderedDict(sorted(self._dict.items()))

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -1,0 +1,431 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 The pyXem developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+import copy
+from itertools import islice
+from collections import OrderedDict
+
+import matplotlib.colors as mcolors
+import numpy as np
+
+from orix.quaternion.symmetry import _groups, Symmetry
+
+
+# All named Matplotlib colors (tableau and xkcd already lower case hex)
+ALL_COLORS = mcolors.TABLEAU_COLORS
+for k, v in {**mcolors.BASE_COLORS, **mcolors.CSS4_COLORS}.items():
+    ALL_COLORS[k] = mcolors.to_hex(v)
+ALL_COLORS.update(mcolors.XKCD_COLORS)
+
+
+class Phase:
+    """Name, crystal symmetry, and color of a phase in a crystallographic
+    map.
+
+    Attributes
+    ----------
+    name : str, None
+        Phase name.
+    symmetry : orix.quaternion.symmetries.Symmetry, None
+        Crystal symmetries of the phase.
+    color : str
+        Name of phase color in Matplotlib's list of named colors.
+    color_rgb : tuple
+        RGB values of phase color, obtained from the color name.
+    """
+
+    def __init__(self, name=None, symmetry=None, color=None):
+        self.name = name
+        self.symmetry = symmetry
+        if color is None:
+            self.color = "tab:blue"
+        else:
+            self.color = color
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        if not isinstance(value, str) and value is not None:
+            raise ValueError(f"Phase name {value} must be of type {str}.")
+        else:
+            self._name = value
+
+    @property
+    def color(self):
+        return self._color
+
+    @color.setter
+    def color(self, value):
+        if mcolors.is_color_like(value):
+            value_hex = mcolors.to_hex(value)
+            for name, color_hex in ALL_COLORS.items():
+                if color_hex == value_hex:
+                    self._color = name
+                    break
+        else:
+            raise ValueError(
+                f"{value} must be in the list of named Matplotlib colors or be "
+                "interpreted as an RGB(A) color by "
+                "matplotlib.colors.is_color_like()."
+            )
+
+    @property
+    def color_rgb(self):
+        return mcolors.to_rgb(self.color)
+
+    @property
+    def symmetry(self):
+        return self._symmetry
+
+    @symmetry.setter
+    def symmetry(self, value):
+        if isinstance(value, str):
+            # TODO: Mapping of more equivalent point group aliases
+            if value == '43':
+                value = '432'
+            for s in _groups:
+                if value.replace('-', '') == s.name.replace('-', ''):
+                    value = s
+                    break
+        if not isinstance(value, Symmetry) and value is not None:
+            raise ValueError(
+                f"{value} must be of type {Symmetry}, the name of a valid point"
+                " group as a string, or None."
+            )
+        else:
+            self._symmetry = value
+
+    def __repr__(self):
+        if self.symmetry:
+            symmetry_name = self.symmetry.name
+        else:
+            symmetry_name = self.symmetry  # Which should be None
+        return (
+            f"<name: {self.name}. symmetry: {symmetry_name}. color: "
+            f"{self.color}>"
+        )
+
+    def deepcopy(self):
+        return copy.deepcopy(self)
+
+
+class PhaseList:
+    """A dictionary of phases in a crystallographic map.
+
+    Each phase in the dictionary must has a unique phase id as key.
+
+    Attributes
+    ----------
+    size : int
+        Number of phases in list.
+    names : list of str
+        List of phase names.
+    symmetries : list of orix.quaternion.symmetry.Symmetry
+        List of phase crystal symmetries.
+    colors : list of tuple
+        List of tuples with three entries, RGB, defining phase colors.
+    phase_ids : list of int
+        List of unique phase indices in a crystallographic map as imported.
+    """
+
+    def __init__(
+            self,
+            phase=None,
+            names=None,
+            symmetries=None,
+            colors=None,
+            phase_ids=None,
+    ):
+        d = {}
+        if isinstance(phase, dict):
+            try:
+                if isinstance(next(iter(phase.values())), Phase):
+                    d = phase
+            except StopIteration:
+                pass
+        elif isinstance(phase, Phase):
+            d = {0: phase}
+        else:
+            # Ensure possible single strings have iterables of length 1
+            if isinstance(names, str):
+                names = list((names,))
+            if isinstance(symmetries, str):
+                symmetries = list((symmetries,))
+            if isinstance(colors, str):
+                colors = list((colors,))
+
+            # Get the maximum number of entries in the input lists (also
+            # handling the case where some lists are None)
+            max_entries = max([
+                len(i) if i is not None else 0 for i in
+                [names, symmetries, phase_ids]])
+
+            if phase_ids is None:
+                phase_ids = list(np.arange(max_entries))
+
+            # Get first n entries in color list
+            all_colors = list(islice(ALL_COLORS.keys(), max_entries))
+
+            def get_entry_or_none(input_list, i):
+                """Return list entry if it exists, else return None."""
+                try:
+                    return input_list[i]
+                except (IndexError, TypeError):
+                    return None
+
+            # Create phase dictionary
+            d = {}
+            color_iter = 0
+            phase_id_iter = 0
+            for i in range(max_entries):
+                name = get_entry_or_none(names, i)
+                symmetry = get_entry_or_none(symmetries, i)
+
+                # Always return a color (possibly not unique)
+                try:
+                    color = colors[i]
+                except (IndexError, TypeError):
+                    color = all_colors[color_iter]
+                    color_iter += 1
+
+                # Always return a unique phase_id
+                try:
+                    phase_id = phase_ids[i]
+                except IndexError:
+                    if phase_ids is not None:
+                        phase_id = max(phase_ids) + phase_id_iter + 1
+                    else:
+                        phase_id = phase_id_iter
+                    phase_id_iter += 1
+
+                d[phase_id] = Phase(name=name, symmetry=symmetry, color=color)
+
+        # Finally create dictionary of phases
+        self._dict = OrderedDict(sorted(d.items()))
+
+    @property
+    def names(self):
+        """List of phase names in the list."""
+        # Also returns None
+        return [phase.name for _, phase in self]
+
+    @property
+    def symmetries(self):
+        """List of crystal symmetries of phases in the list."""
+        # Also returns None
+        return [phase.symmetry for _, phase in self]
+
+    @property
+    def colors(self):
+        """List of phase color names in the list."""
+        # Also returns None
+        return [phase.color for _, phase in self]
+
+    @property
+    def colors_rgb(self):
+        """List of phase color RGB values in the list."""
+        # Also returns None
+        return [phase.color_rgb for _, phase in self]
+
+    @property
+    def size(self):
+        """Number of phases in the list."""
+        return len(self._dict.items())
+
+    @property
+    def phase_ids(self):
+        """Unique phase IDs in the list of phases."""
+        return list(self._dict.keys())
+
+    def __getitem__(self, key):
+        """Return a PhaseList or a Phase object, depending on input.
+
+        Examples
+        --------
+        A PhaseList object can be indexed in multiple ways.
+        >>> pl = PhaseList(names=['a', 'b'], symmetries=['1', '3'])
+        >>> pl
+        Id  Name  Symmetry  Color
+        0   a     1         tab:blue
+        1   b     3         tab:orange
+
+        Return a Phase object
+
+        >>> pl[0]  # Index with a single phase id
+        <name: a. symmetry: 1. color: tab:blue>
+        >>> pl['b']  # Index with a phase name
+        <name: b. symmetry: 3. color: tab:orange>
+
+        Return a PhaseList object
+
+        >>> pl[0:]  # Index with slices
+        Id  Name  Symmetry  Color
+        0   a     1         tab:blue
+        1   b     3         tab:orange
+        >>> pl['a', 'b']  # Index with a tuple of phase names
+        Id  Name  Symmetry  Color
+        0   a     1         tab:blue
+        1   b     3         tab:orange
+        >>> pl[0, 1]  # Index with a tuple of phase ids
+        Id  Name  Symmetry  Color
+        0   a     1         tab:blue
+        1   b     3         tab:orange
+        >>> pl[[0, 1]]  # Index with a list of phase_ids
+        Id  Name  Symmetry  Color
+        0   a     1         tab:blue
+        1   b     3         tab:orange
+        >>> pl[np.array([0, 1])]  # Index with a numpy.ndarray
+        Id  Name  Symmetry  Color
+        0   a     1         tab:blue
+        1   b     3         tab:orange
+        """
+
+        # Make key iterable if it isn't already
+        if (
+                not isinstance(key, tuple)
+                and not isinstance(key, slice)
+                and not isinstance(key, list)
+                and not isinstance(key, np.ndarray)
+        ):
+            key_iter = (key,)
+        else:
+            key_iter = key
+
+        d = {}
+        if (
+                isinstance(key_iter, str)
+                or (
+                isinstance(key_iter, tuple) and isinstance(key_iter[0], str))
+        ):
+            for key_name in list(set(key_iter)):  # Use set to remove duplicates
+                match = False
+                for i, phase in self._dict.items():
+                    if key_name == phase.name:
+                        d[i] = phase
+                        match = True
+                if not match:
+                    # Raises if any string in list of strings is not found
+                    raise IndexError(
+                        f"{key_name} is not among the available phases "
+                        f"{self.names}."
+                    )
+        elif (
+                isinstance(key_iter, int)
+                or isinstance(key_iter, tuple)
+                or isinstance(key_iter, list)
+                or isinstance(key_iter, np.ndarray)
+        ):
+            for i in list(set(key_iter)):  # Use set to remove duplicates
+                try:
+                    d[i] = self._dict[i]
+                except KeyError:
+                    raise IndexError(
+                        f"{i} is not among the available phase IDs "
+                        f"{self.phase_ids}."
+                    )
+        elif isinstance(key_iter, slice):
+            # Dicts cannot be sliced, hence this work-around
+            id_arr = np.arange(max(self.phase_ids) + 1)
+            sliced_arr = id_arr[key_iter]
+            ids_in_slice = [i for i in sliced_arr if i in self.phase_ids]
+            if ids_in_slice:
+                d = {i: self._dict[i] for i in ids_in_slice}
+            else:
+                raise IndexError(
+                    f"{key} is not valid for the available phase IDs "
+                    f"{self.phase_ids}."
+                )
+        else:
+            raise IndexError(f"{key} is not a valid indexing value.")
+
+        # Return a Phase object if only one phase was asked for
+        if isinstance(key, int) or isinstance(key, str):
+            return [i for i in d.values()][0]
+        else:
+            return PhaseList(d)
+
+    def __setitem__(self, key, value):
+        """Add phase to list with a key (phase_id) and value (symmetry)."""
+        if key not in self.names:
+            # Make sure the new phase gets a new color
+            color_new = None
+            for color_name in ALL_COLORS.keys():
+                if color_name not in self.colors:
+                    color_new = color_name
+                    break
+
+            # Create new ID
+            if self.phase_ids:
+                new_phase_id = max(self.phase_ids) + 1
+            else:
+                new_phase_id = 0
+
+            self._dict[new_phase_id] = Phase(
+                name=key, symmetry=value, color=color_new)
+        else:
+            raise ValueError(
+                f"{key} is already in the phase list {self.names}.")
+
+    def __iter__(self):
+        # Returning keys() and values() might confuse the user since the class
+        # is called PhaseList. Could perhaps change class name to PhaseDict?
+        # Called it PhaseList since MTEX calls it that...
+        for phase_id, phase in self._dict.items():
+            yield phase_id, phase
+
+    def __repr__(self):
+        # Ensure attributes set to None are treated OK
+        names = ['None' if not i else i for i in self.names]
+        symmetry_names = ['None' if not i else i.name for i in self.symmetries]
+
+        # Determine column widths (allowing PhaseList to be empty)
+        id_len = 3
+        name_len = 5
+        if names:
+            name_len = max(max([len(i) for i in names]), 5)
+        sym_len = 8
+        if symmetry_names:
+            sym_len = max(max([len(i) for i in symmetry_names]), 8)
+        col_len = 6
+        if self.colors:
+            col_len = max(max([len(i) for i in self.colors]), 6)
+
+        # Header
+        representation = (
+            "{:<{width}} ".format("Id", width=id_len)
+            + "{:<{width}} ".format("Name", width=name_len)
+            + "{:<{width}} ".format("Symmetry", width=sym_len)
+            + "{:<{width}}\n".format("Color", width=col_len)
+        )
+
+        # Overview of each phase
+        for i, phase_id in enumerate(self.phase_ids):
+            representation += (
+                    f"{phase_id:<{id_len}} "
+                    + f"{names[i]:<{name_len}} "
+                    + f"{symmetry_names[i]:<{sym_len}} "
+                    + f"{self.colors[i]:<{col_len}}\n"
+            )
+
+        return representation
+
+    def deepcopy(self):
+        return copy.deepcopy(self)

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
+from collections import OrderedDict
 import copy
 from itertools import islice
-from collections import OrderedDict
+from numbers import Number
 
 import matplotlib.colors as mcolors
 import numpy as np
@@ -123,6 +124,8 @@ class Phase:
     @symmetry.setter
     def symmetry(self, value):
         """Set the crystal symmetry of the phase."""
+        if isinstance(value, Number):
+            value = str(value)
         if isinstance(value, str):
             for correct, alias in POINT_GROUP_ALIASES.items():
                 if value == alias:

--- a/orix/io/__init__.py
+++ b/orix/io/__init__.py
@@ -27,8 +27,8 @@
 
 import numpy as np
 
-from .emsoft_h5ebsd import load_emsoft
-from .ang import load_ang
+from orix.io.emsoft_h5ebsd import load_emsoft
+from orix.io.ang import load_ang
 
 
 def loadang(file_string: str):

--- a/orix/io/__init__.py
+++ b/orix/io/__init__.py
@@ -27,6 +27,9 @@
 
 import numpy as np
 
+from .emsoft_h5ebsd import load_emsoft
+from .ang import load_ang
+
 
 def loadang(file_string: str):
     """Load ``.ang`` files.

--- a/orix/io/ang.py
+++ b/orix/io/ang.py
@@ -1,0 +1,255 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 The pyXem developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import re
+import warnings
+
+import numpy as np
+
+from orix.quaternion.rotation import Rotation
+from orix.crystal_map import CrystalMap
+
+_log = logging.getLogger(__name__)
+
+# MTEX has this format sorted out, check out their readers when fixing issues and
+# adapting to other versions of this file format in the future:
+# https://github.com/mtex-toolbox/mtex/blob/develop/interfaces/loadEBSD_ang.m
+# https://github.com/mtex-toolbox/mtex/blob/develop/interfaces/loadEBSD_ACOM.m
+
+
+def load_ang(filename):
+    """Return a :class:`orix.crystal_map.CrystalMap` object from EDAX TSL's
+    .ang file format. The map in the input file is assumed to be 2D.
+
+    Parameters
+    ----------
+    filename : str
+        Path and file name.
+    """
+
+    # Get file header
+    with open(filename) as f:
+        header = _get_header(f)
+
+    # Get phase names and crystal symmetries from header (potentially empty)
+    phase_names, symmetries = _get_phases_from_header(header)
+
+    # Read all file data
+    file_data = np.loadtxt(filename)
+
+    # Get vendor and column names
+    n_rows, n_cols = file_data.shape
+    vendor, column_names = _get_vendor_columns(header, n_cols)
+
+    # Data needed to create a CrystalMap object
+    data = {
+        "euler1": None,
+        "euler2": None,
+        "euler3": None,
+        "x": None,
+        "y": None,
+        "phase_id": None,
+        "prop": {},
+    }
+    for column, name in enumerate(column_names):
+        for key, value in data.items():
+            if name == key:
+                data[key] = file_data[:, column]
+            elif name not in list(data.keys()):
+                data["prop"][name] = file_data[:, column]
+
+    # Set which data points are not indexed
+    if vendor == "tsl":
+        data["phase_id"][np.where(data["prop"]["ci"] == -1)] = -1
+    # TODO: Add not-indexed convention for INDEX ASTAR
+
+    # Create rotations
+    rotations = Rotation.from_euler(
+        np.column_stack((data["euler1"], data["euler2"], data["euler3"]))
+    )
+
+    return CrystalMap(
+        rotations=rotations,
+        phase_id=data["phase_id"],
+        x=data["x"],
+        y=data["y"],
+        phase_name=phase_names,
+        symmetry=symmetries,
+        prop=data["prop"],
+    )
+
+
+def _get_header(file):
+    """Return the first lines starting with '#' in an .ang file.
+
+    Parameters
+    ----------
+    file : _io.TextIO
+        File object.
+
+    Returns
+    -------
+    header : list
+        List with header lines as individual elements.
+    """
+    _log.debug(f"get_header: From {file.name}")
+    header = []
+    line = file.readline()
+    while line.startswith("#"):
+        header.append(line.rstrip())
+        line = file.readline()
+    return header
+
+
+def _get_vendor_columns(header, n_cols_file):
+    """Return the .ang file column names and vendor, determined from the
+    header.
+
+    Parameters
+    ----------
+    header : list
+        List with header lines as individual elements.
+    n_cols_file : int
+        Number of file columns.
+    """
+    # Assume EDAX TSL by default
+    vendor = "tsl"
+
+    # Determine vendor by searching for the vendor footprint in the header
+    vendor_footprint = {
+        "emsoft": "EMsoft",
+        "astar": "ACOM",
+    }
+    for name, footprint in vendor_footprint.items():
+        for line in header:
+            if footprint in line:
+                vendor = name
+                break
+
+    # Vendor column names
+    column_names = {
+        "unknown": [
+            "euler1",
+            "euler2",
+            "euler3",
+            "x",
+            "y",
+            "unknown1",
+            "unknown2",
+            "phase_id",
+        ],
+        "tsl": [
+            "euler1",
+            "euler2",
+            "euler3",
+            "x",
+            "y",
+            "iq",  # Image quality from Hough transform
+            "ci",  # Confidence index
+            "phase_id",
+            "unknown1",
+            "fit",  # Pattern fit
+            "unknown2",
+            "unknown3",
+            "unknown4",
+            "unknown5",
+        ],
+        "emsoft": [
+            "euler1",
+            "euler2",
+            "euler3",
+            "x",
+            "y",
+            "iq",  # Image quality from Krieger Lassen's method
+            "dp",  # Dot product
+            "phase_id",
+        ],
+        "astar": [
+            "euler1",
+            "euler2",
+            "euler3",
+            "x",
+            "y",
+            "ind",  # Correlation index
+            "rel",  # Reliability
+            "phase_id",
+            "relx100",  # Reliability x 100
+        ],
+    }
+
+    n_cols_expected = len(column_names[vendor])
+    if n_cols_file != n_cols_expected:
+        warnings.warn(
+            f"Number of columns, {n_cols_file}, in the file is not equal to "
+            f"the expected number of columns, {n_cols_expected}, for the \n"
+            f"assumed vendor '{vendor}'. Will therefore assume the following "
+            "columns: euler1, euler2, euler3, x, y, unknown1, unknown2, "
+            "phase_id, etc."
+        )
+        vendor = "unknown"
+        if n_cols_file > n_cols_expected:
+            # Add potential extra columns to properties
+            for i in range(n_cols_file - n_cols_expected):
+                column_names["unknown"].append("unknown" + str(i + 3))
+
+    _log.debug(f"get_vendor_columns: Vendor is {vendor}")
+    return vendor, column_names[vendor]
+
+
+def _get_phases_from_header(header):
+    """Return phase names and symmetries detected in an .ang file
+    header.
+
+    Parameters
+    ----------
+    header : list
+        List with header lines as individual elements.
+
+    Returns
+    -------
+    phase_names : list
+        List of names of detected phases.
+    phase_symmetries : list
+        List of symmetries of detected phase.
+
+    Notes
+    -----
+    Regular expressions are used to collect phase name, formula and
+    symmetry. This function have been tested with files from the following
+    vendor's formats: EDAX TSL OIM Data Collection v7, ASTAR Index, and
+    EMsoft v4.
+    """
+    regexps = {
+        "name": "# MaterialName([ \t]+)([A-z0-9 ]+)",
+        "formula": "# Formula([ \t]+)([A-z0-9 ]+)",
+        "symmetry": "# Symmetry([ \t]+)([A-z0-9 ]+)",
+    }
+    phases = {"name": [], "formula": [], "symmetry": []}
+    for line in header:
+        for key, exp in regexps.items():
+            match = re.search(exp, line)
+            if match:
+                phases[key].append(match.group(2))
+
+    # Check if formula is empty (sometimes the case for ASTAR Index)
+    phase_names = phases["formula"]
+    if len(phase_names) == 0 or any([False if i is "" else True for i in phase_names]):
+        phase_names = phases["name"]
+
+    return phase_names, phases["symmetry"]

--- a/orix/io/ang.py
+++ b/orix/io/ang.py
@@ -133,6 +133,13 @@ def _get_vendor_columns(header, n_cols_file):
     n_cols_file : int
         Number of file columns.
 
+    Returns
+    -------
+    vendor : str
+        Determined vendor ("tsl", "astar", or "emsoft").
+    column_names : list of str
+        List of column names.
+
     """
     # Assume EDAX TSL by default
     vendor = "tsl"
@@ -229,9 +236,9 @@ def _get_phases_from_header(header):
 
     Returns
     -------
-    phase_names : list
+    phase_names : list of str
         List of names of detected phases.
-    phase_symmetries : list
+    phase_symmetries : list of str
         List of symmetries of detected phase.
 
     Notes

--- a/orix/io/ang.py
+++ b/orix/io/ang.py
@@ -206,12 +206,13 @@ def _get_vendor_columns(header, n_cols_file):
             f"the expected number of columns, {n_cols_expected}, for the \n"
             f"assumed vendor '{vendor}'. Will therefore assume the following "
             "columns: euler1, euler2, euler3, x, y, unknown1, unknown2, "
-            "phase_id, etc."
+            "phase_id, unknown3, unknown4, etc."
         )
         vendor = "unknown"
-        if n_cols_file > n_cols_expected:
+        n_cols_unknown = len(column_names["unknown"])
+        if n_cols_file > n_cols_unknown:
             # Add potential extra columns to properties
-            for i in range(n_cols_file - n_cols_expected):
+            for i in range(n_cols_file - n_cols_unknown):
                 column_names["unknown"].append("unknown" + str(i + 3))
 
     return vendor, column_names[vendor]

--- a/orix/io/ang.py
+++ b/orix/io/ang.py
@@ -249,7 +249,7 @@ def _get_phases_from_header(header):
 
     # Check if formula is empty (sometimes the case for ASTAR Index)
     phase_names = phases["formula"]
-    if len(phase_names) == 0 or any([False if i is "" else True for i in phase_names]):
+    if len(phase_names) == 0 or any([False if i == "" else True for i in phase_names]):
         phase_names = phases["name"]
 
     return phase_names, phases["symmetry"]

--- a/orix/io/emsoft_h5ebsd.py
+++ b/orix/io/emsoft_h5ebsd.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-import logging
 import re
 
 import h5py
@@ -24,8 +23,6 @@ import numpy as np
 
 from orix.quaternion.rotation import Rotation
 from orix.crystal_map import CrystalMap
-
-_log = logging.getLogger(__name__)
 
 
 def load_emsoft(filename, refined=False, **kwargs):
@@ -44,7 +41,6 @@ def load_emsoft(filename, refined=False, **kwargs):
 
     mode = kwargs.pop("mode", "r")
     f = h5py.File(filename, mode=mode, **kwargs)
-    _log.debug(f"load_emsoft: File {filename}")
 
     # Get groups for convenience
     ebsd_group = f["Scan 1/EBSD"]
@@ -53,38 +49,38 @@ def load_emsoft(filename, refined=False, **kwargs):
     phase_group = header_group["Phase/1"]
 
     # Get map shape and step sizes
-    ny = header_group["nRows"][()][0]
-    nx = header_group["nColumns"][()][0]
-    step_y = header_group["Step Y"][()][0]
+    ny = header_group["nRows"][:][0]
+    nx = header_group["nColumns"][:][0]
+    step_y = header_group["Step Y"][:][0]
     map_size = ny * nx
 
-    # Get map coordinates ("Y Position" data set is not correct)
-    x = data_group["X Position"][()]
+    # Get map coordinates ("Y Position" data set is not correct in EMsoft as of 2020-04,
+    # see: https://github.com/EMsoft-org/EMsoft/blob/7762e1961508fe3e71d4702620764ceb98a78b9e/Source/EMsoftHDFLib/EMh5ebsd.f90#L1093)
+    x = data_group["X Position"][:]
+    # y = data_group["Y Position"][:]
     y = np.sort(np.tile(np.linspace(0, (ny - 1) * step_y, ny), nx))
 
     # Get number of top matches kept
-    n_top_matches = f["NMLparameters/EBSDIndexingNameListType/nnk"][()][0]
+    n_top_matches = f["NMLparameters/EBSDIndexingNameListType/nnk"][:][0]
 
     # Get phase IDs
-    phase_id = data_group["Phase"][()]
+    phase_id = data_group["Phase"][:]
 
     # Get phase name and phase's crystal symmetry
     phase_name = re.search(
-        r"([A-z0-9]+)", phase_group["MaterialName"][()][0].decode()
+        r"([A-z0-9]+)", phase_group["MaterialName"][:][0].decode()
     ).group(1)
     symmetry = re.search(
-        r"\[([A-z0-9]+)\]", phase_group["Point Group"][()][0].decode()
+        r"\[([A-z0-9]+)\]", phase_group["Point Group"][:][0].decode()
     ).group(1)
 
     # Get rotations
     if refined:
-        euler = data_group["RefinedEulerAngles"][()]
-        _log.debug("load_emsoft: Read refined rotations")
+        euler = data_group["RefinedEulerAngles"][:]
     else:  # Get n top matches for each pixel
-        _log.debug(f"load_emsoft: Read {n_top_matches} rotations per point")
-        top_match_idx = data_group["TopMatchIndices"][()][:map_size]
-        dictionary_size = data_group["FZcnt"][()][0]
-        dictionary_euler = data_group["DictionaryEulerAngles"][()][:dictionary_size]
+        top_match_idx = data_group["TopMatchIndices"][:][:map_size]
+        dictionary_size = data_group["FZcnt"][:][0]
+        dictionary_euler = data_group["DictionaryEulerAngles"][:][:dictionary_size]
         euler = dictionary_euler[top_match_idx, :]
     rotations = Rotation.from_euler(euler)
 
@@ -140,7 +136,7 @@ def _get_properties(data_group, n_top_matches, map_size):
     properties = {}
     for property_name in expected_properties:
         if property_name in data_group.keys():
-            prop = data_group[property_name][()]
+            prop = data_group[property_name][:]
             if prop.shape[-1] == n_top_matches:
                 prop = prop[:map_size].reshape((map_size,) + (n_top_matches,))
             else:

--- a/orix/io/emsoft_h5ebsd.py
+++ b/orix/io/emsoft_h5ebsd.py
@@ -60,13 +60,13 @@ def load_emsoft(filename, refined=False, **kwargs):
     # y = data_group["Y Position"][:]
     y = np.sort(np.tile(np.arange(ny) * step_y, nx))
 
-    # Get number of top matches kept
+    # Get number of top matches kept per data point
     n_top_matches = f["NMLparameters/EBSDIndexingNameListType/nnk"][:][0]
 
     # Get phase IDs
     phase_id = data_group["Phase"][:]
 
-    # Get phase name and phase's crystal symmetry
+    # Get phase name and crystal symmetry
     phase_name = re.search(
         r"([A-z0-9]+)", phase_group["MaterialName"][:][0].decode()
     ).group(1)

--- a/orix/io/emsoft_h5ebsd.py
+++ b/orix/io/emsoft_h5ebsd.py
@@ -58,7 +58,7 @@ def load_emsoft(filename, refined=False, **kwargs):
     # see: https://github.com/EMsoft-org/EMsoft/blob/7762e1961508fe3e71d4702620764ceb98a78b9e/Source/EMsoftHDFLib/EMh5ebsd.f90#L1093)
     x = data_group["X Position"][:]
     # y = data_group["Y Position"][:]
-    y = np.sort(np.tile(np.linspace(0, (ny - 1) * step_y, ny), nx))
+    y = np.sort(np.tile(np.arange(ny) * step_y, nx))
 
     # Get number of top matches kept
     n_top_matches = f["NMLparameters/EBSDIndexingNameListType/nnk"][:][0]

--- a/orix/io/emsoft_h5ebsd.py
+++ b/orix/io/emsoft_h5ebsd.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 The pyXem developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import re
+
+import h5py
+import numpy as np
+
+from orix.quaternion.rotation import Rotation
+from orix.crystal_map import CrystalMap
+
+_log = logging.getLogger(__name__)
+
+
+def load_emsoft(filename, refined=False, **kwargs):
+    """Return a CrystalMap object from EMsoft's dictionary indexing dot
+    product files.
+
+    Parameters
+    ----------
+    filename : str
+        Path and file name.
+    refined : bool, optional
+        Whether to return refined orientations (default is ``False``).
+    kwargs :
+        Keyword arguments passed to :func:`h5py.File`.
+    """
+
+    mode = kwargs.pop("mode", "r")
+    f = h5py.File(filename, mode=mode, **kwargs)
+    _log.debug(f"load_emsoft: File {filename}")
+
+    # Get groups for convenience
+    ebsd_group = f["Scan 1/EBSD"]
+    data_group = ebsd_group["Data"]
+    header_group = ebsd_group["Header"]
+    phase_group = header_group["Phase/1"]
+
+    # Get map shape and step sizes
+    ny = header_group["nRows"][()][0]
+    nx = header_group["nColumns"][()][0]
+    step_y = header_group["Step Y"][()][0]
+    map_size = ny * nx
+
+    # Get map coordinates ("Y Position" data set is not correct)
+    x = data_group["X Position"][()]
+    y = np.sort(np.tile(np.linspace(0, (ny - 1) * step_y, ny), nx))
+
+    # Get number of top matches kept
+    n_top_matches = f["NMLparameters/EBSDIndexingNameListType/nnk"][()][0]
+
+    # Get phase IDs
+    phase_id = data_group["Phase"][()]
+
+    # Get phase name and phase's crystal symmetry
+    phase_name = re.search(
+        r"([A-z0-9]+)", phase_group["MaterialName"][()][0].decode()
+    ).group(1)
+    symmetry = re.search(
+        r"\[([A-z0-9]+)\]", phase_group["Point Group"][()][0].decode()
+    ).group(1)
+
+    # Get rotations
+    if refined:
+        euler = data_group["RefinedEulerAngles"][()]
+        _log.debug("load_emsoft: Read refined rotations")
+    else:  # Get n top matches for each pixel
+        _log.debug(f"load_emsoft: Read {n_top_matches} rotations per point")
+        top_match_idx = data_group["TopMatchIndices"][()][:map_size]
+        dictionary_size = data_group["FZcnt"][()][0]
+        dictionary_euler = data_group["DictionaryEulerAngles"][()][:dictionary_size]
+        euler = dictionary_euler[top_match_idx, :]
+    rotations = Rotation.from_euler(euler)
+
+    properties = _get_properties(
+        data_group=data_group, n_top_matches=n_top_matches, map_size=map_size,
+    )
+
+    return CrystalMap(
+        rotations=rotations,
+        phase_id=phase_id,
+        x=x,
+        y=y,
+        phase_name=phase_name,
+        symmetry=symmetry,
+        prop=properties,
+    )
+
+
+def _get_properties(data_group, n_top_matches, map_size):
+    """Return a dictionary of properties within an EMsoft h5ebsd file, with
+    property names as the dictionary key and arrays as the values.
+
+    Parameters
+    ----------
+    data_group : h5py.Group
+        HDF5 group with the property data sets.
+    n_top_matches : int
+        Number of rotations per point.
+    map_size : int
+        Data size.
+
+    Returns
+    -------
+    properties : dict
+        Property dictionary.
+    """
+    expected_properties = [
+        "AvDotProductMap",
+        "CI",
+        "CIMap",
+        "IQ",
+        "IQMap",
+        "ISM",
+        "ISMap",
+        "KAM",
+        "OSM",
+        "RefinedDotProducts",
+        "TopDotProductList",
+        "TopMatchIndices",
+    ]
+
+    # Get properties
+    properties = {}
+    for property_name in expected_properties:
+        if property_name in data_group.keys():
+            prop = data_group[property_name][()]
+            if prop.shape[-1] == n_top_matches:
+                prop = prop[:map_size].reshape((map_size,) + (n_top_matches,))
+            else:
+                prop = prop.reshape(map_size)
+            properties[property_name] = prop
+
+    return properties

--- a/orix/plot/__init__.py
+++ b/orix/plot/__init__.py
@@ -16,5 +16,5 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-from .rotation_plot import RodriguesPlot
-from .crystal_map_plot import CrystalMapPlot
+from orix.plot.rotation_plot import RodriguesPlot
+from orix.plot.crystal_map_plot import CrystalMapPlot

--- a/orix/plot/__init__.py
+++ b/orix/plot/__init__.py
@@ -17,3 +17,4 @@
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
 from .rotation_plot import RodriguesPlot
+from .crystal_map_plot import _plot_crystal_map

--- a/orix/plot/__init__.py
+++ b/orix/plot/__init__.py
@@ -17,4 +17,4 @@
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
 from .rotation_plot import RodriguesPlot
-from .crystal_map_plot import _plot_crystal_map
+from .crystal_map_plot import CrystalMapPlot

--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -16,22 +16,19 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-import logging
 import warnings
 
+import matplotlib.font_manager as fm
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
 import numpy as np
-from mpl_toolkits.axes_grid1.anchored_artists import AnchoredSizeBar
-from mpl_toolkits.axes_grid1 import make_axes_locatable
 from matplotlib.axes import Axes
 from matplotlib.projections import register_projection
-import matplotlib.patches as mpatches
-import matplotlib.font_manager as fm
-import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+from mpl_toolkits.axes_grid1.anchored_artists import AnchoredSizeBar
 
 from orix.scalar import Scalar
 from orix.vector import Vector3d
-
-_log = logging.getLogger(__name__)
 
 
 class CrystalMapPlot(Axes):
@@ -56,6 +53,7 @@ class CrystalMapPlot(Axes):
         Add an opinionated colorbar to the figure.
     remove_padding()
         Remove all white padding outside of the figure.
+
     """
 
     name = "plot_map"
@@ -117,15 +115,9 @@ class CrystalMapPlot(Axes):
         >>> from orix import plot
         >>> from orix.io import load_ang
 
-        Import a crystal map and inspect it
+        Import a crystal map
 
         >>> cm = load_ang("/some/directory/data.ang")
-        >>> cm
-        Phase  Orientations   Name       Symmetry  Color
-        1      5657 (48.4%)   austenite  432       tab:blue
-        2      6043 (51.6%)   ferrite    432       tab:orange
-        Properties: iq, dp
-        Scan unit: um
 
         Plot a phase map
 
@@ -145,7 +137,7 @@ class CrystalMapPlot(Axes):
 
         Add a colorbar
 
-        >>> cbar = ax.add_colorbar("Dot product")
+        >>> cbar = ax.add_colorbar("Dot product")  # Get colorbar
 
         Plot orientation angle in degrees of one phase
 
@@ -175,8 +167,6 @@ class CrystalMapPlot(Axes):
         """
         patches = None
         if value is None:  # Phase map
-            _log.debug("plot_map: Plot a phase map")
-
             # Color each map pixel with corresponding phase color RGB tuple
             phase_id = crystal_map.get_map_data("phase_id")
             unique_phase_ids = np.unique(phase_id[~np.isnan(phase_id)])
@@ -193,7 +183,6 @@ class CrystalMapPlot(Axes):
                 patches.append(mpatches.Patch(color=p.color_rgb, label=p.name))
         else:  # Create masked array of correct shape
             if isinstance(value, Scalar) or isinstance(value, Vector3d):
-                _log.debug(f"plot_map: Plot {type(value)} attribute data")
                 value = value.data
             data = crystal_map.get_map_data(value)
 
@@ -249,6 +238,7 @@ class CrystalMapPlot(Axes):
         >>> ax = fig.add_subplot(projection="plot_map")
         >>> im = ax.plot_map(cm, scalebar=False)
         >>> sbar = ax.add_scalebar(cm, loc=4, frameon=False)
+
         """
         map_width = crystal_map.shape[-1]
         # TODO: Make this "dynamic"/dependable when enabling specimen reference frame
@@ -309,7 +299,6 @@ class CrystalMapPlot(Axes):
         bar.patch.set_alpha(0.6)
 
         self.axes.add_artist(bar)
-        _log.debug(f"add_scalebar: To {self.axes}")
 
         return bar
 
@@ -341,6 +330,7 @@ class CrystalMapPlot(Axes):
         >>> ax = fig.add_subplot(projection="plot_map")
         >>> im = ax.plot_map(cm)
         >>> ax.add_overlay(cm, cm.dp)
+
         """
         image = self.images[0]
         image_data = image.get_array()
@@ -358,7 +348,6 @@ class CrystalMapPlot(Axes):
         for i in range(n_channels):
             image_data[:, :, i] *= rescaled_overlay
 
-        _log.debug(f"add_overlay: To {image}")
         image.set_data(image_data)
 
     def add_colorbar(self, title=None, **kwargs):
@@ -397,6 +386,7 @@ class CrystalMapPlot(Axes):
         updated
 
         >>> cbar.ax.set_ylabel(title="dp", rotation=90)
+
         """
         # Keyword arguments
         d = {"position": "right", "size": "5%", "pad": 0.1}
@@ -405,7 +395,6 @@ class CrystalMapPlot(Axes):
         # Add colorbar
         divider = make_axes_locatable(self)
         cax = divider.append_axes(**kwargs)
-        _log.debug(f"add_colorbar: To {self.figure}")
         cbar = self.figure.colorbar(self.images[0], cax=cax)
 
         # Set title with padding
@@ -432,6 +421,7 @@ class CrystalMapPlot(Axes):
         >>> ax = fig.add_subplot(projection="plot_map")
         >>> ax.plot_map(cm)
         >>> ax.remove_padding()
+
         """
         self.set_axis_off()
         self.margins(0, 0)
@@ -442,7 +432,6 @@ class CrystalMapPlot(Axes):
             right = self.figure.subplotpars.right
         else:
             right = 1
-        _log.debug(f"remove_padding: From {self.figure}")
         self.figure.subplots_adjust(top=1, bottom=0, right=right, left=0)
 
     def _add_legend(self, patches, **kwargs):
@@ -463,7 +452,6 @@ class CrystalMapPlot(Axes):
             "prop": fm.FontProperties(size=11),
         }
         [kwargs.setdefault(k, v) for k, v in d.items()]
-        _log.debug(f"add_legend: To {self.axes}")
         self.legend(handles=patches, **kwargs)
 
     def _override_status_bar(self, image, crystal_map):
@@ -487,8 +475,8 @@ class CrystalMapPlot(Axes):
         -------
         image : matplotlib.images.AxesImage
             Image object where the above mentioned methods are overridden.
-        """
 
+        """
         # Get map shape
         map_shape = crystal_map._original_shape
         n_rows, n_cols = map_shape
@@ -536,7 +524,6 @@ class CrystalMapPlot(Axes):
         else:
             image.format_cursor_data = format_status_bar_data_scalar
 
-        _log.debug(f"override_status_bar: Of {self.axes}")
         return image
 
 
@@ -572,6 +559,7 @@ def convert_unit(value, unit):
     17.55 um 999.9999999999999
     >>> convert_unit(17.55 * 1e-3, 'mm')
     17.55 um 0.001
+
     """
     # If unit is 'px', we assume 'um', and revert unit in the end
     unit_is_px = False
@@ -603,8 +591,4 @@ def convert_unit(value, unit):
     if unit_is_px:
         new_unit = "px"
 
-    _log.debug(
-        f"convert_unit: From {value} {unit} to {new_value} {new_unit} with factor "
-        f"{factor}"
-    )
     return new_value, new_unit, factor

--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -19,193 +19,484 @@
 import warnings
 
 import numpy as np
-import matplotlib.pyplot as plt
+import matplotlib
 from mpl_toolkits.axes_grid1.anchored_artists import AnchoredSizeBar
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+from matplotlib.axes import Axes
+from matplotlib import projections
+import matplotlib.patches as mpatches
 import matplotlib.font_manager as fm
 
+rcParams = matplotlib.rcParams
 
-def _plot_crystal_map(
-        crystal_map,
-        data,
-        legend_patches=None,
-        scalebar=True,
-        padding=True,
-        **kwargs,
-):
-    """Plot crystal map data.
 
-    Parameters
-    ----------
-    crystal_map : orix.crystal_map.CrystalMap
-        CrystalMap object, needed to get map shape, scan unit and
-        horizontal step size.
-    data : numpy.ndarray
-        Map data to plot. A 2D array with potential RGB(A) channels.
-    legend_patches : list of matplotlib.patches.Patch, optional
-        Legend patches, e.g. phase colors and names. If ``None`` is passed
-        (default), no legend is added.
-    scalebar : bool, optional
-        Whether to display a scalebar (default is ``True``).
-    padding : bool, optional
-        Whether to show white padding (default is ``True``). Setting this
-        to ``False`` removes all white padding outside of plot, including
-        pixel coordinate ticks.
-    **kwargs :
-        Optional keyword arguments passed to
-        :meth:`matplotlib.pyplot.imshow`.
+class CrystalMapPlot(Axes):
+    """A base class for plotting of CrystalMap objects."""
 
-    Returns
-    -------
-    fig : matplotlib.figure.Figure
-        Top level container for all plot elements.
-    ax : matplotlib.axes.Axes
-        Axes object returned by :meth:`matplotlib.pyplot.subplots`.
-    im : matplotlib.image.AxesImage
-        Image object returned by :meth:`matplotlib.axes.Axes.imshow`.
-    """
+    name = None
+    _property_name = None
 
-    cmap = kwargs.pop('cmap', None)
-    interpolation = kwargs.pop('interpolation', 'none')
+    def _plot_crystal_map(
+            self,
+            crystal_map,
+            patches=None,
+            scalebar=True,
+            scalebar_properties=None,
+            legend_properties=None,
+            **kwargs,
+    ):
+        if scalebar:
+            self.add_scalebar(crystal_map, scalebar_properties)
 
-    fig, ax = plt.subplots()
-    im = ax.imshow(data, cmap=cmap, interpolation=interpolation, **kwargs)
+        if patches:
+            d = {
+                "borderpad": 0.3,
+                "handlelength": 0.75,
+                "handletextpad": 0.3,
+                "framealpha": 0.6,
+                "prop": fm.FontProperties(size=11),
+            }
+            if legend_properties is None:
+                legend_properties = {}
+            [legend_properties.setdefault(k, v) for k, v in d.items()]
+            self.legend(handles=patches, **legend_properties)
 
-    # Remove white padding around plot, including pixel coordinate ticks
-    if not padding:
-        ax.set(xticks=[], yticks=[])
-        fig.gca().set_axis_off()
-        fig.subplots_adjust(
-            top=1, bottom=0, right=1, left=0, hspace=0, wspace=0)
-        ax.margins(0, 0)
-        fig.gca().xaxis.set_major_locator(plt.NullLocator())
-        fig.gca().yaxis.set_major_locator(plt.NullLocator())
+        data = kwargs.pop("X")  # Extract for code clarity
+        im = super().imshow(X=data, **kwargs)
 
-    # Legend
-    if legend_patches:
-        ax = _add_legend(axes=ax, patches=legend_patches)
+        im = self._override_status_bar(im, crystal_map)
 
-    # Scalebar
-    if scalebar:
-        ax = _add_scalebar(
-            axes=ax,
-            map_width=crystal_map.shape[1],
-            scan_unit=crystal_map.scan_unit,
-            step_size=crystal_map.step_sizes[-1],
+        return im
+
+    def _override_status_bar(self, image, crystal_map):
+        """Display coordinates and Euler angles per pixel in status bar.
+
+         This is done by overriding
+         :meth:`matplotlib.images.AxesImage.get_cursor_data`,
+         :meth:`matplotlib.images.AxesImage.format_cursor_data` and
+         :meth:`matplotlib.axes.Axes.format_coord`.
+
+        Parameters
+        ----------
+        image : matplotlib.images.AxesImage
+            Image object.
+        crystal_map : orix.crystal_map.CrystalMap
+            Crystal map object to obtain necessary data from.
+
+        Returns
+        -------
+        image : matplotlib.images.AxesImage
+            Image object where the above mentioned methods are overridden.
+        """
+        # Get rotations in radians, ensuring proper masking of pixels
+        r = crystal_map._rotations.to_euler()
+        r = np.round(r, decimals=3)
+        r[~crystal_map.indexed.ravel()] = None
+
+        n_rows, n_cols = crystal_map.shape
+
+        im_data = image.get_array()
+
+        def status_bar_data(event):
+            col = int(event.xdata + 0.5)
+            row = int(event.ydata + 0.5)
+            return row, col, r[col + (row * n_cols)], im_data[row, col]
+
+        # Set width of x and y fields in plotting status bar
+        x_width = len(str(n_cols - 1))
+        y_width = len(str(n_rows - 1))
+
+        if self.name == "property_map":
+            def format_status_bar_data(data):
+                return (
+                    f"(y,x):({data[0]:{y_width}},{data[1]:{x_width}})"
+                    f" {self._property_name}:{data[3]}"
+                    f" rot:({data[2][0]:5},{data[2][1]:5},{data[2][2]:5})"
+                )
+        else:
+            def format_status_bar_data(data):
+                return (
+                    f"(y,x):({data[0]:{y_width}},{data[1]:{x_width}})"
+                    f" rot:({data[2][0]:5},{data[2][1]:5},{data[2][2]:5})"
+                )
+
+        # Override
+        image.get_cursor_data = status_bar_data
+        image.format_cursor_data = format_status_bar_data
+        self.axes.format_coord = lambda x, y: ""
+
+        return image
+
+    def add_scalebar(self, crystal_map, scalebar_properties):
+        """Add a scalebar to the axes object via `AnchoredSizeBar`.
+
+        To find an appropriate scalebar width, this snippet from MTEX
+        [Bachmann2010]_ written by Eric Payton and Philippe Pinard is used:
+        https://github.com/mtex-toolbox/mtex/blob/b8fc167d06d453a2b3e212b1ac383acbf85a5a27/plotting/scaleBar.m,
+
+        Parameters
+        ----------
+        crystal_map : orix.crystal_map.CrystalMap
+            Crystal map object to obtain necessary data from.
+        scalebar_properties : dict
+            Keyword arguments passed to
+            :func:`mpl_toolkits.axes_grid1.anchored_artists.AnchoredSizeBar`.
+
+        Examples
+        --------
+        >>> cm
+        Phase  Orientations   Name       Symmetry  Color
+        1      5657 (48.4%)   austenite  432       tab:blue
+        2      6043 (51.6%)   ferrite    432       tab:orange
+        Properties: iq, ci, fit
+        Scan unit: um
+        >>> fig = plt.figure()
+        >>> ax = fig.add_subplot(projection="phase_map")
+        >>> im = ax.phase_map(cm, scalebar=False)
+        >>> ax.add_scalebar()
+        """
+        map_width = crystal_map.shape[-1]
+        step_size = crystal_map.step_sizes[-1]
+        scan_unit = crystal_map.scan_unit
+
+        # Initial scalebar width should be approximately 1/10 of map width
+        scalebar_width = 0.1 * (map_width * step_size)
+
+        # Ensure a suitable number is used, e.g. going from 1000 nm to 1 um
+        scalebar_width, scan_unit, factor = convert_unit(
+            scalebar_width, scan_unit)
+
+        # This snippet for finding a suitable scalebar width is taken from MTEX:
+        # https://github.com/mtex-toolbox/mtex/blob/b8fc167d06d453a2b3e212b1ac383acbf85a5a27/plotting/scaleBar.m,
+        # written by Eric Payton and Philippe Pinard.
+        # We want a round, not too high number without decimals
+        good_values = np.array(
+            [1, 2, 5, 10, 15, 20, 25, 50, 75, 100, 125, 150, 200, 500, 750],
+            dtype=int,
+        )
+        # Find good data closest to initial scalebar width
+        difference = abs(scalebar_width - good_values)
+        good_value_idx = np.where(difference == difference.min())[0][0]
+        scalebar_width = good_values[good_value_idx]
+
+        # Scale width by factor from above conversion (usually factor = 1.0)
+        scalebar_width = scalebar_width * factor
+        scalebar_width_px = scalebar_width / step_size
+
+        # Allow for a potential decimal in scalebar number if something didn't
+        # go as planned
+        if scalebar_width.is_integer():
+            scalebar_width = int(scalebar_width)
+        else:
+            warnings.warn(f"Scalebar width {scalebar_width} is not an integer.")
+
+        if scan_unit == 'um':
+            scan_unit = "\u03BC" + "m"
+
+        # Set up arguments to AnchoredSizeBar() if not already present in kwargs
+        d = {
+            "loc": 3,
+            "pad": 0.2,
+            "sep": 3,
+            "borderpad": 0.5,
+            "size_vertical": 1,
+            "fontproperties": fm.FontProperties(size=11),
+        }
+        if scalebar_properties is None:
+            scalebar_properties = {}
+        [scalebar_properties.setdefault(k, v) for k, v in d.items()]
+
+        # Create scalebar
+        bar = AnchoredSizeBar(
+            transform=self.axes.transData,
+            size=scalebar_width_px,
+            label=str(scalebar_width) + ' ' + scan_unit,
+            **scalebar_properties,
+        )
+        bar.patch.set_alpha(0.6)
+
+        self.axes.add_artist(bar)
+
+    def remove_padding(self):
+        """Remove all white padding outside of the figure.
+
+        Examples
+        --------
+        >>> cm
+        Phase  Orientations   Name       Symmetry  Color
+        1      5657 (48.4%)   austenite  432       tab:blue
+        2      6043 (51.6%)   ferrite    432       tab:orange
+        Properties: iq, ci, fit
+        Scan unit: um
+        >>> fig = plt.figure()
+        >>> ax = fig.add_subplot(projection="phase_map")
+        >>> ax.phase_map(cm)
+        >>> ax.remove_padding()
+        """
+        self.set_axis_off()
+        self.margins(0, 0)
+
+        # Tune subplot layout
+        colorbar = self.images[0].colorbar
+        if colorbar is not None:
+            right = self.figure.subplotpars.right
+        else:
+            right = 1
+        self.figure.subplots_adjust(top=1, bottom=0, right=right, left=0)
+
+
+class PhaseMap(CrystalMapPlot):
+
+    name = "phase_map"
+
+    def phase_map(
+            self,
+            crystal_map,
+            scalebar=True,
+            scalebar_properties=None,
+            legend_properties=None,
+            **kwargs,
+    ):
+        """Plot a map of phases with a scalebar and legend.
+
+        Wraps :meth:`matplotlib.axes.Axes.imshow`, see that method for
+        relevant keyword arguments.
+
+        Parameters
+        ----------
+        crystal_map : orix.crystal_map.CrystalMap
+            Crystal map object to obtain data to plot from.
+        scalebar : bool, optional
+            Whether to add a scalebar (default is ``True``) along the last
+            map dimension.
+        scalebar_properties : dict
+            Dictionary of keyword arguments passed to
+            :func:`mpl_toolkits.axes_grid1.anchored_artists.AnchoredSizeBar`.
+        legend_properties : dict
+            Dictionary of keyword arguments passed to
+            :meth:`matplotlib.axes.legend`.
+        kwargs :
+            Keyword arguments passed to
+            :meth:`matplotlib.axes.Axes.imshow`.
+
+        Returns
+        -------
+        im : matplotlib.image.AxesImage
+            Image object.
+
+        See Also
+        --------
+        matplotlib.axes.Axes.imshow
+        orix.plot.crystal_map_plot.CrystalMapPlot._add_scalebar
+        """
+
+        # Create data array
+        n_channels = 3  # RGB
+        map_shape = crystal_map.shape
+        data = np.ones((np.prod(map_shape), n_channels))
+
+        # Color each map pixel with corresponding phase color RGB tuple
+        phase_id = crystal_map.phase_id.ravel()
+        for i, color in zip(np.unique(phase_id), crystal_map.phases.colors_rgb):
+            mask = phase_id == i
+            data[mask] = data[mask] * color
+
+        # Reshape to 2D array
+        data = data.reshape(map_shape + (n_channels,))
+
+        # Legend
+        patches = []
+        for _, p in crystal_map.phases_in_map:
+            patches.append(mpatches.Patch(color=p.color_rgb, label=p.name))
+
+        return super()._plot_crystal_map(
+            crystal_map,
+            patches=patches,
+            scalebar=scalebar,
+            scalebar_properties=scalebar_properties,
+            legend_properties=legend_properties,
+            X=data,
+            **kwargs
         )
 
-    return fig, ax, im
+    def add_overlay(self, crystal_map, property_name):
+        """Use a crystal map property as gray scale values of a phase map.
+
+        The property's range is adjusted to [0, 1] for maximum contrast.
+
+        Parameters
+        ----------
+        crystal_map : orix.crystal_map.CrystalMap
+            Crystal map object to obtain necessary data from.
+        property_name : str
+            Name of map property to scale phase array with. The property
+            range is adjusted for maximum contrast.
+
+        Examples
+        --------
+        >>> cm
+        Phase  Orientations   Name       Symmetry  Color
+        1      5657 (48.4%)   austenite  432       tab:blue
+        2      6043 (51.6%)   ferrite    432       tab:orange
+        Properties: iq, ci, fit
+        Scan unit: um
+        >>> fig = plt.figure()
+        >>> ax = fig.add_subplot(projection="phase_map")
+        >>> im = ax.phase_map(cm)
+        >>> ax.add_overlay(cm, "ci")
+       """
+        im = self.images[0]
+        data = im.get_array()
+
+        properties = crystal_map.prop
+        if property_name not in properties.keys():
+            raise ValueError(
+                f"{property_name} is not among available properties "
+                f"{list(properties.keys())}."
+            )
+        prop = properties[property_name]
+
+        # Scale prop to [0, 1] to maximize image contrast
+        prop_min = prop.min()
+        prop = (prop - prop_min) / (prop.max() - prop_min)
+
+        n_channels = 3
+        for i in range(n_channels):
+            data[:, :, i] *= prop
+
+        # Set non-indexed points to white (or None for black)
+        data[~crystal_map.indexed] = (1, 1, 1)
+
+        data = data.reshape(crystal_map.shape + (n_channels,))
+        im.set_data(data)
 
 
-def _add_legend(axes, patches):
-    """Add a legend with patches to axes.
+class PropertyMap(CrystalMapPlot):
 
-    Parameters
-    ----------
-    axes : matplotlib.axes.Axes
-        Axes object to add legend to.
-    patches : list of matplotlib.patches.Patch
-        Legend patches, e.g. phase colors and names.
-    **kwargs :
-        Optional keyword arguments passed to
-        :meth:`matplotlib.axes.Axes.legend`.
+    name = "property_map"
 
-    Returns
-    -------
-    axes : matplotlib.axes.Axes
-        Axes object with legend.
-    """
-    axes.legend(
-        handles=patches,
-        borderpad=0.3,
-        handlelength=0.75,
-        handletextpad=0.3,
-        framealpha=0.6,
-    )
-    return axes
+    def property_map(
+            self,
+            crystal_map,
+            property_name,
+            scalebar=True,
+            scalebar_properties=None,
+            **kwargs,
+    ):
+        """Plot a map of a property with a scalebar.
+
+        Wraps :meth:`matplotlib.axes.Axes.imshow`, see that method for
+        relevant keyword arguments.
+
+        Parameters
+        ----------
+        crystal_map : orix.crystal_map.CrystalMap
+            Crystal map object to obtain data to plot from.
+        property_name : str
+            Name of map property to plot.
+        scalebar : bool, optional
+            Whether to add a scalebar (default is ``True``) along the last
+            map dimension.
+        scalebar_properties : dict
+            Dictionary of keyword arguments passed to
+            :func:`mpl_toolkits.axes_grid1.anchored_artists.AnchoredSizeBar`.
+        kwargs :
+            Keyword arguments passed to
+            :meth:`matplotlib.axes.Axes.imshow` and
+            :meth:`~orix.plot.crystal_map_plot.CrystalMapPlot._add_scalebar`.
+
+        Returns
+        -------
+        im : matplotlib.image.AxesImage
+            Image object.
+
+        See Also
+        --------
+        matplotlib.axes.Axes.imshow
+        orix.plot.crystal_map_plot.CrystalMapPlot._add_scalebar
+
+        Examples
+        --------
+        >>> cm
+        Phase  Orientations   Name       Symmetry  Color
+        1      5657 (48.4%)   austenite  432       tab:blue
+        2      6043 (51.6%)   ferrite    432       tab:orange
+        Properties: iq, ci, fit
+        Scan unit: um
+        >>> fig = plt.figure()
+        >>> ax = fig.add_subplot(projection="property_map")
+        >>> im = ax.property_map(cm, "ci")
+        """
+        properties = crystal_map.prop
+        if property_name not in properties.keys():
+            raise ValueError(
+                f"{property_name} is not among available properties "
+                f"{list(properties.keys())}."
+            )
+        data = properties[property_name]
+
+        self._property_name = property_name
+
+        return super()._plot_crystal_map(
+            crystal_map,
+            scalebar=scalebar,
+            scalebar_properties=scalebar_properties,
+            X=data,
+            cmap=kwargs.pop("cmap", "gray"),
+            **kwargs,
+        )
+
+    def add_colorbar(self, title=None, **kwargs):
+        """Add an opinionated colorbar to the figure.
+
+        Parameters
+        ----------
+        title : str, optional
+            Colorbar title, default is ``None``.
+        kwargs :
+            Keyword arguments passed to
+            :meth:`mpl_toolkits.axes_grid1.make_axes_locatable.append_axes`.
+
+        Examples
+        --------
+        >>> cm
+        Phase  Orientations   Name       Symmetry  Color
+        1      5657 (48.4%)   austenite  432       tab:blue
+        2      6043 (51.6%)   ferrite    432       tab:orange
+        Properties: iq, ci, fit
+        Scan unit: um
+        >>> fig = plt.figure()
+        >>> ax = fig.add_subplot(projection="property_map")
+        >>> im = ax.property_map(cm, "ci")
+        >>> ax.add_colorbar("Confidence index")
+
+        If the default options are not as desired, a colorbar can be added
+        and modified using, instead of the above line:
+
+        >>> cbar = fig.colorbar(im, ax=ax)
+        >>> cbar.ax.set_ylabel(title="ci", rotation=0)
+        """
+
+        # Keyword arguments
+        d = {"position": "right", "size": "5%", "pad": 0.1}
+        [kwargs.setdefault(k, v) for k, v in d.items()]
+
+        # Add colorbar
+        divider = make_axes_locatable(self)
+        cax = divider.append_axes(**kwargs)
+        cbar = self.figure.colorbar(self.images[0], cax=cax)
+
+        # Set title with padding
+        cbar.ax.get_yaxis().labelpad = 15
+        cbar.ax.set_ylabel(title)
 
 
-def _add_scalebar(axes, map_width, scan_unit, step_size):
-    """Add a scalebar via `AnchoredSizeBar` to axes.
-
-    To find an appropriate scalebar width, this snippet from
-    MTEX [Bachmann2010]_, written by Eric Payton and Philippe Pinard, is
-    used: https://github.com/mtex-toolbox/mtex/blob/b8fc167d06d453a2b3e212b1ac383acbf85a5a27/plotting/scaleBar.m,
-
-    Parameters
-    ----------
-    axes : matplotlib.axes.Axes
-        Axes object to add scalebar to.
-    map_width : int
-        Map width in pixels.
-    scan_unit : str
-        Map scan unit, e.g. 'um' or 'nm'.
-    step_size : float
-        Map step size in last map dimension.
-
-    Returns
-    -------
-    axes : matplotlib.axes.Axes
-        Axes object with scalebar.
-    """
-
-    # Initial scalebar width should be approximately 1/10 of map width
-    scalebar_width = 0.1 * (map_width * step_size)
-
-    # Ensure a suitable number is used, e.g. going from 1000 nm to 1 um
-    scalebar_width, scan_unit, factor = convert_unit(scalebar_width, scan_unit)
-
-    # This snippet for finding a suitable scalebar width is taken from
-    # MTEX: https://github.com/mtex-toolbox/mtex/blob/b8fc167d06d453a2b3e212b1ac383acbf85a5a27/plotting/scaleBar.m,
-    # written by Eric Payton and Philippe Pinard.
-    # We want a round, not too high number without decimals
-    good_values = np.array(
-        [1, 2, 5, 10, 15, 20, 25, 50, 75, 100, 125, 150, 200, 500, 750],
-        dtype=int,
-    )
-    # Find good value closest to initial scalebar width
-    difference = abs(scalebar_width - good_values)
-    good_value_idx = np.where(difference == difference.min())[0][0]
-    scalebar_width = good_values[good_value_idx]
-
-    # Scale width by factor from above conversion (usually factor = 1.0)
-    scalebar_width = scalebar_width * factor
-    scalebar_width_px = scalebar_width / step_size
-
-    # Allow for a potential decimal in scalebar number if something didn't go
-    # as planned
-    if scalebar_width.is_integer():
-        scalebar_width = int(scalebar_width)
-    else:
-        warnings.warn(f"Scalebar width {scalebar_width} is not an integer.")
-
-    if scan_unit == 'um':
-        scan_unit = "\u03BC" + "m"
-
-    # Create scalebar
-    fontprops = fm.FontProperties(size=11)
-    bar = AnchoredSizeBar(
-        transform=axes.transData,
-        size=scalebar_width_px,
-        label=str(scalebar_width) + ' ' + scan_unit,
-        loc=3,
-        pad=0.2,
-        sep=3,
-        borderpad=0.3,
-        frameon=True,
-        size_vertical=1,
-        color="black",
-        fontproperties=fontprops,
-    )
-    bar.patch.set_alpha(0.6)
-
-    # Add scalebar to axes
-    axes.add_artist(bar)
-
-    return axes
+projections.register_projection(PhaseMap)
+projections.register_projection(PropertyMap)
 
 
 def convert_unit(value, unit):
-    """Return the value with a suitable, not too large, unit.
+    """Return the data with a suitable, not too large, unit.
 
     This algorithm is taken directly from MTEX [Bachmann2010]_
     https://github.com/mtex-toolbox/mtex/blob/a74545383160610796b9525eedf50a241800ffae/plotting/plotting_tools/switchUnit.m,
@@ -214,18 +505,18 @@ def convert_unit(value, unit):
     Parameters
     ----------
     value : float
-        The value to convert.
+        The data to convert.
     unit : str
-        The value unit, e.g. um.
+        The data unit, e.g. um.
 
     Returns
     -------
     new_value : float
-        The input value converted to the suitable unit.
+        The input data converted to the suitable unit.
     new_unit : str
         A more suitable unit than the input.
     factor : float
-        Factor to multiple `new_value` with to get the input value.
+        Factor to multiple `new_value` with to get the input data.
 
     Examples
     --------
@@ -258,7 +549,7 @@ def convert_unit(value, unit):
     power_of_value = np.floor(np.log10(value_in_metres))
     suitable_unit_idx = int(np.floor(power_of_value / 3) + 8)
 
-    # Calculate new value, unit and the conversion factor
+    # Calculate new data, unit and the conversion factor
     new_value = value_in_metres / lookup_table[suitable_unit_idx][1]
     new_unit = lookup_table[suitable_unit_idx][0]
     factor = lookup_table[suitable_unit_idx][1] / lookup_table[new_unit_idx][1]

--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -90,7 +90,7 @@ def _plot_crystal_map(
             axes=ax,
             map_width=crystal_map.shape[1],
             scan_unit=crystal_map.scan_unit,
-            step_size=crystal_map.dx[-1],
+            step_size=crystal_map.step_sizes[-1],
         )
 
     return fig, ax, im

--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -16,65 +16,465 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import warnings
 
 import numpy as np
-import matplotlib
 from mpl_toolkits.axes_grid1.anchored_artists import AnchoredSizeBar
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from matplotlib.axes import Axes
-from matplotlib import projections
+from matplotlib.projections import register_projection
 import matplotlib.patches as mpatches
 import matplotlib.font_manager as fm
+import matplotlib.pyplot as plt
 
-rcParams = matplotlib.rcParams
+from orix.scalar import Scalar
+from orix.vector import Vector3d
+
+_log = logging.getLogger(__name__)
 
 
 class CrystalMapPlot(Axes):
-    """A base class for plotting of CrystalMap objects."""
+    """A base class for 2D plotting of CrystalMap objects.
 
-    name = None
-    _property_name = None
+    Attributes
+    ----------
+    name : str
+        Matplotlib projection name.
 
-    def _plot_crystal_map(
-            self,
-            crystal_map,
-            patches=None,
-            scalebar=True,
-            scalebar_properties=None,
-            legend_properties=None,
-            **kwargs,
+    Methods
+    -------
+    plot_map(
+        crystal_map, value=None, scalebar=True, scalebar_properties=None,
+        legend=True, legend_properties=None, **kwargs)
+        Plot a 2D map with any CrystalMap attribute as map values.
+    add_scalebar(crystal_map, **kwargs)
+        Add a scalebar to the axes object via `AnchoredSizeBar`.
+    add_overlay(crystal_map, item)
+        Use a crystal map property as gray scale values of a phase map.
+    add_colorbar(title=None, **kwargs)
+        Add an opinionated colorbar to the figure.
+    remove_padding()
+        Remove all white padding outside of the figure.
+    """
+
+    name = "plot_map"
+
+    def plot_map(
+        self,
+        crystal_map,
+        value=None,
+        scalebar=True,
+        scalebar_properties=None,
+        legend=True,
+        legend_properties=None,
+        **kwargs,
     ):
-        if scalebar:
-            self.add_scalebar(crystal_map, scalebar_properties)
+        """Plot a 2D map with any CrystalMap attribute as map values.
 
-        if patches:
-            d = {
-                "borderpad": 0.3,
-                "handlelength": 0.75,
-                "handletextpad": 0.3,
-                "framealpha": 0.6,
-                "prop": fm.FontProperties(size=11),
-            }
+        Wraps :meth:`matplotlib.axes.Axes.imshow`, see that method for
+        relevant keyword arguments.
+
+        Parameters
+        ----------
+        crystal_map : orix.crystal_map.CrystalMap
+            Crystal map object to obtain data to plot from.
+        value : numpy.ndarray, optional
+            Attribute array to plot. If value is ``None`` (default), a
+            phase map is plotted.
+        scalebar : bool, optional
+            Whether to add a scalebar (default is ``True``) along the
+            horizontal map dimension.
+        scalebar_properties : dict
+            Dictionary of keyword arguments passed to
+            :func:`mpl_toolkits.axes_grid1.anchored_artists.AnchoredSizeBar`.
+        legend : bool, optional
+            Whether to add a legend to the plot. This is only implemented for
+            a phase plot (in which case default is ``True``).
+        legend_properties : dict
+            Dictionary of keyword arguments passed to
+            :meth:`matplotlib.axes.legend`.
+        kwargs :
+            Keyword arguments passed to
+            :meth:`matplotlib.axes.Axes.imshow`.
+
+        Returns
+        -------
+        im : matplotlib.image.AxesImage
+            Image object, to be used further to get data from etc.
+
+        See Also
+        --------
+        matplotlib.axes.Axes.imshow
+        orix.plot.CrystalMapPlot.add_scalebar
+        orix.plot.CrystalMapPlot.add_overlay
+        orix.plot.CrystalMapPlot.add_colorbar
+
+        Examples
+        --------
+        >>> import matplotlib.pyplot as plt
+        >>> import numpy as np
+        >>> from orix import plot
+        >>> from orix.io import load_ang
+
+        Import a crystal map and inspect it
+
+        >>> cm = load_ang("/some/directory/data.ang")
+        >>> cm
+        Phase  Orientations   Name       Symmetry  Color
+        1      5657 (48.4%)   austenite  432       tab:blue
+        2      6043 (51.6%)   ferrite    432       tab:orange
+        Properties: iq, dp
+        Scan unit: um
+
+        Plot a phase map
+
+        >>> fig = plt.figure()  # Get figure
+        >>> ax = fig.add_subplot(projection="plot_map")  # Get axes
+        >>> im = ax.plot_map(cm)  # Get image
+
+        Add an overlay
+
+        >>> ax.add_overlay(cm, cm.iq)
+
+        Plot an arbitrary map property, also changing scalebar location
+
+        >>> ax = plt.subplot(projection="plot_map")
+        >>> ax.plot_map(
+        ...     cm, cm.dp, cmap="cividis", scalebar_properties={"loc": 4})
+
+        Add a colorbar
+
+        >>> cbar = ax.add_colorbar("Dot product")
+
+        Plot orientation angle in degrees of one phase
+
+        >>> cm2 = cm["austenite"]
+        >>> austenite_angles = cm2.orientations.angle.data * 180 / np.pi
+        >>> fig = plt.figure()
+        >>> ax = fig.add_subplot(projection="plot_map")
+        >>> im = ax.plot_map(cm2, austenite_angles)
+        >>> ax.add_colorbar("Orientation angle [$^{\circ}$]")
+
+        Remove all figure and axes padding
+
+        >>> ax.remove_padding()
+
+        Write annotated figure to file
+
+        >>> fig.savefig(
+        ...     "/some/directory/image.png",
+        ...     pad_inches=0,
+        ...     bbox_inches="tight"
+        ...)
+
+        Write un-annotated image to file
+
+        >>> plt.imsave("/some/directory/image2.png", im.get_array())
+
+        """
+        patches = None
+        if value is None:  # Phase map
+            _log.debug("plot_map: Plot a phase map")
+
+            # Color each map pixel with corresponding phase color RGB tuple
+            phase_id = crystal_map.get_map_data("phase_id")
+            unique_phase_ids = np.unique(phase_id[~np.isnan(phase_id)])
+            data = np.ones(phase_id.shape + (3,))
+            for i, color in zip(
+                unique_phase_ids, crystal_map.phases_in_data.colors_rgb
+            ):
+                mask = phase_id == int(i)
+                data[mask] = data[mask] * color
+
+            # Add legend patches to plot
+            patches = []
+            for _, p in crystal_map.phases_in_data:
+                patches.append(mpatches.Patch(color=p.color_rgb, label=p.name))
+        else:  # Create masked array of correct shape
+            if isinstance(value, Scalar) or isinstance(value, Vector3d):
+                _log.debug(f"plot_map: Plot {type(value)} attribute data")
+                value = value.data
+            data = crystal_map.get_map_data(value)
+
+        # Legend
+        if legend and isinstance(patches, list):
             if legend_properties is None:
                 legend_properties = {}
-            [legend_properties.setdefault(k, v) for k, v in d.items()]
-            self.legend(handles=patches, **legend_properties)
+            self._add_legend(patches, **legend_properties)
 
-        data = kwargs.pop("X")  # Extract for code clarity
-        im = super().imshow(X=data, **kwargs)
+        # Scalebar
+        if scalebar:
+            if scalebar_properties is None:
+                scalebar_properties = {}
+            _ = self.add_scalebar(crystal_map, **scalebar_properties)
 
+        im = self.imshow(X=data, **kwargs)
         im = self._override_status_bar(im, crystal_map)
 
         return im
 
-    def _override_status_bar(self, image, crystal_map):
-        """Display coordinates and Euler angles per pixel in status bar.
+    def add_scalebar(self, crystal_map, **kwargs):
+        """Add a scalebar to the axes object via `AnchoredSizeBar`.
 
-         This is done by overriding
-         :meth:`matplotlib.images.AxesImage.get_cursor_data`,
-         :meth:`matplotlib.images.AxesImage.format_cursor_data` and
-         :meth:`matplotlib.axes.Axes.format_coord`.
+        To find an appropriate scalebar width, this snippet from MTEX
+        [Bachmann2010]_ written by Eric Payton and Philippe Pinard is used:
+        https://github.com/mtex-toolbox/mtex/blob/b8fc167d06d453a2b3e212b1ac383acbf85a5a27/plotting/scaleBar.m,
+
+        Parameters
+        ----------
+        crystal_map : orix.crystal_map.CrystalMap
+            Crystal map object to obtain necessary data from.
+        **kwargs : dict
+            Keyword arguments passed to
+            :func:`mpl_toolkits.axes_grid1.anchored_artists.AnchoredSizeBar`.
+
+        Returns
+        -------
+        bar : mpl_toolkits.axes_grid1.anchored_artists.AnchoredSizeBar
+            Scalebar.
+
+        Examples
+        --------
+        >>> cm
+        Phase  Orientations   Name       Symmetry  Color
+        1      5657 (48.4%)   austenite  432       tab:blue
+        2      6043 (51.6%)   ferrite    432       tab:orange
+        Properties: iq, dp
+        Scan unit: um
+
+        Create a phase map without a scale bar and add it afterwards
+
+        >>> fig = plt.figure()
+        >>> ax = fig.add_subplot(projection="plot_map")
+        >>> im = ax.plot_map(cm, scalebar=False)
+        >>> sbar = ax.add_scalebar(cm, loc=4, frameon=False)
+        """
+        map_width = crystal_map.shape[-1]
+        # TODO: Make this "dynamic"/dependable when enabling specimen reference frame
+        step_size = crystal_map._step_sizes["x"]
+        scan_unit = crystal_map.scan_unit
+
+        # Initial scalebar width should be approximately 1/10 of map width
+        scalebar_width = 0.1 * map_width * step_size
+
+        # Ensure a suitable number is used, e.g. going from 1000 nm to 1 um
+        scalebar_width, scan_unit, factor = convert_unit(scalebar_width, scan_unit)
+
+        # This snippet for finding a suitable scalebar width is taken from MTEX:
+        # https://github.com/mtex-toolbox/mtex/blob/b8fc167d06d453a2b3e212b1ac383acbf85a5a27/plotting/scaleBar.m,
+        # written by Eric Payton and Philippe Pinard. We want a round, not too high
+        # number without decimals
+        good_values = np.array(
+            [1, 2, 5, 10, 15, 20, 25, 50, 75, 100, 125, 150, 200, 500, 750], dtype=int,
+        )
+        # Find good data closest to initial scalebar width
+        difference = abs(scalebar_width - good_values)
+        good_value_idx = np.where(difference == difference.min())[0][0]
+        scalebar_width = good_values[good_value_idx]
+
+        # Scale width by factor from above conversion (usually factor = 1.0)
+        scalebar_width = scalebar_width * factor
+        scalebar_width_px = scalebar_width / step_size
+
+        # Allow for a potential decimal in scalebar number if something didn't go as
+        # planned
+        if scalebar_width.is_integer():
+            scalebar_width = int(scalebar_width)
+        else:
+            warnings.warn(f"Scalebar width {scalebar_width} is not an integer.")
+
+        if scan_unit == "um":
+            scan_unit = "\u03BC" + "m"
+
+        # Set up arguments to AnchoredSizeBar() if not already present in kwargs
+        d = {
+            "loc": 3,
+            "pad": 0.2,
+            "sep": 3,
+            "frameon": True,
+            "borderpad": 0.5,
+            "size_vertical": scalebar_width_px / 12,
+            "fontproperties": fm.FontProperties(size=11),
+        }
+        [kwargs.setdefault(k, v) for k, v in d.items()]
+
+        # Create scalebar
+        bar = AnchoredSizeBar(
+            transform=self.axes.transData,
+            size=scalebar_width_px,
+            label=str(scalebar_width) + " " + scan_unit,
+            **kwargs,
+        )
+        bar.patch.set_alpha(0.6)
+
+        self.axes.add_artist(bar)
+        _log.debug(f"add_scalebar: To {self.axes}")
+
+        return bar
+
+    def add_overlay(self, crystal_map, item):
+        """Use a crystal map property as gray scale values of a phase map.
+
+        The property's range is adjusted to [0, 1] for maximum contrast.
+
+        Parameters
+        ----------
+        crystal_map : orix.crystal_map.CrystalMap
+            Crystal map object to obtain necessary data from.
+        item : str
+            Name of map property to scale phase array with. The property
+            range is adjusted for maximum contrast.
+
+        Examples
+        --------
+        >>> cm
+        Phase  Orientations   Name       Symmetry  Color
+        1      5657 (48.4%)   austenite  432       tab:blue
+        2      6043 (51.6%)   ferrite    432       tab:orange
+        Properties: iq, dp
+        Scan unit: um
+
+        Plot a phase map with a map property as overlay
+
+        >>> fig = plt.figure()
+        >>> ax = fig.add_subplot(projection="plot_map")
+        >>> im = ax.plot_map(cm)
+        >>> ax.add_overlay(cm, cm.dp)
+        """
+        image = self.images[0]
+        image_data = image.get_array()
+
+        if image_data.ndim < 3:
+            # Adding overlay to a scalar plot (should this be allowed?)
+            image_data = image.to_rgba(image_data)[:, :, :3]  # No alpha
+
+        # Scale prop to [0, 1] to maximize image contrast
+        overlay = crystal_map.get_map_data(item)
+        overlay_min = np.nanmin(overlay)
+        rescaled_overlay = (overlay - overlay_min) / (np.nanmax(overlay) - overlay_min)
+
+        n_channels = 3
+        for i in range(n_channels):
+            image_data[:, :, i] *= rescaled_overlay
+
+        _log.debug(f"add_overlay: To {image}")
+        image.set_data(image_data)
+
+    def add_colorbar(self, title=None, **kwargs):
+        """Add an opinionated colorbar to the figure.
+
+        Parameters
+        ----------
+        title : str, optional
+            Colorbar title, default is ``None``.
+        kwargs :
+            Keyword arguments passed to
+            :meth:`mpl_toolkits.axes_grid1.make_axes_locatable.append_axes`.
+
+        Returns
+        -------
+        cbar : matplotlib.colorbar
+            Colorbar.
+
+        Examples
+        --------
+        >>> cm
+        Phase  Orientations   Name       Symmetry  Color
+        1      5657 (48.4%)   austenite  432       tab:blue
+        2      6043 (51.6%)   ferrite    432       tab:orange
+        Properties: iq, dp
+        Scan unit: um
+
+        Plot a map property and add a colorbar
+
+        >>> fig = plt.figure()
+        >>> ax = fig.add_subplot(projection="plot_map")
+        >>> im = ax.plot_map(cm, cm.dp, cmap="inferno")
+        >>> cbar = ax.add_colorbar("Dot product")
+
+        If the default options are not satisfactory, the colorbar can be
+        updated
+
+        >>> cbar.ax.set_ylabel(title="dp", rotation=90)
+        """
+        # Keyword arguments
+        d = {"position": "right", "size": "5%", "pad": 0.1}
+        [kwargs.setdefault(k, v) for k, v in d.items()]
+
+        # Add colorbar
+        divider = make_axes_locatable(self)
+        cax = divider.append_axes(**kwargs)
+        _log.debug(f"add_colorbar: To {self.figure}")
+        cbar = self.figure.colorbar(self.images[0], cax=cax)
+
+        # Set title with padding
+        cbar.ax.get_yaxis().labelpad = 15
+        cbar.ax.set_ylabel(title, rotation=270)
+
+        return cbar
+
+    def remove_padding(self):
+        """Remove all white padding outside of the figure.
+
+        Examples
+        --------
+        >>> cm
+        Phase  Orientations   Name       Symmetry  Color
+        1      5657 (48.4%)   austenite  432       tab:blue
+        2      6043 (51.6%)   ferrite    432       tab:orange
+        Properties: iq, dp
+        Scan unit: um
+
+        Remove all figure and axes padding of a phase map
+
+        >>> fig = plt.figure()
+        >>> ax = fig.add_subplot(projection="plot_map")
+        >>> ax.plot_map(cm)
+        >>> ax.remove_padding()
+        """
+        self.set_axis_off()
+        self.margins(0, 0)
+
+        # Tune subplot layout
+        colorbar = self.images[0].colorbar
+        if colorbar is not None:
+            right = self.figure.subplotpars.right
+        else:
+            right = 1
+        _log.debug(f"remove_padding: From {self.figure}")
+        self.figure.subplots_adjust(top=1, bottom=0, right=right, left=0)
+
+    def _add_legend(self, patches, **kwargs):
+        """Add a legend to the axes object.
+
+        Parameters
+        ----------
+        patches : list of matplotlib.patches.Patch
+            Patches with color code and name.
+        **kwargs :
+            Keyword arguments passed to :meth:`matplotlib.axes.legend`.
+        """
+        d = {
+            "borderpad": 0.3,
+            "handlelength": 0.75,
+            "handletextpad": 0.3,
+            "framealpha": 0.6,
+            "prop": fm.FontProperties(size=11),
+        }
+        [kwargs.setdefault(k, v) for k, v in d.items()]
+        _log.debug(f"add_legend: To {self.axes}")
+        self.legend(handles=patches, **kwargs)
+
+    def _override_status_bar(self, image, crystal_map):
+        """Display coordinates, a property value (if scalar values are
+        plotted), and Euler angles (in radians) per data point in the
+        status bar.
+
+        This is done by overriding
+        :meth:`matplotlib.images.AxesImage.get_cursor_data`,
+        :meth:`matplotlib.images.AxesImage.format_cursor_data` and
+        :meth:`matplotlib.axes.Axes.format_coord`.
 
         Parameters
         ----------
@@ -88,411 +488,59 @@ class CrystalMapPlot(Axes):
         image : matplotlib.images.AxesImage
             Image object where the above mentioned methods are overridden.
         """
-        # Get rotations in radians, ensuring proper masking of pixels
-        r = crystal_map._rotations.to_euler()
-        r = np.round(r, decimals=3)
-        r[~crystal_map.indexed.ravel()] = None
 
-        n_rows, n_cols = crystal_map.shape
+        # Get map shape
+        map_shape = crystal_map._original_shape
+        n_rows, n_cols = map_shape
 
-        im_data = image.get_array()
+        # Get rotations, ensuring correct masking
+        # TODO: Show orientations in Euler angles (computationally intensive...)
+        r = crystal_map.get_map_data("rotations", decimals=3)
+
+        # Get image data, overwriting potentially masked regions set to 0.0
+        image_data = image.get_array()  # numpy.masked.MaskedArray
+        image_data[image_data.mask] = np.nan
 
         def status_bar_data(event):
             col = int(event.xdata + 0.5)
             row = int(event.ydata + 0.5)
-            return row, col, r[col + (row * n_cols)], im_data[row, col]
+            return row, col, r[row, col], image_data[row, col]
 
-        # Set width of x and y fields in plotting status bar
+        # Set width of status bar fields
         x_width = len(str(n_cols - 1))
         y_width = len(str(n_rows - 1))
-
-        if self.name == "property_map":
-            def format_status_bar_data(data):
-                return (
-                    f"(y,x):({data[0]:{y_width}},{data[1]:{x_width}})"
-                    f" {self._property_name}:{data[3]}"
-                    f" rot:({data[2][0]:5},{data[2][1]:5},{data[2][2]:5})"
-                )
-        else:
-            def format_status_bar_data(data):
-                return (
-                    f"(y,x):({data[0]:{y_width}},{data[1]:{x_width}})"
-                    f" rot:({data[2][0]:5},{data[2][1]:5},{data[2][2]:5})"
-                )
+        scalar_width = len(str(np.nanmax(image_data)))
 
         # Override
         image.get_cursor_data = status_bar_data
-        image.format_cursor_data = format_status_bar_data
         self.axes.format_coord = lambda x, y: ""
 
+        def format_status_bar_data_rgb(data):
+            """Status bar format for RGB plots."""
+            return (
+                f"(y,x):({data[0]:{y_width}},{data[1]:{x_width}})"
+                f" rot:({data[2][0]:5},{data[2][1]:5},{data[2][2]:5})"
+            )
+
+        def format_status_bar_data_scalar(data):
+            """Status bar format for scalar plots."""
+            return (
+                f"(y,x):({data[0]:{y_width}},{data[1]:{x_width}})"
+                f" val:{data[3]:{scalar_width}}"
+                f" rot:({data[2][0]:5},{data[2][1]:5},{data[2][2]:5})"
+            )
+
+        # Pick status bar format and override this as well
+        if image_data.shape[-1] == 3:
+            image.format_cursor_data = format_status_bar_data_rgb
+        else:
+            image.format_cursor_data = format_status_bar_data_scalar
+
+        _log.debug(f"override_status_bar: Of {self.axes}")
         return image
 
-    def add_scalebar(self, crystal_map, scalebar_properties):
-        """Add a scalebar to the axes object via `AnchoredSizeBar`.
 
-        To find an appropriate scalebar width, this snippet from MTEX
-        [Bachmann2010]_ written by Eric Payton and Philippe Pinard is used:
-        https://github.com/mtex-toolbox/mtex/blob/b8fc167d06d453a2b3e212b1ac383acbf85a5a27/plotting/scaleBar.m,
-
-        Parameters
-        ----------
-        crystal_map : orix.crystal_map.CrystalMap
-            Crystal map object to obtain necessary data from.
-        scalebar_properties : dict
-            Keyword arguments passed to
-            :func:`mpl_toolkits.axes_grid1.anchored_artists.AnchoredSizeBar`.
-
-        Examples
-        --------
-        >>> cm
-        Phase  Orientations   Name       Symmetry  Color
-        1      5657 (48.4%)   austenite  432       tab:blue
-        2      6043 (51.6%)   ferrite    432       tab:orange
-        Properties: iq, ci, fit
-        Scan unit: um
-        >>> fig = plt.figure()
-        >>> ax = fig.add_subplot(projection="phase_map")
-        >>> im = ax.phase_map(cm, scalebar=False)
-        >>> ax.add_scalebar()
-        """
-        map_width = crystal_map.shape[-1]
-        step_size = crystal_map.step_sizes[-1]
-        scan_unit = crystal_map.scan_unit
-
-        # Initial scalebar width should be approximately 1/10 of map width
-        scalebar_width = 0.1 * (map_width * step_size)
-
-        # Ensure a suitable number is used, e.g. going from 1000 nm to 1 um
-        scalebar_width, scan_unit, factor = convert_unit(
-            scalebar_width, scan_unit)
-
-        # This snippet for finding a suitable scalebar width is taken from MTEX:
-        # https://github.com/mtex-toolbox/mtex/blob/b8fc167d06d453a2b3e212b1ac383acbf85a5a27/plotting/scaleBar.m,
-        # written by Eric Payton and Philippe Pinard.
-        # We want a round, not too high number without decimals
-        good_values = np.array(
-            [1, 2, 5, 10, 15, 20, 25, 50, 75, 100, 125, 150, 200, 500, 750],
-            dtype=int,
-        )
-        # Find good data closest to initial scalebar width
-        difference = abs(scalebar_width - good_values)
-        good_value_idx = np.where(difference == difference.min())[0][0]
-        scalebar_width = good_values[good_value_idx]
-
-        # Scale width by factor from above conversion (usually factor = 1.0)
-        scalebar_width = scalebar_width * factor
-        scalebar_width_px = scalebar_width / step_size
-
-        # Allow for a potential decimal in scalebar number if something didn't
-        # go as planned
-        if scalebar_width.is_integer():
-            scalebar_width = int(scalebar_width)
-        else:
-            warnings.warn(f"Scalebar width {scalebar_width} is not an integer.")
-
-        if scan_unit == 'um':
-            scan_unit = "\u03BC" + "m"
-
-        # Set up arguments to AnchoredSizeBar() if not already present in kwargs
-        d = {
-            "loc": 3,
-            "pad": 0.2,
-            "sep": 3,
-            "borderpad": 0.5,
-            "size_vertical": 1,
-            "fontproperties": fm.FontProperties(size=11),
-        }
-        if scalebar_properties is None:
-            scalebar_properties = {}
-        [scalebar_properties.setdefault(k, v) for k, v in d.items()]
-
-        # Create scalebar
-        bar = AnchoredSizeBar(
-            transform=self.axes.transData,
-            size=scalebar_width_px,
-            label=str(scalebar_width) + ' ' + scan_unit,
-            **scalebar_properties,
-        )
-        bar.patch.set_alpha(0.6)
-
-        self.axes.add_artist(bar)
-
-    def remove_padding(self):
-        """Remove all white padding outside of the figure.
-
-        Examples
-        --------
-        >>> cm
-        Phase  Orientations   Name       Symmetry  Color
-        1      5657 (48.4%)   austenite  432       tab:blue
-        2      6043 (51.6%)   ferrite    432       tab:orange
-        Properties: iq, ci, fit
-        Scan unit: um
-        >>> fig = plt.figure()
-        >>> ax = fig.add_subplot(projection="phase_map")
-        >>> ax.phase_map(cm)
-        >>> ax.remove_padding()
-        """
-        self.set_axis_off()
-        self.margins(0, 0)
-
-        # Tune subplot layout
-        colorbar = self.images[0].colorbar
-        if colorbar is not None:
-            right = self.figure.subplotpars.right
-        else:
-            right = 1
-        self.figure.subplots_adjust(top=1, bottom=0, right=right, left=0)
-
-
-class PhaseMap(CrystalMapPlot):
-
-    name = "phase_map"
-
-    def phase_map(
-            self,
-            crystal_map,
-            scalebar=True,
-            scalebar_properties=None,
-            legend_properties=None,
-            **kwargs,
-    ):
-        """Plot a map of phases with a scalebar and legend.
-
-        Wraps :meth:`matplotlib.axes.Axes.imshow`, see that method for
-        relevant keyword arguments.
-
-        Parameters
-        ----------
-        crystal_map : orix.crystal_map.CrystalMap
-            Crystal map object to obtain data to plot from.
-        scalebar : bool, optional
-            Whether to add a scalebar (default is ``True``) along the last
-            map dimension.
-        scalebar_properties : dict
-            Dictionary of keyword arguments passed to
-            :func:`mpl_toolkits.axes_grid1.anchored_artists.AnchoredSizeBar`.
-        legend_properties : dict
-            Dictionary of keyword arguments passed to
-            :meth:`matplotlib.axes.legend`.
-        kwargs :
-            Keyword arguments passed to
-            :meth:`matplotlib.axes.Axes.imshow`.
-
-        Returns
-        -------
-        im : matplotlib.image.AxesImage
-            Image object.
-
-        See Also
-        --------
-        matplotlib.axes.Axes.imshow
-        orix.plot.crystal_map_plot.CrystalMapPlot._add_scalebar
-        """
-
-        # Create data array
-        n_channels = 3  # RGB
-        map_shape = crystal_map.shape
-        data = np.ones((np.prod(map_shape), n_channels))
-
-        # Color each map pixel with corresponding phase color RGB tuple
-        phase_id = crystal_map.phase_id.ravel()
-        for i, color in zip(np.unique(phase_id), crystal_map.phases.colors_rgb):
-            mask = phase_id == i
-            data[mask] = data[mask] * color
-
-        # Reshape to 2D array
-        data = data.reshape(map_shape + (n_channels,))
-
-        # Legend
-        patches = []
-        for _, p in crystal_map.phases_in_map:
-            patches.append(mpatches.Patch(color=p.color_rgb, label=p.name))
-
-        return super()._plot_crystal_map(
-            crystal_map,
-            patches=patches,
-            scalebar=scalebar,
-            scalebar_properties=scalebar_properties,
-            legend_properties=legend_properties,
-            X=data,
-            **kwargs
-        )
-
-    def add_overlay(self, crystal_map, property_name):
-        """Use a crystal map property as gray scale values of a phase map.
-
-        The property's range is adjusted to [0, 1] for maximum contrast.
-
-        Parameters
-        ----------
-        crystal_map : orix.crystal_map.CrystalMap
-            Crystal map object to obtain necessary data from.
-        property_name : str
-            Name of map property to scale phase array with. The property
-            range is adjusted for maximum contrast.
-
-        Examples
-        --------
-        >>> cm
-        Phase  Orientations   Name       Symmetry  Color
-        1      5657 (48.4%)   austenite  432       tab:blue
-        2      6043 (51.6%)   ferrite    432       tab:orange
-        Properties: iq, ci, fit
-        Scan unit: um
-        >>> fig = plt.figure()
-        >>> ax = fig.add_subplot(projection="phase_map")
-        >>> im = ax.phase_map(cm)
-        >>> ax.add_overlay(cm, "ci")
-       """
-        im = self.images[0]
-        data = im.get_array()
-
-        properties = crystal_map.prop
-        if property_name not in properties.keys():
-            raise ValueError(
-                f"{property_name} is not among available properties "
-                f"{list(properties.keys())}."
-            )
-        prop = properties[property_name]
-
-        # Scale prop to [0, 1] to maximize image contrast
-        prop_min = prop.min()
-        prop = (prop - prop_min) / (prop.max() - prop_min)
-
-        n_channels = 3
-        for i in range(n_channels):
-            data[:, :, i] *= prop
-
-        # Set non-indexed points to white (or None for black)
-        data[~crystal_map.indexed] = (1, 1, 1)
-
-        data = data.reshape(crystal_map.shape + (n_channels,))
-        im.set_data(data)
-
-
-class PropertyMap(CrystalMapPlot):
-
-    name = "property_map"
-
-    def property_map(
-            self,
-            crystal_map,
-            property_name,
-            scalebar=True,
-            scalebar_properties=None,
-            **kwargs,
-    ):
-        """Plot a map of a property with a scalebar.
-
-        Wraps :meth:`matplotlib.axes.Axes.imshow`, see that method for
-        relevant keyword arguments.
-
-        Parameters
-        ----------
-        crystal_map : orix.crystal_map.CrystalMap
-            Crystal map object to obtain data to plot from.
-        property_name : str
-            Name of map property to plot.
-        scalebar : bool, optional
-            Whether to add a scalebar (default is ``True``) along the last
-            map dimension.
-        scalebar_properties : dict
-            Dictionary of keyword arguments passed to
-            :func:`mpl_toolkits.axes_grid1.anchored_artists.AnchoredSizeBar`.
-        kwargs :
-            Keyword arguments passed to
-            :meth:`matplotlib.axes.Axes.imshow` and
-            :meth:`~orix.plot.crystal_map_plot.CrystalMapPlot._add_scalebar`.
-
-        Returns
-        -------
-        im : matplotlib.image.AxesImage
-            Image object.
-
-        See Also
-        --------
-        matplotlib.axes.Axes.imshow
-        orix.plot.crystal_map_plot.CrystalMapPlot._add_scalebar
-
-        Examples
-        --------
-        >>> cm
-        Phase  Orientations   Name       Symmetry  Color
-        1      5657 (48.4%)   austenite  432       tab:blue
-        2      6043 (51.6%)   ferrite    432       tab:orange
-        Properties: iq, ci, fit
-        Scan unit: um
-        >>> fig = plt.figure()
-        >>> ax = fig.add_subplot(projection="property_map")
-        >>> im = ax.property_map(cm, "ci")
-        """
-        properties = crystal_map.prop
-        if property_name not in properties.keys():
-            raise ValueError(
-                f"{property_name} is not among available properties "
-                f"{list(properties.keys())}."
-            )
-        data = properties[property_name]
-
-        self._property_name = property_name
-
-        return super()._plot_crystal_map(
-            crystal_map,
-            scalebar=scalebar,
-            scalebar_properties=scalebar_properties,
-            X=data,
-            cmap=kwargs.pop("cmap", "gray"),
-            **kwargs,
-        )
-
-    def add_colorbar(self, title=None, **kwargs):
-        """Add an opinionated colorbar to the figure.
-
-        Parameters
-        ----------
-        title : str, optional
-            Colorbar title, default is ``None``.
-        kwargs :
-            Keyword arguments passed to
-            :meth:`mpl_toolkits.axes_grid1.make_axes_locatable.append_axes`.
-
-        Examples
-        --------
-        >>> cm
-        Phase  Orientations   Name       Symmetry  Color
-        1      5657 (48.4%)   austenite  432       tab:blue
-        2      6043 (51.6%)   ferrite    432       tab:orange
-        Properties: iq, ci, fit
-        Scan unit: um
-        >>> fig = plt.figure()
-        >>> ax = fig.add_subplot(projection="property_map")
-        >>> im = ax.property_map(cm, "ci")
-        >>> ax.add_colorbar("Confidence index")
-
-        If the default options are not as desired, a colorbar can be added
-        and modified using, instead of the above line:
-
-        >>> cbar = fig.colorbar(im, ax=ax)
-        >>> cbar.ax.set_ylabel(title="ci", rotation=0)
-        """
-
-        # Keyword arguments
-        d = {"position": "right", "size": "5%", "pad": 0.1}
-        [kwargs.setdefault(k, v) for k, v in d.items()]
-
-        # Add colorbar
-        divider = make_axes_locatable(self)
-        cax = divider.append_axes(**kwargs)
-        cbar = self.figure.colorbar(self.images[0], cax=cax)
-
-        # Set title with padding
-        cbar.ax.get_yaxis().labelpad = 15
-        cbar.ax.set_ylabel(title)
-
-
-projections.register_projection(PhaseMap)
-projections.register_projection(PropertyMap)
+register_projection(CrystalMapPlot)
 
 
 def convert_unit(value, unit):
@@ -524,22 +572,20 @@ def convert_unit(value, unit):
     17.55 um 999.9999999999999
     >>> convert_unit(17.55 * 1e-3, 'mm')
     17.55 um 0.001
-
     """
-
     # If unit is 'px', we assume 'um', and revert unit in the end
     unit_is_px = False
-    if unit == 'px':
-        unit = 'um'
+    if unit == "px":
+        unit = "um"
         unit_is_px = True
 
     # Create lookup-table with units and power
     lookup_table = []
-    letters = 'yzafpnum kMGTPEZY'
+    letters = "yzafpnum kMGTPEZY"
     new_unit_idx = None
     for i, letter in enumerate(letters):
         # Ensure 'm' is entered correctly
-        current_unit = (letter + 'm').strip(' ')
+        current_unit = (letter + "m").strip(" ")
         lookup_table.append((current_unit, 10 ** (3 * i - 24)))
         if unit == current_unit:
             new_unit_idx = i
@@ -555,6 +601,10 @@ def convert_unit(value, unit):
     factor = lookup_table[suitable_unit_idx][1] / lookup_table[new_unit_idx][1]
 
     if unit_is_px:
-        new_unit = 'px'
+        new_unit = "px"
 
+    _log.debug(
+        f"convert_unit: From {value} {unit} to {new_value} {new_unit} with factor "
+        f"{factor}"
+    )
     return new_value, new_unit, factor

--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -236,6 +236,12 @@ def convert_unit(value, unit):
 
     """
 
+    # If unit is 'px', we assume 'um', and revert unit in the end
+    unit_is_px = False
+    if unit == 'px':
+        unit = 'um'
+        unit_is_px = True
+
     # Create lookup-table with units and power
     lookup_table = []
     letters = 'yzafpnum kMGTPEZY'
@@ -256,5 +262,8 @@ def convert_unit(value, unit):
     new_value = value_in_metres / lookup_table[suitable_unit_idx][1]
     new_unit = lookup_table[suitable_unit_idx][0]
     factor = lookup_table[suitable_unit_idx][1] / lookup_table[new_unit_idx][1]
+
+    if unit_is_px:
+        new_unit = 'px'
 
     return new_value, new_unit, factor

--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -1,0 +1,260 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 The pyXem developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+import warnings
+
+import numpy as np
+import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1.anchored_artists import AnchoredSizeBar
+import matplotlib.font_manager as fm
+
+
+def _plot_crystal_map(
+        crystal_map,
+        data,
+        legend_patches=None,
+        scalebar=True,
+        padding=True,
+        **kwargs,
+):
+    """Plot crystal map data.
+
+    Parameters
+    ----------
+    crystal_map : orix.crystal_map.CrystalMap
+        CrystalMap object, needed to get map shape, scan unit and
+        horizontal step size.
+    data : numpy.ndarray
+        Map data to plot. A 2D array with potential RGB(A) channels.
+    legend_patches : list of matplotlib.patches.Patch, optional
+        Legend patches, e.g. phase colors and names. If ``None`` is passed
+        (default), no legend is added.
+    scalebar : bool, optional
+        Whether to display a scalebar (default is ``True``).
+    padding : bool, optional
+        Whether to show white padding (default is ``True``). Setting this
+        to ``False`` removes all white padding outside of plot, including
+        pixel coordinate ticks.
+    **kwargs :
+        Optional keyword arguments passed to
+        :meth:`matplotlib.pyplot.imshow`.
+
+    Returns
+    -------
+    fig : matplotlib.figure.Figure
+        Top level container for all plot elements.
+    ax : matplotlib.axes.Axes
+        Axes object returned by :meth:`matplotlib.pyplot.subplots`.
+    im : matplotlib.image.AxesImage
+        Image object returned by :meth:`matplotlib.axes.Axes.imshow`.
+    """
+
+    cmap = kwargs.pop('cmap', None)
+    interpolation = kwargs.pop('interpolation', 'none')
+
+    fig, ax = plt.subplots()
+    im = ax.imshow(data, cmap=cmap, interpolation=interpolation, **kwargs)
+
+    # Remove white padding around plot, including pixel coordinate ticks
+    if not padding:
+        ax.set(xticks=[], yticks=[])
+        fig.gca().set_axis_off()
+        fig.subplots_adjust(
+            top=1, bottom=0, right=1, left=0, hspace=0, wspace=0)
+        ax.margins(0, 0)
+        fig.gca().xaxis.set_major_locator(plt.NullLocator())
+        fig.gca().yaxis.set_major_locator(plt.NullLocator())
+
+    # Legend
+    if legend_patches:
+        ax = _add_legend(axes=ax, patches=legend_patches)
+
+    # Scalebar
+    if scalebar:
+        ax = _add_scalebar(
+            axes=ax,
+            map_width=crystal_map.shape[1],
+            scan_unit=crystal_map.scan_unit,
+            step_size=crystal_map.dx[-1],
+        )
+
+    return fig, ax, im
+
+
+def _add_legend(axes, patches):
+    """Add a legend with patches to axes.
+
+    Parameters
+    ----------
+    axes : matplotlib.axes.Axes
+        Axes object to add legend to.
+    patches : list of matplotlib.patches.Patch
+        Legend patches, e.g. phase colors and names.
+    **kwargs :
+        Optional keyword arguments passed to
+        :meth:`matplotlib.axes.Axes.legend`.
+
+    Returns
+    -------
+    axes : matplotlib.axes.Axes
+        Axes object with legend.
+    """
+    axes.legend(
+        handles=patches,
+        borderpad=0.3,
+        handlelength=0.75,
+        handletextpad=0.3,
+        framealpha=0.6,
+    )
+    return axes
+
+
+def _add_scalebar(axes, map_width, scan_unit, step_size):
+    """Add a scalebar via `AnchoredSizeBar` to axes.
+
+    To find an appropriate scalebar width, this snippet from
+    MTEX [Bachmann2010]_, written by Eric Payton and Philippe Pinard, is
+    used: https://github.com/mtex-toolbox/mtex/blob/b8fc167d06d453a2b3e212b1ac383acbf85a5a27/plotting/scaleBar.m,
+
+    Parameters
+    ----------
+    axes : matplotlib.axes.Axes
+        Axes object to add scalebar to.
+    map_width : int
+        Map width in pixels.
+    scan_unit : str
+        Map scan unit, e.g. 'um' or 'nm'.
+    step_size : float
+        Map step size in last map dimension.
+
+    Returns
+    -------
+    axes : matplotlib.axes.Axes
+        Axes object with scalebar.
+    """
+
+    # Initial scalebar width should be approximately 1/10 of map width
+    scalebar_width = 0.1 * (map_width * step_size)
+
+    # Ensure a suitable number is used, e.g. going from 1000 nm to 1 um
+    scalebar_width, scan_unit, factor = convert_unit(scalebar_width, scan_unit)
+
+    # This snippet for finding a suitable scalebar width is taken from
+    # MTEX: https://github.com/mtex-toolbox/mtex/blob/b8fc167d06d453a2b3e212b1ac383acbf85a5a27/plotting/scaleBar.m,
+    # written by Eric Payton and Philippe Pinard.
+    # We want a round, not too high number without decimals
+    good_values = np.array(
+        [1, 2, 5, 10, 15, 20, 25, 50, 75, 100, 125, 150, 200, 500, 750],
+        dtype=int,
+    )
+    # Find good value closest to initial scalebar width
+    difference = abs(scalebar_width - good_values)
+    good_value_idx = np.where(difference == difference.min())[0][0]
+    scalebar_width = good_values[good_value_idx]
+
+    # Scale width by factor from above conversion (usually factor = 1.0)
+    scalebar_width = scalebar_width * factor
+    scalebar_width_px = scalebar_width / step_size
+
+    # Allow for a potential decimal in scalebar number if something didn't go
+    # as planned
+    if scalebar_width.is_integer():
+        scalebar_width = int(scalebar_width)
+    else:
+        warnings.warn(f"Scalebar width {scalebar_width} is not an integer.")
+
+    if scan_unit == 'um':
+        scan_unit = "\u03BC" + "m"
+
+    # Create scalebar
+    fontprops = fm.FontProperties(size=11)
+    bar = AnchoredSizeBar(
+        transform=axes.transData,
+        size=scalebar_width_px,
+        label=str(scalebar_width) + ' ' + scan_unit,
+        loc=3,
+        pad=0.2,
+        sep=3,
+        borderpad=0.3,
+        frameon=True,
+        size_vertical=1,
+        color="black",
+        fontproperties=fontprops,
+    )
+    bar.patch.set_alpha(0.6)
+
+    # Add scalebar to axes
+    axes.add_artist(bar)
+
+    return axes
+
+
+def convert_unit(value, unit):
+    """Return the value with a suitable, not too large, unit.
+
+    This algorithm is taken directly from MTEX [Bachmann2010]_
+    https://github.com/mtex-toolbox/mtex/blob/a74545383160610796b9525eedf50a241800ffae/plotting/plotting_tools/switchUnit.m,
+    written by Ralf Hielscher.
+
+    Parameters
+    ----------
+    value : float
+        The value to convert.
+    unit : str
+        The value unit, e.g. um.
+
+    Returns
+    -------
+    new_value : float
+        The input value converted to the suitable unit.
+    new_unit : str
+        A more suitable unit than the input.
+    factor : float
+        Factor to multiple `new_value` with to get the input value.
+
+    Examples
+    --------
+    >>> convert_unit(17.55 * 1e3, 'nm')
+    17.55 um 999.9999999999999
+    >>> convert_unit(17.55 * 1e-3, 'mm')
+    17.55 um 0.001
+
+    """
+
+    # Create lookup-table with units and power
+    lookup_table = []
+    letters = 'yzafpnum kMGTPEZY'
+    new_unit_idx = None
+    for i, letter in enumerate(letters):
+        # Ensure 'm' is entered correctly
+        current_unit = (letter + 'm').strip(' ')
+        lookup_table.append((current_unit, 10 ** (3 * i - 24)))
+        if unit == current_unit:
+            new_unit_idx = i
+
+    # Find the lookup-table index of the most suitable unit
+    value_in_metres = value * lookup_table[new_unit_idx][1]
+    power_of_value = np.floor(np.log10(value_in_metres))
+    suitable_unit_idx = int(np.floor(power_of_value / 3) + 8)
+
+    # Calculate new value, unit and the conversion factor
+    new_value = value_in_metres / lookup_table[suitable_unit_idx][1]
+    new_unit = lookup_table[suitable_unit_idx][0]
+    factor = lookup_table[suitable_unit_idx][1] / lookup_table[new_unit_idx][1]
+
+    return new_value, new_unit, factor

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -163,7 +163,10 @@ class Misorientation(Rotation):
                [1.57079633, 0.        ]])
         """
         if speed == 1:
-            warnings.warn("This method is inferior and be removed in 0.3.0; use speed=2 instead", RuntimeWarning)
+            warnings.warn(
+                "This method is inferior and be removed in 0.3.0; use speed=2 instead",
+                RuntimeWarning,
+            )
             distance = _distance_1(self, verbose)
         else:
             distance = _distance_2(self, verbose, split_size)
@@ -266,6 +269,7 @@ def _distance_2(misorientation, verbose, split_size=100):
     outer_range = range(0, num_orientations, split_size)
     if verbose:
         from tqdm import tqdm
+
         outer_range = tqdm(outer_range, total=np.ceil(num_orientations / split_size))
     S_1_outer_S_1 = S_1.outer(S_1)
 

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -129,7 +129,7 @@ def temp_ang_file():
 @pytest.fixture(
     params=[
         # Tuple with default values for five parameters: map_shape, step_sizes,
-        # phase_id, n_unknown_columns, and example_rotations (see docstring below)
+        # phase_id, n_unknown_columns, and rotations (see docstring below)
         (
             (7, 13),  # map_shape
             (0.1, 0.1),  # step_sizes
@@ -137,7 +137,7 @@ def temp_ang_file():
             5,  # Number of unknown columns (one between ci and fit, the rest after fit)
             np.array(
                 [[4.48549, 0.95242, 0.79150], [1.34390, 0.27611, 0.82589],]
-            ),  # example_rotations as rows of Euler angle triplets
+            ),  # rotations as rows of Euler angle triplets
         )
     ]
 )
@@ -157,7 +157,7 @@ def angfile_tsl(tmpdir, request):
         Array of map size with phase IDs in header.
     n_unknown_columns : int
         Number of columns with unknown values.
-    example_rotations : np.ndarray
+    rotations : np.ndarray
         A sample, smaller than the map size, of example rotations as
         rows of Euler angle triplets.
 
@@ -208,14 +208,14 @@ def angfile_tsl(tmpdir, request):
 @pytest.fixture(
     params=[
         # Tuple with default values for four parameters: map_shape, step_sizes,
-        # phase_id, and example_rotations (see docstring below)
+        # phase_id, and rotations (see docstring below)
         (
             (7, 5),  # map_shape
             (2.86, 2.86),  # step_sizes
             np.ones(7 * 5, dtype=int),  # phase_id
             np.array(
                 [[6.148271, 0.792205, 1.324879], [6.155951, 0.793078, 1.325229],]
-            ),  # example_rotations as rows of Euler angle triplets
+            ),  # rotations as rows of Euler angle triplets
         )
     ]
 )
@@ -230,7 +230,7 @@ def angfile_astar(tmpdir, request):
         Step sizes in x and y coordinates in nanometres.
     phase_id : np.ndarray
         Array of map size with phase IDs in header.
-    example_rotations : np.ndarray
+    rotations : np.ndarray
         A sample, smaller than the map size, of example rotations as
         rows of Euler angle triplets.
 
@@ -253,7 +253,7 @@ def angfile_astar(tmpdir, request):
     if n_rotations == map_size:
         rot = example_rotations
     else:
-        # Sample as many rotations from `example_rotations` as `map_size`
+        # Sample as many rotations from `rotations` as `map_size`
         rot_idx = np.random.choice(np.arange(len(example_rotations)), map_size)
         rot = example_rotations[rot_idx]
 
@@ -273,14 +273,14 @@ def angfile_astar(tmpdir, request):
 @pytest.fixture(
     params=[
         # Tuple with default values for four parameters: map_shape, step_sizes,
-        # phase_id, and example_rotations (see docstring below)
+        # phase_id, and rotations (see docstring below)
         (
             (9, 7),  # map_shape
             (1.5, 1.5),  # step_sizes
             np.random.choice([1, 2], 9 * 7),  # phase_id
             np.array(
                 [[6.148271, 0.792205, 1.324879], [6.155951, 0.793078, 1.325229],]
-            ),  # example_rotations as rows of Euler angle triplets
+            ),  # rotations as rows of Euler angle triplets
         )
     ]
 )
@@ -295,7 +295,7 @@ def angfile_emsoft(tmpdir, request):
         Step sizes in x and y coordinates in nanometres.
     phase_id : np.ndarray
         Array of map size with phase IDs in header.
-    example_rotations : np.ndarray
+    rotations : np.ndarray
         A sample, smaller than the map size, of example rotations as
         rows of Euler angle triplets.
 
@@ -330,13 +330,13 @@ def angfile_emsoft(tmpdir, request):
 @pytest.fixture(
     params=[
         # Tuple with default values for parameters: map_shape, step_sizes,
-        # example_rotations, n_top_matches, and refined (see docstring below)
+        # rotations, n_top_matches, and refined (see docstring below)
         (
             (13, 3),  # map_shape
             (1.5, 1.5),  # step_sizes
             np.array(
                 [[6.148271, 0.792205, 1.324879], [6.155951, 0.793078, 1.325229],]
-            ),  # example_rotations as rows of Euler angle triplets
+            ),  # rotations as rows of Euler angle triplets
             50,  # n_top_matches
             True,  # refined
         )
@@ -351,7 +351,7 @@ def temp_emsoft_h5ebsd_file(tmpdir, request):
         Map shape to create.
     step_sizes : tuple of floats
         Step sizes in x and y coordinates in nanometres.
-    example_rotations : np.ndarray
+    rotations : np.ndarray
         A sample, smaller than the map size, of example rotations as
         rows of Euler angle triplets.
     n_top_matches : int
@@ -404,7 +404,7 @@ def temp_emsoft_h5ebsd_file(tmpdir, request):
         data_group.create_dataset(name, data=np.zeros(shape, dtype=dtype))
 
     # `data_group` with rotations
-    # Sample as many rotations from `example_rotations` as `map_size`
+    # Sample as many rotations from `rotations` as `map_size`
     rot_idx = np.random.choice(np.arange(len(example_rotations)), map_size)
     rot = example_rotations[rot_idx]
     n_sampled_oris = 333227  # Cubic space group with Ncubochoric = 100
@@ -472,7 +472,7 @@ def phase_list():
         ),
     ],
 )
-def crystal_map_input(request):
+def crystal_map_input(request, rotations):
     # Unpack parameters
     (nz, ny, nx), (dz, dy, dx), rotations_per_point = request.param
     map_size = nz * ny * nx
@@ -481,16 +481,15 @@ def crystal_map_input(request):
     y = np.tile(np.sort(np.tile(np.arange(ny) * dy, nx)), nz)
     x = np.tile(np.arange(nx) * dx, ny * nz)
 
-    example_rotations = Rotation([(2, 4, 6, 8), (-1, -2, -3, -4)])
     rot_idx = np.random.choice(
-        np.arange(example_rotations.size), map_size * rotations_per_point
+        np.arange(rotations.size), map_size * rotations_per_point
     )
 
     data_shape = (map_size,)
     if rotations_per_point > 1:
         data_shape += (rotations_per_point,)
 
-    rotations = example_rotations[rot_idx].reshape(*data_shape)
+    rotations = rotations[rot_idx].reshape(*data_shape)
 
     return {
         "rotations": rotations,
@@ -503,3 +502,8 @@ def crystal_map_input(request):
 @pytest.fixture
 def crystal_map(crystal_map_input):
     return CrystalMap(**crystal_map_input)
+
+
+@pytest.fixture
+def rotations():
+    return Rotation([(2, 4, 6, 8), (-1, -2, -3, -4)])

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 The pyXem developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+
+@pytest.fixture(
+    params=[
+        """4.485496 0.952426 0.791507     0.000     0.000   22.2  0.060  1       6
+1.343904 0.276111 0.825890    19.000     0.000   16.3  0.020  1       2""",
+    ]
+)
+def angfile(tmpdir, request):
+    f = tmpdir.mkdir("angfiles").join("angfile.ang")
+    f.write(
+        """# File created from ACOM RES results
+# ni-dislocations.res
+#
+#
+# MaterialName      Nickel
+# Formula
+# Symmetry          43
+# LatticeConstants  3.520  3.520  3.520  90.000  90.000  90.000
+# NumberFamilies    4
+# hklFamilies       1  1  1 1 0.000000
+# hklFamilies       2  0  0 1 0.000000
+# hklFamilies       2  2  0 1 0.000000
+# hklFamilies       3  1  1 1 0.000000
+#
+# GRID: SqrGrid#"""
+    )
+    f.write(request.param)
+    return str(f)

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -18,11 +18,13 @@
 
 from gc import collect
 import os
-from tempfile import TemporaryDirectory, TemporaryFile
+from tempfile import TemporaryDirectory
 
 from h5py import File
 import numpy as np
 import pytest
+
+from orix.crystal_map.phase_list import PhaseList
 
 
 # TODO: Exchange for a multiphase header (change `phase_id` accordingly)
@@ -446,3 +448,12 @@ def temp_emsoft_h5ebsd_file(tmpdir, request):
 
     yield f
     collect()
+
+
+@pytest.fixture
+def phase_list():
+    names = ["a", "b", "c"]
+    symmetry_names = ["m-3m", "432", "3"]
+    colors = ["r", "g", "b"]
+
+    return PhaseList(names=names, symmetries=symmetry_names, colors=colors)

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -17,6 +17,8 @@
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import random
+import string
 import tempfile
 
 import numpy as np
@@ -115,8 +117,11 @@ ANGFILE_EMSOFT_HEADER = (
 @pytest.fixture
 def temp_ang_file():
     with tempfile.TemporaryDirectory() as tempdir:
-        fname = os.path.join(tempdir, "angfile.ang")
-        f = open(fname, mode="w+")
+        random_fname = "".join(
+            [random.choice(string.ascii_letters + string.digits) for _ in range(10)]
+        )
+        fname_path = os.path.join(tempdir, random_fname)
+        f = open(fname_path, mode="w+")
         yield f
 
 

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -127,9 +127,9 @@ def temp_ang_file():
         # Tuple with default values for five parameters: map_shape, step_sizes,
         # phase_id, n_unknown_columns, and example_rotations (see docstring below)
         (
-            (13, 42),  # map_shape
+            (7, 13),  # map_shape
             (0.1, 0.1),  # step_sizes
-            np.random.choice([0], 13 * 42),  # phase_id
+            np.random.choice([0], 7 * 13),  # phase_id
             5,  # Number of unknown columns (one between ci and fit, the rest after fit)
             np.array(
                 [[4.48549, 0.95242, 0.79150], [1.34390, 0.27611, 0.82589],]
@@ -206,9 +206,9 @@ def angfile_tsl(tmpdir, request):
         # Tuple with default values for four parameters: map_shape, step_sizes,
         # phase_id, and example_rotations (see docstring below)
         (
-            (10, 10),  # map_shape
+            (7, 5),  # map_shape
             (2.86, 2.86),  # step_sizes
-            np.ones(10 * 10, dtype=int),  # phase_id
+            np.ones(7 * 5, dtype=int),  # phase_id
             np.array(
                 [[6.148271, 0.792205, 1.324879], [6.155951, 0.793078, 1.325229],]
             ),  # example_rotations as rows of Euler angle triplets
@@ -271,9 +271,9 @@ def angfile_astar(tmpdir, request):
         # Tuple with default values for four parameters: map_shape, step_sizes,
         # phase_id, and example_rotations (see docstring below)
         (
-            (42, 13),  # map_shape
+            (9, 7),  # map_shape
             (1.5, 1.5),  # step_sizes
-            np.random.choice([1, 2], 42 * 13),  # phase_id
+            np.random.choice([1, 2], 9 * 7),  # phase_id
             np.array(
                 [[6.148271, 0.792205, 1.324879], [6.155951, 0.793078, 1.325229],]
             ),  # example_rotations as rows of Euler angle triplets
@@ -309,13 +309,8 @@ def angfile_emsoft(tmpdir, request):
     dp = np.round(np.random.random(map_size), decimals=3)  # [0, 1]
 
     # Rotations
-    n_rotations = len(example_rotations)
-    if n_rotations == map_size:
-        rot = example_rotations
-    else:
-        # Sample as many rotations from `example_rotations` as `map_size`
-        rot_idx = np.random.choice(np.arange(len(example_rotations)), map_size)
-        rot = example_rotations[rot_idx]
+    rot_idx = np.random.choice(np.arange(len(example_rotations)), map_size)
+    rot = example_rotations[rot_idx]
 
     np.savetxt(
         fname=f,
@@ -333,7 +328,7 @@ def angfile_emsoft(tmpdir, request):
         # Tuple with default values for parameters: map_shape, step_sizes,
         # example_rotations, n_top_matches, and refined (see docstring below)
         (
-            (42, 13),  # map_shape
+            (13, 3),  # map_shape
             (1.5, 1.5),  # step_sizes
             np.array(
                 [[6.148271, 0.792205, 1.324879], [6.155951, 0.793078, 1.325229],]
@@ -405,12 +400,9 @@ def temp_emsoft_h5ebsd_file(tmpdir, request):
         data_group.create_dataset(name, data=np.zeros(shape, dtype=dtype))
 
     # `data_group` with rotations
-    if len(example_rotations) == map_size:
-        rot = example_rotations
-    else:
-        # Sample as many rotations from `example_rotations` as `map_size`
-        rot_idx = np.random.choice(np.arange(len(example_rotations)), map_size)
-        rot = example_rotations[rot_idx]
+    # Sample as many rotations from `example_rotations` as `map_size`
+    rot_idx = np.random.choice(np.arange(len(example_rotations)), map_size)
+    rot = example_rotations[rot_idx]
     n_sampled_oris = 333227  # Cubic space group with Ncubochoric = 100
     data_group.create_dataset("FZcnt", data=np.array([n_sampled_oris], dtype=np.int32))
     data_group.create_dataset(

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -18,10 +18,12 @@
 
 import gc
 import os
-import random
-import string
-import tempfile
 
+# import random
+# import string
+from tempfile import TemporaryDirectory  # , TemporaryFile
+
+# from h5py import File
 import numpy as np
 import pytest
 
@@ -115,14 +117,13 @@ ANGFILE_EMSOFT_HEADER = (
 )
 
 
-@pytest.fixture
+@pytest.fixture()
 def temp_ang_file():
-    with tempfile.TemporaryDirectory() as tempdir:
-        random_fname = "".join(
-            [random.choice(string.ascii_letters + string.digits) for _ in range(10)]
-        )
-        fname_path = os.path.join(tempdir, random_fname + ".ang")
-        f = open(fname_path, mode="w+")
+    with TemporaryDirectory() as tempdir:
+        #        random_fname = "".join(
+        #            [random.choice(string.ascii_letters + string.digits) for _ in range(10)]
+        #        )
+        f = open(os.path.join(tempdir, "temp_ang_file.ang"), mode="w+")
         yield f
         gc.collect()
 
@@ -331,3 +332,9 @@ def angfile_emsoft(tmpdir, request):
     )
 
     return f
+
+
+# @pytest.fixture()
+# def temp_emsoft_h5ebsd_file():
+#    with TemporaryFile() as tf:
+#        f = File(tf, mode="w")

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
+import gc
 import os
 import random
 import string
@@ -120,9 +121,10 @@ def temp_ang_file():
         random_fname = "".join(
             [random.choice(string.ascii_letters + string.digits) for _ in range(10)]
         )
-        fname_path = os.path.join(tempdir, random_fname)
+        fname_path = os.path.join(tempdir, random_fname + ".ang")
         f = open(fname_path, mode="w+")
         yield f
+        gc.collect()
 
 
 @pytest.fixture(

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -29,6 +29,11 @@ from orix.crystal_map.phase_list import PhaseList
 from orix.quaternion.rotation import Rotation
 
 
+@pytest.fixture
+def rotations():
+    return Rotation([(2, 4, 6, 8), (-1, -2, -3, -4)])
+
+
 # TODO: Exchange for a multiphase header (change `phase_id` accordingly)
 ANGFILE_TSL_HEADER = (
     "# TEM_PIXperUM          1.000000\n"
@@ -501,8 +506,3 @@ def crystal_map_input(request, rotations):
 @pytest.fixture
 def crystal_map(crystal_map_input):
     return CrystalMap(**crystal_map_input)
-
-
-@pytest.fixture
-def rotations():
-    return Rotation([(2, 4, 6, 8), (-1, -2, -3, -4)])

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
+import numpy as np
 import pytest
 
 
@@ -25,8 +26,8 @@ import pytest
 1.343904 0.276111 0.825890    19.000     0.000   16.3  0.020  1       2""",
     ]
 )
-def angfile(tmpdir, request):
-    f = tmpdir.mkdir("angfiles").join("angfile.ang")
+def angfile_astar(tmpdir, request):
+    f = tmpdir.mkdir("angfiles").join("angfile_astar.ang")
     f.write(
         """# File created from ACOM RES results
 # ni-dislocations.res
@@ -45,4 +46,108 @@ def angfile(tmpdir, request):
 # GRID: SqrGrid#"""
     )
     f.write(request.param)
+    return str(f)
+
+
+@pytest.fixture(
+    params=[
+        # Tuple with four parameters: map_shape, step_sizes, phase_id, n_unknown_columns
+        (
+            (10, 10),  # map_shape
+            (0.1, 0.1),  # step_sizes
+            np.zeros(10 * 10, dtype=int),  # phase_id
+            5,  # Number of unknown columns (one between ci and fit, the rest after fit)
+        )
+    ]
+)
+def angfile_tsl(tmpdir, request):
+    """Create a dummy EDAX TSL .ang file from input.
+
+    Parameters expected in 'request'
+    --------------------------------
+    map_shape : tuple of ints
+        Map shape to create.
+    step_sizes : tuple of floats
+        Step sizes in x and y coordinates.
+    phase_id : np.ndarray
+        Array of map size with phase IDs in header.
+    n_unknown_columns : int
+        Number of columns with unknown values.
+
+    """
+    f = tmpdir.mkdir("angfiles").join("angfile_tsl.ang")
+
+    # Unpack parameters
+    (ny, nx), (dy, dx), phase_id, n_unknown_columns = request.param
+
+    # File header
+    # TODO: Exchange for a multiphase header
+    header = (
+        "# TEM_PIXperUM          1.000000"
+        "# x-star                0.413900"
+        "# y-star                0.729100"
+        "# z-star                0.514900"
+        "# WorkingDistance       27.100000"
+        "#"
+        "# Phase 1"
+        "# MaterialName      Aluminum"
+        "# Formula       Al"
+        "# Info      "
+        "# Symmetry              43"
+        "# LatticeConstants      4.040 4.040 4.040  90.000  90.000  90.000"
+        "# NumberFamilies        69"
+        "# hklFamilies        1 -1 -1 1 8.469246 1"
+        "# ElasticConstants  -1.000000 -1.000000 -1.000000 -1.000000 -1.000000 -1.000000"
+        "# Categories0 0 0 0 0 "
+        "#"
+        "# GRID: SqrGrid"
+        "# XSTEP: 0.100000"
+        "# YSTEP: 0.100000"
+        "# NCOLS_ODD: 997"
+        "# NCOLS_EVEN: 997"
+        "# NROWS: 2"
+        "#"
+        "# OPERATOR:     sem"
+        "#"
+        "# SAMPLEID:     "
+        "#"
+        "# SCANID:   "
+        "#"
+    )
+
+    # File columns
+    map_size = ny * nx
+    x = np.tile(np.arange(nx) * dx, ny)
+    y = np.sort(np.tile(np.arange(ny) * dy, nx))
+    e13 = np.tile(np.linspace(0, 2 * np.pi, nx), ny)
+    e2 = np.tile(np.linspace(0, np.pi, nx), ny)
+    ci = np.random.random(map_size)
+    iq = np.random.uniform(1e3, 1e6, map_size)
+    un = np.zeros(map_size, dtype=int)
+    fit = np.random.uniform(0, 3, map_size)
+
+    # Insert 10% non-indexed points
+    non_indexed_points = np.random.choice(
+        np.arange(map_size), replace=False, size=int(map_size * 0.1)
+    )
+    e13[non_indexed_points] = 4 * np.pi
+    e2[non_indexed_points] = 4 * np.pi
+    ci[non_indexed_points] = -1
+    fit[non_indexed_points] = 180.0
+
+    np.savetxt(
+        f,
+        X=np.column_stack(
+            (e13, e2, e13, x, y, iq, ci, phase_id, un, fit)
+            + (un,) * (n_unknown_columns - 1)
+        ),
+        fmt=(
+            "%9.5f%10.5f%10.5f%13.5f%13.5f%9.1f%7.3f%3i%7i%8.3f"
+            + "%10.5f" * (n_unknown_columns - 1)
+            + " "
+        ),
+        header=header,
+        comments="",
+    )
+
     return str(f)

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -16,129 +16,175 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+import tempfile
+
 import numpy as np
 import pytest
 
 
-@pytest.fixture(
-    params=[
-        """4.485496 0.952426 0.791507     0.000     0.000   22.2  0.060  1       6
-1.343904 0.276111 0.825890    19.000     0.000   16.3  0.020  1       2""",
-    ]
+# TODO: Exchange for a multiphase header (change `phase_id` accordingly)
+ANGFILE_TSL_HEADER = (
+    "# TEM_PIXperUM          1.000000\n"
+    "# x-star                0.413900\n"
+    "# y-star                0.729100\n"
+    "# z-star                0.514900\n"
+    "# WorkingDistance       27.100000\n"
+    "#\n"
+    "# Phase 1\n"
+    "# MaterialName      Aluminum\n"
+    "# Formula       Al\n"
+    "# Info      \n"
+    "# Symmetry              43\n"
+    "# LatticeConstants      4.040 4.040 4.040  90.000  90.000  90.000\n"
+    "# NumberFamilies        69\n"
+    "# hklFamilies        1 -1 -1 1 8.469246 1\n"
+    "# ElasticConstants  -1.000000 -1.000000 -1.000000 -1.000000 -1.000000 -1.000000\n"
+    "# Categories0 0 0 0 0 \n"
+    "#\n"
+    "# GRID: SqrGrid\n"
+    "# XSTEP: 0.100000\n"
+    "# YSTEP: 0.100000\n"
+    "# NCOLS_ODD: 42\n"
+    "# NCOLS_EVEN: 42\n"
+    "# NROWS: 13\n"
+    "#\n"
+    "# OPERATOR:     sem\n"
+    "#\n"
+    "# SAMPLEID:     \n"
+    "#\n"
+    "# SCANID:   \n"
+    "#\n"
 )
-def angfile_astar(tmpdir, request):
-    f = tmpdir.mkdir("angfiles").join("angfile_astar.ang")
-    f.write(
-        """# File created from ACOM RES results
-# ni-dislocations.res
-#
-#
-# MaterialName      Nickel
-# Formula
-# Symmetry          43
-# LatticeConstants  3.520  3.520  3.520  90.000  90.000  90.000
-# NumberFamilies    4
-# hklFamilies       1  1  1 1 0.000000
-# hklFamilies       2  0  0 1 0.000000
-# hklFamilies       2  2  0 1 0.000000
-# hklFamilies       3  1  1 1 0.000000
-#
-# GRID: SqrGrid#"""
-    )
-    f.write(request.param)
-    return str(f)
+
+ANGFILE_ASTAR_HEADER = (
+    "# File created from ACOM RES results\n"
+    "# ni-dislocations.res\n"
+    "#     \n"
+    "#     \n"
+    "# MaterialName      Nickel\n"
+    "# Formula\n"
+    "# Symmetry          43\n"
+    "# LatticeConstants  3.520  3.520  3.520  90.000  90.000  90.000\n"
+    "# NumberFamilies    4\n"
+    "# hklFamilies       1  1  1 1 0.000000\n"
+    "# hklFamilies       2  0  0 1 0.000000\n"
+    "# hklFamilies       2  2  0 1 0.000000\n"
+    "# hklFamilies       3  1  1 1 0.000000\n"
+    "#\n"
+    "# GRID: SqrGrid#\n"
+)
+
+ANGFILE_EMSOFT_HEADER = (
+    "# TEM_PIXperUM          1.000000\n"
+    "# x-star                 0.446667\n"
+    "# y-star                 0.586875\n"
+    "# z-star                 0.713450\n"
+    "# WorkingDistance        0.000000\n"
+    "#\n"
+    "# Phase 1\n"
+    "# MaterialName    austenite\n"
+    "# Formula       austenite\n"
+    "# Info          patterns indexed using EMsoft::EMEBSDDI\n"
+    "# Symmetry              43\n"
+    "# LatticeConstants      3.595 3.595 3.595   90.000 90.000 90.000\n"
+    "# NumberFamilies        0\n"
+    "# Phase 2\n"
+    "# MaterialName    ferrite/ferrite\n"
+    "# Formula       ferrite/ferrite\n"
+    "# Info          patterns indexed using EMsoft::EMEBSDDI\n"
+    "# Symmetry              43\n"
+    "# LatticeConstants      2.867 2.867 2.867   90.000 90.000 90.000\n"
+    "# NumberFamilies        0\n"
+    "# GRID: SqrGrid\n"
+    "# XSTEP:  1.500000\n"
+    "# YSTEP:  1.500000\n"
+    "# NCOLS_ODD:   13\n"
+    "# NCOLS_EVEN:   13\n"
+    "# NROWS:   42\n"
+    "#\n"
+    "# OPERATOR:   Håkon Wiik Ånes\n"
+    "#\n"
+    "# SAMPLEID:\n"
+    "#\n"
+    "# SCANID:\n"
+    "#\n"
+)
+
+
+@pytest.fixture
+def temp_ang_file():
+    with tempfile.TemporaryDirectory() as tempdir:
+        fname = os.path.join(tempdir, "angfile.ang")
+        f = open(fname, mode="w+")
+        yield f
 
 
 @pytest.fixture(
     params=[
-        # Tuple with four parameters: map_shape, step_sizes, phase_id, n_unknown_columns
+        # Tuple with default values for five parameters: map_shape, step_sizes,
+        # phase_id, n_unknown_columns, and example_rotations (see docstring below)
         (
-            (10, 10),  # map_shape
+            (13, 42),  # map_shape
             (0.1, 0.1),  # step_sizes
-            np.zeros(10 * 10, dtype=int),  # phase_id
+            np.random.choice([0], 13 * 42),  # phase_id
             5,  # Number of unknown columns (one between ci and fit, the rest after fit)
+            np.array(
+                [[4.48549, 0.95242, 0.79150], [1.34390, 0.27611, 0.82589],]
+            ),  # example_rotations as rows of Euler angle triplets
         )
     ]
 )
 def angfile_tsl(tmpdir, request):
     """Create a dummy EDAX TSL .ang file from input.
 
-    Parameters expected in 'request'
+    10% of map points are set to non-indexed (confidence index equal to
+    -1).
+
+    Parameters expected in `request`
     --------------------------------
     map_shape : tuple of ints
         Map shape to create.
     step_sizes : tuple of floats
-        Step sizes in x and y coordinates.
+        Step sizes in x and y coordinates in microns.
     phase_id : np.ndarray
         Array of map size with phase IDs in header.
     n_unknown_columns : int
         Number of columns with unknown values.
+    example_rotations : np.ndarray
+        A sample, smaller than the map size, of example rotations as
+        rows of Euler angle triplets.
 
     """
     f = tmpdir.mkdir("angfiles").join("angfile_tsl.ang")
 
     # Unpack parameters
-    (ny, nx), (dy, dx), phase_id, n_unknown_columns = request.param
-
-    # File header
-    # TODO: Exchange for a multiphase header
-    header = (
-        "# TEM_PIXperUM          1.000000"
-        "# x-star                0.413900"
-        "# y-star                0.729100"
-        "# z-star                0.514900"
-        "# WorkingDistance       27.100000"
-        "#"
-        "# Phase 1"
-        "# MaterialName      Aluminum"
-        "# Formula       Al"
-        "# Info      "
-        "# Symmetry              43"
-        "# LatticeConstants      4.040 4.040 4.040  90.000  90.000  90.000"
-        "# NumberFamilies        69"
-        "# hklFamilies        1 -1 -1 1 8.469246 1"
-        "# ElasticConstants  -1.000000 -1.000000 -1.000000 -1.000000 -1.000000 -1.000000"
-        "# Categories0 0 0 0 0 "
-        "#"
-        "# GRID: SqrGrid"
-        "# XSTEP: 0.100000"
-        "# YSTEP: 0.100000"
-        "# NCOLS_ODD: 997"
-        "# NCOLS_EVEN: 997"
-        "# NROWS: 2"
-        "#"
-        "# OPERATOR:     sem"
-        "#"
-        "# SAMPLEID:     "
-        "#"
-        "# SCANID:   "
-        "#"
-    )
+    (ny, nx), (dy, dx), phase_id, n_unknown_columns, example_rotations = request.param
 
     # File columns
     map_size = ny * nx
     x = np.tile(np.arange(nx) * dx, ny)
     y = np.sort(np.tile(np.arange(ny) * dy, nx))
-    e13 = np.tile(np.linspace(0, 2 * np.pi, nx), ny)
-    e2 = np.tile(np.linspace(0, np.pi, nx), ny)
-    ci = np.random.random(map_size)
-    iq = np.random.uniform(1e3, 1e6, map_size)
+    ci = np.random.random(map_size)  # [0, 1]
+    iq = np.random.uniform(low=1e3, high=1e6, size=map_size)
     un = np.zeros(map_size, dtype=int)
-    fit = np.random.uniform(0, 3, map_size)
+    fit = np.random.uniform(low=0, high=3, size=map_size)
+    # Rotations
+    rot_idx = np.random.choice(np.arange(len(example_rotations)), map_size)
+    rot = example_rotations[rot_idx]
 
     # Insert 10% non-indexed points
     non_indexed_points = np.random.choice(
         np.arange(map_size), replace=False, size=int(map_size * 0.1)
     )
-    e13[non_indexed_points] = 4 * np.pi
-    e2[non_indexed_points] = 4 * np.pi
+    rot[non_indexed_points] = 4 * np.pi
     ci[non_indexed_points] = -1
     fit[non_indexed_points] = 180.0
 
     np.savetxt(
-        f,
+        fname=f,
         X=np.column_stack(
-            (e13, e2, e13, x, y, iq, ci, phase_id, un, fit)
+            (rot[:, 0], rot[:, 1], rot[:, 2], x, y, iq, ci, phase_id, un, fit)
             + (un,) * (n_unknown_columns - 1)
         ),
         fmt=(
@@ -146,8 +192,135 @@ def angfile_tsl(tmpdir, request):
             + "%10.5f" * (n_unknown_columns - 1)
             + " "
         ),
-        header=header,
+        header=ANGFILE_TSL_HEADER,
         comments="",
     )
 
-    return str(f)
+    return f
+
+
+@pytest.fixture(
+    params=[
+        # Tuple with default values for four parameters: map_shape, step_sizes,
+        # phase_id, and example_rotations (see docstring below)
+        (
+            (10, 10),  # map_shape
+            (2.86, 2.86),  # step_sizes
+            np.ones(10 * 10, dtype=int),  # phase_id
+            np.array(
+                [[6.148271, 0.792205, 1.324879], [6.155951, 0.793078, 1.325229],]
+            ),  # example_rotations as rows of Euler angle triplets
+        )
+    ]
+)
+def angfile_astar(tmpdir, request):
+    """Create a dummy NanoMegas ASTAR Index .ang file from input.
+
+    Parameters expected in `request`
+    --------------------------------
+    map_shape : tuple of ints
+        Map shape to create.
+    step_sizes : tuple of floats
+        Step sizes in x and y coordinates in nanometres.
+    phase_id : np.ndarray
+        Array of map size with phase IDs in header.
+    example_rotations : np.ndarray
+        A sample, smaller than the map size, of example rotations as
+        rows of Euler angle triplets.
+
+    """
+    f = tmpdir.mkdir("angfiles").join("angfile_astar.ang")
+
+    # Unpack parameters
+    (ny, nx), (dy, dx), phase_id, example_rotations = request.param
+
+    # File columns
+    map_size = ny * nx
+    x = np.tile(np.arange(nx) * dx, ny)
+    y = np.sort(np.tile(np.arange(ny) * dy, nx))
+    ind = np.random.uniform(low=0, high=100, size=map_size)
+    rel = np.round(np.random.random(map_size), decimals=2)  # [0, 1]
+    relx100 = (rel * 100).astype(int)
+
+    # Rotations
+    n_rotations = len(example_rotations)
+    if n_rotations == map_size:
+        rot = example_rotations
+    else:
+        # Sample as many rotations from `example_rotations` as `map_size`
+        rot_idx = np.random.choice(np.arange(len(example_rotations)), map_size)
+        rot = example_rotations[rot_idx]
+
+    np.savetxt(
+        fname=f,
+        X=np.column_stack(
+            (rot[:, 0], rot[:, 1], rot[:, 2], x, y, ind, rel, phase_id, relx100)
+        ),
+        fmt="%8.6f%9.6f%9.6f%10.3f%10.3f%7.1f%7.3f%3i%8i",
+        header=ANGFILE_ASTAR_HEADER,
+        comments="",
+    )
+
+    return f
+
+
+@pytest.fixture(
+    params=[
+        # Tuple with default values for four parameters: map_shape, step_sizes,
+        # phase_id, and example_rotations (see docstring below)
+        (
+            (42, 13),  # map_shape
+            (1.5, 1.5),  # step_sizes
+            np.random.choice([1, 2], 42 * 13),  # phase_id
+            np.array(
+                [[6.148271, 0.792205, 1.324879], [6.155951, 0.793078, 1.325229],]
+            ),  # example_rotations as rows of Euler angle triplets
+        )
+    ]
+)
+def angfile_emsoft(tmpdir, request):
+    """Create a dummy EMsoft .ang file from input.
+
+    Parameters expected in `request`
+    --------------------------------
+    map_shape : tuple of ints
+        Map shape to create.
+    step_sizes : tuple of floats
+        Step sizes in x and y coordinates in nanometres.
+    phase_id : np.ndarray
+        Array of map size with phase IDs in header.
+    example_rotations : np.ndarray
+        A sample, smaller than the map size, of example rotations as
+        rows of Euler angle triplets.
+
+    """
+    f = tmpdir.mkdir("angfiles").join("angfile_emsoft.ang")
+
+    # Unpack parameters
+    (ny, nx), (dy, dx), phase_id, example_rotations = request.param
+
+    # File columns
+    map_size = ny * nx
+    x = np.tile(np.arange(nx) * dx, ny)
+    y = np.sort(np.tile(np.arange(ny) * dy, nx))
+    iq = np.round(np.random.uniform(low=0, high=100, size=map_size), decimals=1)
+    dp = np.round(np.random.random(map_size), decimals=3)  # [0, 1]
+
+    # Rotations
+    n_rotations = len(example_rotations)
+    if n_rotations == map_size:
+        rot = example_rotations
+    else:
+        # Sample as many rotations from `example_rotations` as `map_size`
+        rot_idx = np.random.choice(np.arange(len(example_rotations)), map_size)
+        rot = example_rotations[rot_idx]
+
+    np.savetxt(
+        fname=f,
+        X=np.column_stack((rot[:, 0], rot[:, 1], rot[:, 2], x, y, iq, dp, phase_id)),
+        fmt="%.5f %.5f %.5f %.5f %.5f %.1f %.3f %i",
+        header=ANGFILE_EMSOFT_HEADER,
+        comments="",
+    )
+
+    return f

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -20,8 +20,10 @@ import numpy as np
 import pytest
 
 from orix.crystal_map import CrystalMap
+from orix.crystal_map.phase_list import Phase, PhaseList
 from orix.quaternion.orientation import Orientation
 from orix.quaternion.rotation import Rotation
+from orix.quaternion.symmetry import C2, C3, C4, O
 
 # Note that many parts of the CrystalMap() class are tested while testing IO and the
 # Phase() and PhaseList() classes
@@ -35,6 +37,7 @@ class TestCrystalMapInit:
 
         cm = CrystalMap(rotations=rotations)
 
+        assert np.allclose(cm.x, np.arange(map_size))
         assert cm.size == map_size
         assert cm.shape == (map_size,)
         assert cm.ndim
@@ -52,14 +55,19 @@ class TestCrystalMapInit:
 
     @pytest.mark.parametrize(
         (
-            "crystal_map_input, expected_shape, expected_step_sizes, "
+            "crystal_map_input, expected_shape, expected_size, expected_step_sizes, "
             "expected_rotations_per_point"
         ),
         [
-            (((1, 5, 5), (0, 1.5, 1.5), 3), (5, 5), {"z": 0, "y": 1.5, "x": 1.5}, 3),
-            (((1, 1, 10), (0, 0.1, 0.1), 1), (10,), {"z": 0, "y": 0, "x": 0.1}, 1),
-            (((2, 10, 1), (0, 1e-3, 0), 2), (10,), {"z": 0, "y": 1e-3, "x": 0}, 2),
-            (((10, 1, 1), (0, 0.1, 0.1), 1), (), {"z": 0, "y": 0, "x": 0}, 1),
+            (
+                ((1, 5, 5), (0, 1.5, 1.5), 3),
+                (5, 5),
+                25,
+                {"z": 0, "y": 1.5, "x": 1.5},
+                3,
+            ),
+            (((1, 1, 10), (0, 0.1, 0.1), 1), (10,), 10, {"z": 0, "y": 0, "x": 0.1}, 1),
+            (((1, 10, 1), (0, 1e-3, 0), 2), (10,), 10, {"z": 0, "y": 1e-3, "x": 0}, 2,),
         ],
         indirect=["crystal_map_input"],
     )
@@ -67,43 +75,30 @@ class TestCrystalMapInit:
         self,
         crystal_map_input,
         expected_shape,
+        expected_size,
         expected_step_sizes,
         expected_rotations_per_point,
     ):
-        z = crystal_map_input["z"]
-        y = crystal_map_input["y"]
-        x = crystal_map_input["x"]
         cm = CrystalMap(**crystal_map_input)
+        coordinate_arrays = [
+            crystal_map_input["z"],
+            crystal_map_input["y"],
+            crystal_map_input["x"],
+        ]
 
         assert cm.shape == expected_shape
+        assert cm.size == expected_size
         assert cm._step_sizes == expected_step_sizes
         assert cm.rotations_per_point == expected_rotations_per_point
 
-        if cm.shape == ():
-            assert cm._coordinates == {"z": None, "y": None, "x": None}
-        else:
-            for actual_coords, expected_coords, expected_step_size in zip(
-                cm._coordinates.values(), [z, y, x], expected_step_sizes.values()
-            ):
-                if expected_step_size == 0:
-                    assert actual_coords is None
-                else:
-                    assert np.allclose(actual_coords, expected_coords)
-
-    @pytest.mark.parametrize(
-        "crystal_map_input",
-        [((2, 10, 5), (1, 1, 1), 1)],
-        indirect=["crystal_map_input"],
-    )
-    def test_init_without_x_coordinates(self, crystal_map_input):
-        r = crystal_map_input["rotations"]
-        z = crystal_map_input["z"]
-        y = crystal_map_input["y"]
-        cm = CrystalMap(rotations=r, x=None, y=y, z=z)
-
-        assert np.allclose(cm.x, np.arange(cm.size))
-        assert np.allclose(cm.y, y)
-        assert np.allclose(cm.z, z)
+        for actual_coords, expected_coords, expected_step_size in zip(
+            cm._coordinates.values(), coordinate_arrays, expected_step_sizes.values()
+        ):
+            print(actual_coords, expected_coords)
+            if expected_coords is None:
+                assert actual_coords is None
+            else:
+                assert np.allclose(actual_coords, expected_coords)
 
     def test_init_map_with_props(self, crystal_map_input):
         x = crystal_map_input["x"]
@@ -134,6 +129,16 @@ class TestCrystalMapInit:
             assert cm.all_indexed
             assert -1 not in cm.phases.phase_ids
 
+    def test_init_with_symmetry_list(self, crystal_map_input):
+        symmetries = [C2, C3]
+        cm = CrystalMap(symmetry=symmetries, **crystal_map_input)
+        assert cm.phases.symmetries == symmetries
+
+    def test_init_with_single_symmetry(self, crystal_map_input):
+        symmetry = O
+        cm = CrystalMap(symmetry=symmetry, **crystal_map_input)
+        assert cm.phases.symmetries[0] == symmetry
+
 
 class TestCrystalMapGetItem:
     @pytest.mark.parametrize(
@@ -142,13 +147,23 @@ class TestCrystalMapGetItem:
             (((5, 5, 5), (1, 1, 1), 1), slice(None, None, None), (5, 5, 5)),
             (
                 ((5, 5, 5), (1, 1, 1), 1),
-                (slice(1, 2, None), slice(None, None, None),),
-                (5, 5),
+                (slice(1, 2, None), slice(None, None, None)),
+                (1, 5, 5),
             ),
             (
                 ((2, 5, 5), (1, 1, 1), 1),
-                (slice(0, 2, None), slice(None, None, None), slice(1, 4, None),),
+                (slice(0, 2, None), slice(None, None, None), slice(1, 4, None)),
                 (2, 5, 3),
+            ),
+            (
+                ((3, 10, 10), (1, 0.5, 0.1), 2),
+                (1, slice(5, 10, None), slice(None, None, None)),
+                (1, 5, 10),
+            ),
+            (
+                ((3, 10, 10), (1, 0.5, 0.1), 2),
+                (slice(None, 10, None), slice(2, 4, None), slice(None, 3, None)),
+                (3, 2, 3),
             ),
         ],
         indirect=["crystal_map_input"],
@@ -194,20 +209,25 @@ class TestCrystalMapGetItem:
 
         assert indexed.size + not_indexed.size == cm.size
         assert np.allclose(np.unique(not_indexed.phase_id), np.array([-1]))
-        assert np.allclose(np.unique(indexed.phase_id), np.array([1]))
+        assert np.allclose(np.unique(indexed.phase_id), np.array([0]))
 
-    def test_get_by_condition(self, crystal_map):
-        cm = crystal_map
+    @pytest.mark.parametrize(
+        "crystal_map_input",
+        [((1, 4, 3), (1, 1, 1), 1)],
+        indirect=["crystal_map_input"],
+    )
+    def test_get_by_condition(self, crystal_map_input):
+        cm = CrystalMap(**crystal_map_input)
 
         cm.prop["dp"] = np.arange(cm.size)
 
         n_points = 2
-        assert cm.ndim == 2  # Test code assumption
+        assert cm.shape == (4, 3)  # Test code assumption
         cm[0, :n_points].dp = -1
         cm2 = cm[cm.dp < 0]
 
         assert cm2.size == n_points
-        assert np.sum(cm2.dp) == -2
+        assert np.sum(cm2.dp) == -n_points
 
     def test_get_by_multiple_conditions(self, crystal_map, phase_list):
         cm = crystal_map
@@ -225,14 +245,28 @@ class TestCrystalMapGetItem:
         assert cm2.size == np.sum(condition1 * condition2)
         assert np.allclose(cm2.is_in_data, condition1 * condition2)
 
-    @pytest.mark.parametrize("point_id, raises", [(0, False), (1, False), (1000, True)])
-    def test_get_by_integer(self, crystal_map, point_id, raises):
+    @pytest.mark.parametrize(
+        "crystal_map_input, integer_slices, expected_id, raises",
+        [
+            (((3, 4, 4), (1, 1, 1), 1), (0, 0, 2), 2, False),
+            (((3, 4, 4), (1, 1, 1), 3), (0, 2, 0), 8, False),
+            (((3, 4, 4), (1, 1, 1), 3), (2, 0, 0), 32, False),
+            (((1, 4, 1), (0, 1, 0), 2), 1, 1, False),
+            (((3, 4, 4), (1, 1, 1), 3), (1000, 0, 0), None, True),
+        ],
+        indirect=["crystal_map_input"],
+    )
+    def test_get_by_integer(
+        self, crystal_map_input, integer_slices, expected_id, raises
+    ):
+        # This also tests `phase_id`
+        cm = CrystalMap(**crystal_map_input)
         if raises:
-            with pytest.raises(IndexError, match=f"{point_id} is out of bounds for"):
-                _ = crystal_map[point_id]
+            with pytest.raises(IndexError, match=f".* is out of bounds for"):
+                _ = cm[integer_slices]
         else:
-            point = crystal_map[point_id]
-            expected_point = crystal_map[crystal_map.id == point_id]
+            point = cm[integer_slices]
+            expected_point = cm[cm.id == expected_id]
 
             assert np.allclose(point.rotations.data, expected_point.rotations.data)
             assert point._coordinates == expected_point._coordinates
@@ -261,7 +295,7 @@ class TestCrystalMapSetAttributes:
         if set_phase_id == -1:
             assert "not_indexed" in cm.phases.names
 
-    @pytest.mark.parametrize("set_phase_id, index_error", [(-1, False), (2, True)])
+    @pytest.mark.parametrize("set_phase_id, index_error", [(-1, False), (1, True)])
     def test_set_phase_id_with_unknown_id(self, crystal_map, set_phase_id, index_error):
         cm = crystal_map
 
@@ -275,7 +309,7 @@ class TestCrystalMapSetAttributes:
                 _ = cm.__repr__()
 
             # Add unknown ID to phase list to fix `self.__repr__()`
-            cm.phases["a"] = 432
+            cm.phases["a"] = 432  # Add phase with ID 1
         else:
             cm[condition].phase_id = set_phase_id
 
@@ -326,7 +360,28 @@ class TestCrystalMapOrientations:
 
         assert orientations_size == cm.size
 
-    def test_getting_orientations_none_symmetry_raises(self, crystal_map_input):
+    @pytest.mark.parametrize(
+        "symmetry, rotation, expected_orientation",
+        [
+            (C2, [(0.6088, 0, 0, 0.7934)], [(-0.7934, 0, 0, 0.6088)]),
+            (C3, [(0.6088, 0, 0, 0.7934)], [(-0.9914, 0, 0, 0.1305)]),
+            (C4, [(0.6088, 0, 0, 0.7934)], [(-0.9914, 0, 0, -0.1305)]),
+            (O, [(0.6088, 0, 0, 0.7934)], [(-0.9914, 0, 0, -0.1305)]),
+        ],
+    )
+    def test_orientations_symmetry(self, symmetry, rotation, expected_orientation):
+        r = Rotation(rotation)
+        cm = CrystalMap(rotations=r, phase_id=np.array([0]))
+        cm.phases = PhaseList(Phase("a", symmetry=symmetry))
+
+        o = cm.orientations
+
+        assert np.allclose(
+            o.data, Orientation(r).set_symmetry(symmetry).data, atol=1e-3
+        )
+        assert np.allclose(o.data, expected_orientation, atol=1e-3)
+
+    def test_orientations_none_symmetry_raises(self, crystal_map_input):
         cm = CrystalMap(**crystal_map_input)
 
         assert cm.phases.symmetries == [None]
@@ -334,7 +389,7 @@ class TestCrystalMapOrientations:
         with pytest.raises(TypeError, match="'NoneType' object is not iterable"):
             _ = cm.orientations
 
-    def test_getting_orientations_multiple_phases_raises(self, crystal_map, phase_list):
+    def test_orientations_multiple_phases_raises(self, crystal_map, phase_list):
         cm = crystal_map
 
         cm.phases = phase_list
@@ -353,7 +408,8 @@ class TestCrystalMapOrientations:
     ):
         cm = CrystalMap(**crystal_map_input)
 
-        cm.phases[1].symmetry = "m-3m"
+        assert cm.phases.phase_ids == [0]  # Test code assumption
+        cm.phases[0].symmetry = "m-3m"
 
         assert cm.rotations_per_point == rotations_per_point
         assert cm.orientations.size == cm.size
@@ -438,11 +494,6 @@ class TestCrystalMapGetMapData:
         # Make sure they are the same
         assert np.allclose(data_via_array, data_via_string)
 
-    def test_get_none_raises(self, crystal_map):
-        item = "z"
-        with pytest.raises(ValueError, match=f"{item} is None."):
-            _ = crystal_map.get_map_data(item)
-
     def test_get_property_array(self, crystal_map):
         cm = crystal_map
 
@@ -456,30 +507,39 @@ class TestCrystalMapGetMapData:
 
     @pytest.mark.parametrize(
         "crystal_map_input",
-        [((1, 3, 2), (0, 1, 1), 3), ((2, 1, 2), (1, 1, 1), 1),],
+        [((1, 3, 2), (0, 1, 1), 3), ((3, 1, 2), (1, 1, 1), 1)],
         indirect=["crystal_map_input"],
     )
     def test_get_orientations_array(self, crystal_map_input, phase_list):
         cm = CrystalMap(**crystal_map_input)
 
-        cm[3].phase_id = 2
+        cm[:2, 0].phase_id = 1
         # Test code assumption
-        assert np.allclose(np.unique(cm.phase_id), np.array([1, 2]))
+        id1 = 0
+        id2 = 1
+        assert np.allclose(np.unique(cm.phase_id), np.array([id1, id2]))
         cm.phases = phase_list
 
         # Get all with string
         o = cm.get_map_data("orientations")
 
         # Get per phase with string
-        o1 = cm[cm.phase_id == 1].get_map_data("orientations")
-        o2 = cm[cm.phase_id == 2].get_map_data("orientations")
+        cm1 = cm[cm.phase_id == id1]
+        cm2 = cm[cm.phase_id == id2]
+        o1 = cm1.get_map_data("orientations")
+        o2 = cm2.get_map_data("orientations")
 
-        # Merge the two orientation arrays
-        o3 = o1
-        mask = ~np.isnan(o2)
-        o3[mask] = o2[mask]
+        expected_o1 = cm1.orientations.to_euler()
+        expected_shape = expected_o1.shape
+        assert np.allclose(
+            o1[~np.isnan(o1)].reshape(expected_shape), expected_o1, atol=1e-3
+        )
 
-        assert np.allclose(o, o3, atol=1e-3)
+        expected_o2 = cm2.orientations.to_euler()
+        expected_shape = expected_o2.shape
+        assert np.allclose(
+            o2[~np.isnan(o2)].reshape(expected_shape), expected_o2, atol=1e-3
+        )
 
         # Do calculations "manually"
         data_shape = (cm.size, 3)
@@ -521,6 +581,29 @@ class TestCrystalMapGetMapData:
         r2 = cm.get_map_data(r.reshape(*new_shape2))
         assert np.allclose(r2, expected_array, atol=1e-3)
 
+    @pytest.mark.parametrize(
+        "crystal_map_input",
+        [((3, 9, 3), (1, 1.5, 1.5), 2), ((2, 10, 5), (1, 0.1, 0.1), 3),],
+        indirect=["crystal_map_input"],
+    )
+    def test_get_phase_id_array_from_3d_data(self, crystal_map_input):
+        cm = CrystalMap(**crystal_map_input)
+        _ = cm.get_map_data(cm.phase_id)
+
+    @pytest.mark.parametrize(
+        "crystal_map_input, to_get",
+        [
+            (((1, 4, 3), (1, 1, 1), 1), "z"),
+            (((4, 1, 3), (1, 1, 1), 1), "y"),
+            (((4, 3, 1), (1, 1, 1), 1), "x"),
+        ],
+        indirect=["crystal_map_input"],
+    )
+    def test_get_unknown_string_raises(self, crystal_map_input, to_get):
+        cm = CrystalMap(**crystal_map_input)
+        with pytest.raises(ValueError, match=f"{to_get} is None."):
+            _ = cm.get_map_data(to_get)
+
 
 class TestCrystalMapRepresentation:
     def test_representation(self, crystal_map, phase_list):
@@ -528,10 +611,12 @@ class TestCrystalMapRepresentation:
         cm.phases = phase_list
         cm.scan_unit = "nm"
 
-        assert phase_list.phase_ids == [0, 1, 2]  # Test code assumption
+        # Test code assumptions
+        assert phase_list.phase_ids == [0, 1, 2]
+        assert cm.shape == (4, 3)
 
-        cm[0].phase_id = phase_list.phase_ids[0]
-        cm[1].phase_id = phase_list.phase_ids[2]
+        cm[0, 1].phase_id = phase_list.phase_ids[1]
+        cm[1, 1].phase_id = phase_list.phase_ids[2]
 
         cm.prop["iq"] = np.arange(cm.size)
 
@@ -541,8 +626,8 @@ class TestCrystalMapRepresentation:
 
         assert cm.__repr__() == (
             "Phase   Orientations   Name  Symmetry   Color\n"
-            "    0       1 (8.3%)      a      m-3m       r\n"
-            "    1     10 (83.3%)      b       432       g\n"
+            "    0     10 (83.3%)      a      m-3m       r\n"
+            "    1       1 (8.3%)      b       432       g\n"
             "    2       1 (8.3%)      c         3       b\n"
             "Properties: iq\n"
             "Scan unit: nm"
@@ -562,7 +647,7 @@ class TestCrystalMapCopying:
         assert np.may_share_memory(cm2._phase_id, cm._phase_id)
         assert np.may_share_memory(cm2._rotations.data, cm._rotations.data)
 
-        cm[5].phase_id = -2
+        cm[3, 0].phase_id = -2
         assert np.allclose(cm2.phase_id, cm.phase_id)
         assert np.allclose(cm3.phase_id, cm.phase_id)
 
@@ -581,6 +666,120 @@ class TestCrystalMapCopying:
 
         cm2 = cm.deepcopy()
 
-        cm[5].phase_id = -2
+        cm[3, 0].phase_id = -2
         assert np.allclose(cm2.phase_id, cm.phase_id) is False
         assert np.may_share_memory(cm2._phase_id, cm._phase_id) is False
+
+
+class TestCrystalMapShape:
+    @pytest.mark.parametrize(
+        "crystal_map_input, expected_slices",
+        [
+            (((1, 10, 30), (0, 0.1, 0.1), 2), (slice(0, 10, None), slice(0, 30, None))),
+            (
+                ((2, 13, 27), (0.3, 0.7, 0.9), 3),
+                (slice(0, 2, None), slice(0, 13, None), slice(0, 27, None)),
+            ),
+            (((1, 4, 3), (0, 1.5, 1.5), 1), (slice(0, 4, None), slice(0, 3, None))),
+            # Testing rounding 15 / 2 = 7.5 and 45 / 2 = 22.5
+            (((1, 15, 45), (0, 2, 2), 1), (slice(0, 15, None), slice(0, 45, None))),
+        ],
+        indirect=["crystal_map_input"],
+    )
+    def test_data_slices_from_coordinates(self, crystal_map_input, expected_slices):
+        cm = CrystalMap(**crystal_map_input)
+        assert cm._data_slices_from_coordinates() == expected_slices
+
+    @pytest.mark.parametrize(
+        "crystal_map_input, slices, expected_size, expected_shape, expected_slices",
+        [
+            # Slice 3D data with an index in all axes
+            (
+                ((2, 3, 4), (1, 1, 1), 1),
+                (1, 2, 3),
+                1,
+                (1, 1, 1),
+                (slice(1, 2, None), slice(2, 3, None), slice(3, 4, None)),
+            ),
+            # Slice 3D data with indices in only two axes
+            (
+                ((2, 3, 4), (0.1, 0.1, 0.1), 1),
+                (1, 2),
+                4,
+                (1, 1, 4),
+                (slice(1, 2, None), slice(2, 3, None), slice(0, 4, None)),
+            ),
+            # Slice 3D data with indices in only two axes (same as above, to make sure
+            # slice determination is unaffected by step size)
+            (
+                ((2, 3, 4), (1, 1, 1), 1),
+                (1, 2),
+                4,
+                (1, 1, 4),
+                (slice(1, 2, None), slice(2, 3, None), slice(0, 4, None)),
+            ),
+            # Slice 3D data with an index in only one axis
+            (
+                ((2, 3, 4), (0.1, 0.1, 0.1), 1),
+                (1,),
+                12,
+                (1, 3, 4),
+                (slice(1, 2, None), slice(0, 3, None), slice(0, 4, None)),
+            ),
+        ],
+        indirect=["crystal_map_input"],
+    )
+    def test_data_slice_from_coordinates_masked(
+        self, crystal_map_input, slices, expected_size, expected_shape, expected_slices
+    ):
+        cm = CrystalMap(**crystal_map_input)
+
+        # Mask data
+        cm2 = cm[slices]
+
+        assert cm2.size == expected_size
+        assert cm2.shape == expected_shape
+        assert cm2._data_slices_from_coordinates() == expected_slices
+
+    @pytest.mark.parametrize(
+        "crystal_map_input, expected_shape",
+        [
+            (((1, 10, 30), (0, 0.1, 0.1), 2), (10, 30)),
+            (((2, 13, 27), (0.3, 0.7, 0.9), 3), (2, 13, 27)),
+            (((1, 4, 3), (0, 1.5, 1.5), 1), (4, 3)),
+            (((1, 15, 45), (0, 2, 2), 2), (15, 45)),
+        ],
+        indirect=["crystal_map_input"],
+    )
+    def test_shape_from_coordinates(self, crystal_map_input, expected_shape):
+        cm = CrystalMap(**crystal_map_input)
+        assert cm.shape == expected_shape
+
+    @pytest.mark.parametrize(
+        "crystal_map_input, expected_shape",
+        [
+            (((1, 10, 30), (0, 0.1, 0.1), 2), (10, 30, 2)),
+            (((2, 13, 27), (0.3, 0.7, 0.9), 3), (2, 13, 27, 3)),
+            (((1, 4, 3), (0, 1.5, 1.5), 5), (4, 3, 5)),
+            (((1, 15, 45), (0, 2, 2), 2), (15, 45, 2)),
+        ],
+        indirect=["crystal_map_input"],
+    )
+    def test_rotation_shape(self, crystal_map_input, expected_shape):
+        cm = CrystalMap(**crystal_map_input)
+        assert cm.rotations_shape == expected_shape
+
+    @pytest.mark.parametrize(
+        "crystal_map_input, expected_coordinate_axes",
+        [
+            (((1, 10, 30), (0, 0.1, 0.1), 1), {0: "y", 1: "x"}),
+            (((2, 13, 27), (0.3, 0.7, 0.9), 1), {0: "z", 1: "y", 2: "x"}),
+            (((1, 13, 27), (0, 1.5, 1.5), 1), {0: "y", 1: "x"}),
+            (((2, 13, 1), (1, 2, 1), 2), {0: "z", 1: "y"}),
+            (((2, 1, 13), (1, 0, 2), 1), {0: "z", 1: "x"}),
+        ],
+        indirect=["crystal_map_input"],
+    )
+    def test_coordinate_axes(self, crystal_map_input, expected_coordinate_axes):
+        cm = CrystalMap(**crystal_map_input)
+        assert cm._coordinate_axes == expected_coordinate_axes

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -16,17 +16,349 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
+import numpy as np
+import pytest
+
+from orix.crystal_map import CrystalMap
+from orix.quaternion.orientation import Orientation
+from orix.quaternion.rotation import Rotation
+
+
+ROTATIONS = Rotation([(2, 4, 6, 8), (-1, -2, -3, -4)])
+
+# Note that many parts of the CrystalMap() class are tested while testing IO and the
+# Phase() and PhaseList() classes
+
 
 class TestCrystalMapInit:
-    pass
+    def test_minimal_init(self):
+        map_size = 2
+
+        assert isinstance(ROTATIONS, Rotation)
+
+        cm = CrystalMap(rotations=ROTATIONS)
+
+        assert cm.size == map_size
+        assert cm.shape == (map_size,)
+        assert cm.ndim
+        assert np.allclose(cm.id, np.arange(map_size))
+        assert isinstance(cm.rotations, Rotation)
+        assert np.allclose(cm.rotations.data, ROTATIONS.data)
+
+    @pytest.mark.parametrize("rotations", [ROTATIONS.data, list(ROTATIONS.data)])
+    def test_init_with_invalid_rotations(self, rotations):
+        with pytest.raises(ValueError):
+            _ = CrystalMap(rotations=rotations)
+
+    @pytest.mark.parametrize(
+        (
+            "crystal_map_input, expected_shape, expected_step_sizes, "
+            "expected_rotations_per_point"
+        ),
+        [
+            (((1, 5, 5), (0, 1.5, 1.5), 3), (5, 5), {"z": 0, "y": 1.5, "x": 1.5}, 3),
+            (((1, 1, 10), (0, 0.1, 0.1), 1), (10,), {"z": 0, "y": 0, "x": 0.1}, 1),
+            (((2, 10, 1), (0, 1e-3, 0), 2), (10,), {"z": 0, "y": 1e-3, "x": 0}, 2),
+            (((10, 1, 1), (0, 0.1, 0.1), 1), (), {"z": 0, "y": 0, "x": 0}, 1),
+        ],
+        indirect=["crystal_map_input"],
+    )
+    def test_init_with_different_coordinate_arrays(
+        self,
+        crystal_map_input,
+        expected_shape,
+        expected_step_sizes,
+        expected_rotations_per_point,
+    ):
+        z = crystal_map_input["z"]
+        y = crystal_map_input["y"]
+        x = crystal_map_input["x"]
+        cm = CrystalMap(**crystal_map_input)
+
+        assert cm.shape == expected_shape
+        assert cm._step_sizes == expected_step_sizes
+        assert cm.rotations_per_point == expected_rotations_per_point
+
+        if cm.shape == ():
+            assert cm._coordinates == {"z": None, "y": None, "x": None}
+        else:
+            for actual_coords, expected_coords, expected_step_size in zip(
+                cm._coordinates.values(), [z, y, x], expected_step_sizes.values()
+            ):
+                if expected_step_size == 0:
+                    assert actual_coords is None
+                else:
+                    assert np.allclose(actual_coords, expected_coords)
+
+    @pytest.mark.parametrize(
+        "crystal_map_input",
+        [((2, 10, 5), (1, 1, 1), 1)],
+        indirect=["crystal_map_input"],
+    )
+    def test_init_without_x_coordinates(self, crystal_map_input):
+        r = crystal_map_input["rotations"]
+        z = crystal_map_input["z"]
+        y = crystal_map_input["y"]
+        cm = CrystalMap(rotations=r, x=None, y=y, z=z)
+
+        assert np.allclose(cm.x, np.arange(cm.size))
+        assert np.allclose(cm.y, y)
+        assert np.allclose(cm.z, z)
+
+    def test_init_map_with_props(self, crystal_map_input):
+        x = crystal_map_input["x"]
+        props = {"iq": np.arange(x.size)}
+        cm = CrystalMap(prop=props, **crystal_map_input)
+
+        assert cm.prop == props
+        assert np.allclose(cm.prop.id, cm.id)
+        assert np.allclose(cm.prop.is_in_data, cm.is_in_data)
+
+    @pytest.mark.parametrize("unique_phase_ids", [[0, 1], [1, -1]])
+    def test_init_with_phase_id(self, crystal_map_input, unique_phase_ids):
+        x = crystal_map_input["x"]
+
+        # Create phase ID array, ensuring all are present
+        phase_id = np.random.choice(unique_phase_ids, x.size)
+        for i, unique_id in enumerate(unique_phase_ids):
+            phase_id[i] = unique_id
+
+        cm = CrystalMap(phase_id=phase_id, **crystal_map_input)
+
+        assert np.allclose(cm.phase_id, phase_id)
+        # Test all_indexed
+        if -1 in unique_phase_ids:
+            assert not cm.all_indexed
+            assert -1 in cm.phases.phase_ids
+        else:
+            assert cm.all_indexed
+            assert -1 not in cm.phases.phase_ids
 
 
-class TestCrystalMapGetting:
-    pass
+class TestCrystalMapGetItem:
+    @pytest.mark.parametrize(
+        "crystal_map_input, slice_tuple, expected_shape",
+        [
+            (((5, 5, 5), (1, 1, 1), 1), slice(None, None, None), (5, 5, 5)),
+            (
+                ((5, 5, 5), (1, 1, 1), 1),
+                (slice(1, 2, None), slice(None, None, None),),
+                (1, 5, 5),
+            ),
+            (
+                ((2, 5, 5), (1, 1, 1), 1),
+                (slice(0, 2, None), slice(None, None, None), slice(1, 4, None),),
+                (2, 5, 3),
+            ),
+        ],
+        indirect=["crystal_map_input"],
+    )
+    def test_get_by_slice(self, crystal_map_input, slice_tuple, expected_shape):
+        cm = CrystalMap(**crystal_map_input)
+
+        cm2 = cm[slice_tuple]
+        assert cm2.shape == expected_shape
+
+    def test_get_by_phase_name(self, crystal_map_input, phase_list):
+        x = crystal_map_input["x"]
+
+        # Create phase ID array, ensuring all are present
+        phase_ids = np.random.choice(phase_list.phase_ids, x.size)
+        for i, unique_id in enumerate(phase_list.phase_ids):
+            phase_ids[i] = unique_id
+
+        # Get number of points with each phase ID
+        n_points_per_phase = {}
+        for phase_i, phase in phase_list:
+            n_points_per_phase[phase.name] = len(np.where(phase_ids == phase_i)[0])
+
+        cm = CrystalMap(phase_id=phase_ids, **crystal_map_input)
+        cm.phases = phase_list
+
+        for (_, phase), (expected_phase_name, n_points) in zip(
+            phase_list, n_points_per_phase.items()
+        ):
+            cm2 = cm[phase.name]
+
+            assert cm2.size == n_points
+            assert cm2.phases_in_data.names == [expected_phase_name]
+
+    def test_get_by_indexed_not_indexed(self):
+        pass
+
+    def test_get_by_condition(self):
+        pass
+
+    @pytest.mark.parametrize("point_id, raises", [(0, False), (1, False), (1000, True)])
+    def test_get_by_integer(self, crystal_map, point_id, raises):
+        if raises:
+            with pytest.raises(IndexError, match=f"{point_id} is out of bounds for"):
+                _ = crystal_map[point_id]
+        else:
+            point = crystal_map[point_id]
+            expected_point = crystal_map[crystal_map.id == point_id]
+
+            assert np.allclose(point.rotations.data, expected_point.rotations.data)
+            assert point._coordinates == expected_point._coordinates
 
 
-class TestCrystalMapSetting:
-    pass
+class TestCrystalMapSetAttributes:
+    def test_set_scan_unit(self, crystal_map):
+        cm = crystal_map
+        assert cm.scan_unit == "px"
+
+        micron = "um"
+        cm.scan_unit = micron
+        assert cm.scan_unit == micron
+
+    @pytest.mark.parametrize("set_phase_id", [1, -1])
+    def test_set_phase_ids(self, crystal_map, set_phase_id):
+        cm = crystal_map
+
+        phase_ids = cm.phase_id
+        condition = cm.x > 1.5
+        cm[condition].phase_id = set_phase_id
+        phase_ids[condition] = set_phase_id
+
+        assert np.allclose(cm.phase_id, phase_ids)
+
+        if set_phase_id == -1:
+            assert "not_indexed" in cm.phases.names
+
+    @pytest.mark.parametrize("set_phase_id, index_error", [(-1, False), (2, True)])
+    def test_set_phase_id_with_unknown_id(self, crystal_map, set_phase_id, index_error):
+        cm = crystal_map
+
+        condition = cm.x > 1.5
+        phase_ids = cm.phases.phase_ids  # Get before adding a new phase
+
+        if index_error:
+            with pytest.raises(IndexError, match="list index out of range"):
+                # `set_phase_id` ID is not in `self.phases.phase_ids`
+                cm[condition].phase_id = set_phase_id
+                _ = cm.__repr__()
+
+            # Add unknown ID to phase list to fix `self.__repr__()`
+            cm.phases["a"] = 432
+        else:
+            cm[condition].phase_id = set_phase_id
+
+        _ = cm.__repr__()
+
+        new_phase_ids = phase_ids + [set_phase_id]
+        new_phase_ids.sort()
+        assert cm.phases.phase_ids == new_phase_ids
+
+    def test_phases_in_data(self, crystal_map, phase_list):
+        cm = crystal_map
+        cm.phases = phase_list
+
+        assert cm.phases_in_data.names != cm.phases.names
+
+        ids_not_in_data = np.setdiff1d(
+            np.array(cm.phases.phase_ids), np.array(cm.phases_in_data.phase_ids)
+        )
+        condition1 = cm.x > 1.5
+        condition2 = cm.y > 1.5
+        for new_id, condition in zip(ids_not_in_data, [condition1, condition2]):
+            cm[condition].phase_id = new_id
+
+        assert cm.phases_in_data.names == cm.phases.names
+
+
+class TestCrystalMapOrientations:
+    def test_orientations(self, crystal_map_input, phase_list):
+        x = crystal_map_input["x"]
+
+        # Create phase ID array, ensuring all are present
+        phase_ids = np.random.choice(phase_list.phase_ids, x.size)
+        for i, unique_id in enumerate(phase_list.phase_ids):
+            phase_ids[i] = unique_id
+
+        cm = CrystalMap(phase_id=phase_ids, **crystal_map_input)
+
+        # Set phases and make sure all are in data
+        cm.phases = phase_list
+        assert cm.phases_in_data.names == cm.phases.names
+
+        # Ensure all points have a valid orientation
+        orientations_size = 0
+        for phase_id in phase_list.phase_ids:
+            o = cm[cm.phase_id == phase_id].orientations
+            assert isinstance(o, Orientation)
+            orientations_size += o.size
+
+        assert orientations_size == cm.size
+
+    def test_getting_orientations_none_symmetry_raises(self, crystal_map_input):
+        cm = CrystalMap(**crystal_map_input)
+
+        assert cm.phases.symmetries == [None]
+
+        with pytest.raises(TypeError, match="'NoneType' object is not iterable"):
+            _ = cm.orientations
+
+    def test_getting_orientations_multiple_phases_raises(self, crystal_map, phase_list):
+        cm = crystal_map
+
+        cm.phases = phase_list
+        cm[cm.x > 1.5].phase_id = 2
+
+        with pytest.raises(ValueError, match="Data has the phases "):
+            _ = cm.orientations
+
+    @pytest.mark.parametrize(
+        "crystal_map_input, rotations_per_point",
+        [(((1, 5, 5), (0, 1.5, 1.5), 3), 3)],
+        indirect=["crystal_map_input"],
+    )
+    def test_multiple_orientations_per_point(
+        self, crystal_map_input, rotations_per_point
+    ):
+        cm = CrystalMap(**crystal_map_input)
+
+        cm.phases[1].symmetry = "m-3m"
+
+        assert cm.rotations_per_point == rotations_per_point
+        assert cm.orientations.size == cm.size
+
+
+class TestCrystalMapProp:
+    def test_add_new_crystal_map_property(self, crystal_map):
+        cm = crystal_map
+
+        prop_name = "iq"
+        prop_values = np.arange(cm.size)
+        cm.prop[prop_name] = prop_values
+
+        assert np.allclose(cm.prop.get(prop_name), prop_values)
+        assert np.allclose(cm.prop[prop_name], prop_values)
+
+    def test_overwrite_crystal_map_property_values(self, crystal_map):
+        cm = crystal_map
+
+        prop_name = "iq"
+        prop_values = np.arange(cm.size)
+        cm.prop[prop_name] = prop_values
+
+        assert np.allclose(cm.prop[prop_name], prop_values)
+
+        new_prop_value = -1
+        cm.__setattr__(prop_name, new_prop_value)
+
+        assert np.allclose(cm.prop[prop_name], np.ones(cm.size) * new_prop_value)
+
+
+class TestCrystalMapMasking:
+    def test_masking_props(self, crystal_map_input):
+        x = crystal_map_input["x"]
+        props = {"iq": np.arange(x.size)}
+        cm = CrystalMap(prop=props, **crystal_map_input)
+
+        cm2 = cm[cm.iq > 1]
+
+        assert np.allclose(cm2.prop.id, cm2.id)
+        assert np.allclose(cm2.prop.is_in_data, cm2.is_in_data)
 
 
 class TestCrystalMapGetMapData:
@@ -34,4 +366,5 @@ class TestCrystalMapGetMapData:
 
 
 class TestCrystalMapCopying:
-    pass
+    def test_shallowcopy_crystal_map(self, crystal_map_input):
+        pass

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 The pyXem developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class TestCrystalMapInit:
+    pass
+
+
+class TestCrystalMapGetting:
+    pass
+
+
+class TestCrystalMapSetting:
+    pass
+
+
+class TestCrystalMapGetMapData:
+    pass
+
+
+class TestCrystalMapCopying:
+    pass

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -295,6 +295,10 @@ class TestCrystalMapSetAttributes:
         if set_phase_id == -1:
             assert "not_indexed" in cm.phases.names
 
+    def test_set_phase_ids_raises(self, crystal_map):
+        with pytest.raises(ValueError, match="NumPy boolean array indexing assignment"):
+            crystal_map[1, 1].phase_id = -1 * np.ones(10)
+
     @pytest.mark.parametrize("set_phase_id, index_error", [(-1, False), (1, True)])
     def test_set_phase_id_with_unknown_id(self, crystal_map, set_phase_id, index_error):
         cm = crystal_map

--- a/orix/tests/test_crystal_map_plot.py
+++ b/orix/tests/test_crystal_map_plot.py
@@ -16,10 +16,531 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
+import copy
+
+import numpy as np
+import matplotlib.pyplot as plt
+import pytest
+
+from orix import plot  # Needed for projection="plot_map"? Might be imported via below
+from orix.plot import CrystalMapPlot
+from orix.plot.crystal_map_plot import convert_unit
+from orix.crystal_map import CrystalMap
+from orix.crystal_map.phase_list import PhaseList
+
+plt.rcParams["backend"] = "TkAgg"
+
+# Warning raised when plot width is too small (this too is tested)
+SCALEBAR_WARNING = "Scalebar width .* is not an integer."
+
+# Can be easily changed in the future
+PLOT_MAP = "plot_map"
+
 
 class TestCrystalMapPlot:
-    pass
+    @pytest.mark.parametrize(
+        "crystal_map_input, expected_data_shape",
+        [
+            (((1, 10, 20), (0, 1.5, 1.5), 1), (10, 20, 3)),
+            (((1, 4, 3), (0, 0.1, 0.1), 1), (4, 3, 3)),
+        ],
+        indirect=["crystal_map_input"],
+    )
+    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
+    def test_plot_phase(self, crystal_map_input, phase_list, expected_data_shape):
+        cm = CrystalMap(**crystal_map_input)
+
+        assert np.unique(cm.phase_id) == np.array([0])  # Test code assumption
+        assert phase_list.phase_ids == [0, 1, 2]
+        cm.phases = phase_list
+        cm[0, 0].phase_id = 0
+        cm[1, 1].phase_id = 2
+
+        fig = plt.figure()
+        ax = fig.add_subplot(projection=PLOT_MAP)
+        im = ax.plot_map(cm)
+
+        # Expected image data
+        phase_id = cm.get_map_data("phase_id")
+        unique_phase_ids = np.unique(phase_id[~np.isnan(phase_id)])
+        expected_data = np.ones(phase_id.shape + (3,))
+        for i, color in zip(unique_phase_ids, cm.phases_in_data.colors_rgb):
+            mask = phase_id == int(i)
+            expected_data[mask] = expected_data[mask] * color
+
+        image_data = im.get_array()
+        assert np.allclose(image_data.shape, expected_data_shape)
+        assert np.allclose(image_data, expected_data)
+
+    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
+    def test_plot_property(self, crystal_map):
+        cm = crystal_map
+
+        prop_name = "iq"
+        prop_data = np.arange(cm.size)
+        cm.prop[prop_name] = prop_data
+
+        fig = plt.figure()
+        ax = fig.add_subplot(projection=PLOT_MAP)
+        im = ax.plot_map(cm, cm.iq)
+
+        assert np.allclose(im.get_array(), prop_data.reshape(cm.shape))
+
+    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
+    def test_plot_scalar(self, crystal_map):
+        cm = crystal_map
+
+        angles = cm.rotations.angle.data
+
+        fig1 = plt.figure()
+        ax1 = fig1.add_subplot(projection=PLOT_MAP)
+        # Test use of `vmax` as well
+        im1 = ax1.plot_map(cm, angles, vmax=angles.max() - 10)
+
+        assert np.allclose(im1.get_array(), angles.reshape(cm.shape), atol=1e-3)
+
+        fig2 = plt.figure()
+        ax2 = fig2.add_subplot(projection=PLOT_MAP)
+        im2 = ax2.plot_map(cm, cm.rotations.angle)
+
+        assert np.allclose(im2.get_array(), angles.reshape(cm.shape), atol=1e-3)
+
+    @pytest.mark.parametrize(
+        "crystal_map_input",
+        [((2, 9, 3), (1, 1.5, 1.5), 1), ((2, 10, 5), (1, 0.1, 0.1), 1)],
+        indirect=["crystal_map_input"],
+    )
+    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
+    def test_plot_masked_phase(self, crystal_map_input, phase_list):
+        cm = CrystalMap(**crystal_map_input)
+
+        # Test code assumptions
+        assert np.unique(cm.phase_id) == np.array([0])
+        assert phase_list.phase_ids == [0, 1, 2]
+        assert cm.ndim == 3
+
+        cm.phases = phase_list
+
+        cm[0, :2, :1].phase_id = 1
+        cm[1, 2:4, :1].phase_id = 2
+        assert np.allclose(np.unique(cm.phase_id), np.array([0, 1, 2]))
+
+        # One phase plot per masked map
+        for i, phase in phase_list:
+            fig = plt.figure()
+            ax = fig.add_subplot(projection=PLOT_MAP)
+            _ = ax.plot_map(cm[cm.phase_id == i])
+
+    @pytest.mark.parametrize(
+        "crystal_map_input",
+        [((2, 9, 6), (1, 1.5, 1.5), 2), ((2, 10, 5), (1, 0.1, 0.1), 1)],
+        indirect=["crystal_map_input"],
+    )
+    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
+    def test_plot_masked_scalar(self, crystal_map_input):
+        cm = CrystalMap(**crystal_map_input)
+
+        cm.prop["test"] = np.zeros(cm.size)
+        cm[1, 5, 4].test = 1
+
+        fig1 = plt.figure()
+        ax1 = fig1.add_subplot(projection=PLOT_MAP)
+        im1 = ax1.plot_map(cm, cm.test)
+
+        fig2 = plt.figure()
+        ax2 = fig2.add_subplot(projection=PLOT_MAP)
+        im2 = ax2.plot_map(cm, cm.test, depth=1)
+
+        expected_data_im1 = np.zeros(ax1._data_shape)
+        expected_data_im2 = np.zeros(ax2._data_shape)
+        expected_data_im2[5, 4] = 1
+
+        im1_data = im1.get_array()
+        im2_data = im2.get_array()
+        assert np.allclose(im1_data, expected_data_im1)
+        assert np.allclose(im2_data, expected_data_im2)
 
 
 class TestCrystalMapPlotUtilities:
-    pass
+    def test_init_projection(self):
+        # Option 1
+        fig = plt.figure()
+        ax1 = fig.add_subplot(projection=PLOT_MAP)
+        assert isinstance(ax1, CrystalMapPlot)
+
+        # Option 2 (`label` to suppress warning of non-unique figure objects)
+        ax2 = plt.subplot(projection=PLOT_MAP, label="unique")
+        assert isinstance(ax2, CrystalMapPlot)
+
+    @pytest.mark.parametrize(
+        "crystal_map_input, idx_to_change, axes, depth, expected_plot_shape",
+        [
+            (((2, 10, 20), (1, 1.5, 1.5), 1), (1, 5, 4), (1, 2), 1, (10, 20)),
+            (((4, 4, 3), (0.1, 0.1, 0.1), 1), (0, 0, 2), (0, 1), 2, (4, 4)),
+            (((10, 10, 10), (1, 1, 1), 2), (-1, 8, -1), (0, 2), 8, (10, 10)),
+        ],
+        indirect=["crystal_map_input"],
+    )
+    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
+    def test_get_plot_shape(
+        self, crystal_map_input, idx_to_change, axes, depth, expected_plot_shape
+    ):
+        cm = CrystalMap(**crystal_map_input)
+
+        cm.prop["test"] = np.zeros(cm.size)
+        cm[idx_to_change].test = 1
+
+        fig = plt.figure()
+        ax = fig.add_subplot(projection=PLOT_MAP)
+        im = ax.plot_map(cm, cm.test, axes=axes, depth=depth)
+
+        assert ax._data_shape == expected_plot_shape
+        assert np.allclose(np.unique(im.get_array()), np.array([0, 1]))
+
+    @pytest.mark.parametrize("to_plot", ["scalar", "rgb"])
+    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
+    def test_add_overlay(self, crystal_map, to_plot):
+        cm = crystal_map
+
+        assert np.allclose(cm.phase_id, np.zeros(cm.size))  # Assumption
+
+        fig = plt.figure()
+        ax = fig.add_subplot(projection=PLOT_MAP)
+        if to_plot == "scalar":
+            im = ax.plot_map(cm, cm.y)
+            im_data = im.get_array()
+            assert im_data.ndim == 2
+            im_data = im.to_rgba(im_data)[:, :, :3]
+        else:  # rgb
+            im = ax.plot_map(cm)
+            im_data = copy.deepcopy(im.get_array())
+
+        to_overlay = cm.id
+        ax.add_overlay(cm, to_overlay)
+        im_data2 = ax.images[0].get_array()
+
+        assert np.allclose(im_data, im_data2) is False
+
+        overlay = cm.get_map_data(to_overlay)
+        overlay_min = np.nanmin(overlay)
+        rescaled_overlay = (overlay - overlay_min) / (np.nanmax(overlay) - overlay_min)
+
+        for i in range(3):
+            im_data[:, :, i] *= rescaled_overlay
+
+        assert np.allclose(im_data, im_data2)
+
+    @pytest.mark.parametrize(
+        "phase_names, phase_colors, legend_properties",
+        [
+            (["a", "b"], ["r", "b"], {}),
+            (
+                ["austenite", "ferrite"],
+                ["xkcd:violet", "lime"],
+                {"borderpad": 1, "framealpha": 1},
+            ),
+            (
+                ["al", "au"],
+                ["tab:orange", "tab:green"],
+                {"handlelength": 0.5, "handletextpad": 0.5},
+            ),
+        ],
+    )
+    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
+    def test_phase_legend(
+        self, crystal_map, phase_names, phase_colors, legend_properties
+    ):
+        cm = crystal_map
+        cm[0, 0].phase_id = 1
+        cm.phases = PhaseList(names=phase_names, symmetries=[3, 3], colors=phase_colors)
+
+        fig = plt.figure()
+        ax = fig.add_subplot(projection=PLOT_MAP)
+        _ = ax.plot_map(cm, legend_properties=legend_properties)
+
+        legend = ax.legend_
+
+        assert legend._fontsize == 11.0
+        assert [i._text for i in legend.texts] == phase_names
+
+        frame_alpha = legend_properties.pop("framealpha", 0.6)
+        assert legend.get_frame().get_alpha() == frame_alpha
+
+        for k, v in legend_properties.items():
+            assert legend.__getattribute__(k) == v
+
+    @pytest.mark.parametrize("with_colorbar", [True, False])
+    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
+    def test_remove_padding(self, crystal_map, with_colorbar):
+        fig = plt.figure()
+        ax = fig.add_subplot(projection=PLOT_MAP)
+        _ = ax.plot_map(crystal_map)
+
+        if with_colorbar:
+            _ = ax.add_colorbar(position="right")
+
+        # Before
+        margin_before = 0.05
+        assert ax._xmargin == margin_before
+        assert ax._ymargin == margin_before
+
+        expected_subplot_params = (0.88, 0.11, 0.9, 0.125)  # top, bottom, right, left
+        subplot_params = fig.subplotpars
+        assert (
+            subplot_params.top,
+            subplot_params.bottom,
+            subplot_params.right,
+            subplot_params.left,
+        ) == expected_subplot_params
+
+        ax.remove_padding()
+
+        # After
+        margin_after = 0
+        expected_subplot_params = (1, 0, 1, 0)
+        assert ax._xmargin == margin_after
+        assert ax._ymargin == margin_after
+
+        if with_colorbar:
+            expected_subplot_params = (1, 0, 0.9, 0)
+        subplot_params = fig.subplotpars
+        assert (
+            subplot_params.top,
+            subplot_params.bottom,
+            subplot_params.right,
+            subplot_params.left,
+        ) == expected_subplot_params
+
+    @pytest.mark.parametrize("cmap", ["viridis", "cividis", "inferno"])
+    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
+    def test_set_colormap(self, crystal_map, cmap):
+        fig = plt.figure()
+        ax = fig.add_subplot(projection=PLOT_MAP)
+        im = ax.plot_map(crystal_map, cmap=cmap)
+
+        assert im.cmap.name == cmap
+
+    @pytest.mark.parametrize(
+        "cmap, label, position",
+        [("viridis", "a", "right"), ("cividis", "b", "left"), ("inferno", "c", "top"),],
+    )
+    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
+    def test_add_colorbar(self, crystal_map, cmap, label, position):
+        fig = plt.figure()
+        ax = fig.add_subplot(projection=PLOT_MAP)
+        im = ax.plot_map(crystal_map, cmap=cmap)
+
+        assert im.cmap.name == cmap
+
+        cbar = ax.add_colorbar(label=label, position=position)
+
+        assert cbar.cmap.name == cmap
+        assert cbar.ax.get_ylabel() == label
+
+        new_label = label + "z"
+        cbar.ax.set_ylabel(ylabel=new_label)
+        assert cbar.ax.get_ylabel() == new_label
+
+        assert cbar.ax.yaxis.labelpad == 15
+
+    @pytest.mark.parametrize(
+        "value, unit, expected_value, expected_unit, expected_factor",
+        [
+            (3.141592 * 1e3, "nm", 3.141592, "um", 1e3),
+            (10.55 * 1e-3, "mm", 10.55, "um", 1e-3),
+            (23.7 * 1e3, "px", 23.7, "px", 1e3),
+        ],
+    )
+    def test_convert_unit(
+        self, value, unit, expected_value, expected_unit, expected_factor
+    ):
+        new_value, new_unit, factor = convert_unit(value, unit)
+        assert np.allclose(new_value, expected_value, atol=1e-6)
+        assert new_unit == expected_unit
+        assert np.allclose(factor, expected_factor)
+
+
+class TestStatusBar:
+    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
+    def test_status_bar_call_directly(self, crystal_map):
+        fig = plt.figure()
+        ax = fig.add_subplot(projection=PLOT_MAP)
+        im = ax.plot_map(crystal_map)
+
+        _ = ax._override_status_bar(im, crystal_map)
+
+        # Check that silencing of default status bar is successful
+        assert ax.format_coord(0, 0) == ""
+
+    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
+    def test_status_bar_silence_default_format_coord(self, crystal_map):
+        fig = plt.figure()
+        ax = fig.add_subplot(projection=PLOT_MAP)
+        _ = ax.plot_map(crystal_map)
+
+        assert ax.format_coord(0, 0) == ""
+
+    @pytest.mark.parametrize("to_plot", ["rgb", "scalar"])
+    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
+    def test_status_bar(self, crystal_map, to_plot):
+        fig = plt.figure()
+        ax = fig.add_subplot(projection=PLOT_MAP)
+
+        if to_plot == "rgb":
+            im = ax.plot_map(crystal_map)
+        else:  # scalar
+            im = ax.plot_map(crystal_map, crystal_map.id)
+
+        # Get figure canvas (x, y) from transformation from data (x, y)
+        data_idx = (2, 2)
+        x, y = ax.transData.transform(data_idx)
+
+        # Mock a mouse event
+        plt.matplotlib.backends.backend_agg.FigureCanvasBase.motion_notify_event(
+            fig.canvas, x, y
+        )
+        cursor_event = plt.matplotlib.backend_bases.MouseEvent(
+            "motion_notify_event", fig.canvas, x, y
+        )
+
+        # Call our custom cursor data function
+        cursor_data = im.get_cursor_data(cursor_event)
+
+        # Get crystal map data
+        point = crystal_map[data_idx]
+        r = point.rotations.to_euler()
+
+        # Expected indices, rotation and value
+        assert cursor_data[:2] == data_idx
+        assert np.allclose(cursor_data[2], r, atol=1e-3)
+        if to_plot == "rgb":
+            assert np.allclose(cursor_data[3], point.phases_in_data.colors_rgb)
+        else:  # scalar
+            assert np.allclose(cursor_data[3], point.id)
+
+
+class TestScalebar:
+    @pytest.mark.parametrize(
+        "crystal_map_input, scalebar_properties, artist_attribute",
+        [
+            (((1, 10, 30), (0, 1, 1), 1), {}, {}),  # Default
+            (
+                ((1, 10, 30), (0, 1, 1), 1),
+                {
+                    "loc": 4,
+                    "frameon": False,
+                    "sep": 6,
+                    "size_vertical": 0.2,
+                    "alpha": 0.8,
+                },
+                {
+                    "loc": "loc",
+                    "frameon": "_drawFrame",
+                    "sep": ["_box", "sep"],
+                    "size_vertical": ["size_bar", "_children", 0, "_height"],
+                    "alpha": ["patch", "_alpha"],
+                },
+            ),
+        ],
+        indirect=["crystal_map_input"],
+    )
+    def test_scalebar_properties(
+        self, crystal_map_input, scalebar_properties, artist_attribute
+    ):
+        cm = CrystalMap(**crystal_map_input)
+        cm.scan_unit = "um"
+
+        fig = plt.figure()
+        ax = fig.add_subplot(projection=PLOT_MAP)
+        _ = ax.plot_map(cm, scalebar=False)
+        sbar = ax.add_scalebar(cm, **scalebar_properties)
+
+        if "alpha" not in scalebar_properties.keys():  # Check default
+            assert sbar.patch._alpha == 0.6
+
+        for (k, v), attr_loc in zip(
+            scalebar_properties.items(), artist_attribute.values()
+        ):
+            if isinstance(attr_loc, list):
+                sbar_attr = sbar.__getattribute__(attr_loc[0])
+                for i in attr_loc[1:]:
+                    if isinstance(i, int):
+                        sbar_attr = sbar_attr[i]
+                    else:
+                        sbar_attr = sbar_attr.__getattribute__(i)
+            else:
+                sbar_attr = sbar.__getattribute__(attr_loc)
+            assert sbar_attr == v
+
+    @pytest.mark.parametrize(
+        (
+            "crystal_map_input, unit, expected_coordinate_axes, expected_width_px, "
+            "expected_width_unit, expected_unit"
+        ),
+        [
+            (((10, 20, 1), (1, 1, 0), 1), "px", {0: "z", 1: "y"}, 2, 2, "px"),
+            (((1, 10, 30), (0, 1, 1), 1), "px", {0: "y", 1: "x"}, 2, 2, "px"),
+            (((1, 10, 40), (0, 1, 1), 1), "px", {0: "y", 1: "x"}, 5, 5, "px"),
+            (((20, 1, 10), (1, 1, 1), 1), "um", {0: "z", 1: "x"}, 1, 1, "um"),
+            (
+                ((1, 100, 117), (0, 1.5, 1.5), 1),
+                "nm",
+                {0: "y", 1: "x"},
+                13.33,
+                20,
+                "nm",
+            ),
+        ],
+        indirect=["crystal_map_input"],
+    )
+    def test_scalebar_axis(
+        self,
+        crystal_map_input,
+        unit,
+        expected_coordinate_axes,
+        expected_width_px,
+        expected_width_unit,
+        expected_unit,
+    ):
+        cm = CrystalMap(**crystal_map_input)
+        cm.scan_unit = unit
+
+        assert cm._coordinate_axes == expected_coordinate_axes
+
+        fig = plt.figure()
+        ax = fig.add_subplot(projection=PLOT_MAP)
+        _ = ax.plot_map(cm, scalebar=False)
+        sbar = ax.add_scalebar(cm)
+
+        # Scalebar width (_width attribute of Rectangle artist)
+        assert np.allclose(
+            sbar.size_bar._children[0]._width, expected_width_px, atol=1e-2
+        )
+
+        # Scalebar text
+        if expected_unit == "um":
+            expected_unit = "\u03BC" + "m"
+        assert (
+            sbar.txt_label._children[0]._text
+            == f"{expected_width_unit} {expected_unit}"
+        )
+
+    @pytest.mark.parametrize(
+        "crystal_map_input, warns",
+        [
+            (((1, 10, 20), (0, 1.5, 1.5), 1), False),
+            (((1, 4, 3), (0, 0.1, 0.1), 1), True),
+        ],
+        indirect=["crystal_map_input"],
+    )
+    def test_scalebar_warns(self, crystal_map_input, warns):
+        cm = CrystalMap(**crystal_map_input)
+
+        fig = plt.figure()
+        ax = fig.add_subplot(projection=PLOT_MAP)
+
+        if warns:
+            with pytest.warns(UserWarning, match=SCALEBAR_WARNING):
+                _ = ax.plot_map(cm)
+        else:
+            _ = ax.plot_map(cm)

--- a/orix/tests/test_crystal_map_plot.py
+++ b/orix/tests/test_crystal_map_plot.py
@@ -435,6 +435,10 @@ class TestStatusBar:
         # Call our custom cursor data function
         cursor_data = im.get_cursor_data(cursor_event)
 
+        # Check status bar data formatting
+        data_format = im.format_cursor_data(cursor_data)
+        expected_format = f"(y,x):({data_idx[0]},{data_idx[1]})"
+
         # Get crystal map data
         point = crystal_map[data_idx]
         r = point.rotations.to_euler()
@@ -446,6 +450,12 @@ class TestStatusBar:
             assert np.allclose(cursor_data[3], point.phases_in_data.colors_rgb)
         else:  # scalar
             assert np.allclose(cursor_data[3], point.id)
+            expected_format += " val: {:.1f}".format(point.id[0])
+
+        expected_format += " rot:({:.3f},{:.3f},{:.3f})".format(
+            r[0, 0], r[0, 1], r[0, 2]
+        )
+        assert data_format == expected_format
 
         plt.close("all")
 

--- a/orix/tests/test_crystal_map_plot.py
+++ b/orix/tests/test_crystal_map_plot.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 The pyXem developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class TestCrystalMapPlot:
+    pass
+
+
+class TestCrystalMapPlotUtilities:
+    pass

--- a/orix/tests/test_crystal_map_plot.py
+++ b/orix/tests/test_crystal_map_plot.py
@@ -393,9 +393,6 @@ class TestStatusBar:
 
         _ = ax._override_status_bar(im, crystal_map)
 
-        # Check that silencing of default status bar is successful
-        assert ax.format_coord(0, 0) == ""
-
         plt.close("all")
 
     @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
@@ -414,7 +411,9 @@ class TestStatusBar:
         fig = plt.figure()
         ax = fig.add_subplot(projection=PLOT_MAP)
 
-        fig.canvas.draw()
+        f = plt.gcf()
+        f.canvas.draw()
+        f.canvas.flush_events()
 
         if to_plot == "rgb":
             im = ax.plot_map(crystal_map)
@@ -427,10 +426,10 @@ class TestStatusBar:
 
         # Mock a mouse event
         plt.matplotlib.backends.backend_agg.FigureCanvasBase.motion_notify_event(
-            fig.canvas, x, y
+            f.canvas, x, y
         )
         cursor_event = plt.matplotlib.backend_bases.MouseEvent(
-            "motion_notify_event", fig.canvas, x, y
+            "motion_notify_event", f.canvas, x, y
         )
 
         # Call our custom cursor data function

--- a/orix/tests/test_crystal_map_plot.py
+++ b/orix/tests/test_crystal_map_plot.py
@@ -72,6 +72,8 @@ class TestCrystalMapPlot:
         assert np.allclose(image_data.shape, expected_data_shape)
         assert np.allclose(image_data, expected_data)
 
+        plt.close("all")
+
     @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
     def test_plot_property(self, crystal_map):
         cm = crystal_map
@@ -85,6 +87,8 @@ class TestCrystalMapPlot:
         im = ax.plot_map(cm, cm.iq)
 
         assert np.allclose(im.get_array(), prop_data.reshape(cm.shape))
+
+        plt.close("all")
 
     @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
     def test_plot_scalar(self, crystal_map):
@@ -104,6 +108,8 @@ class TestCrystalMapPlot:
         im2 = ax2.plot_map(cm, cm.rotations.angle)
 
         assert np.allclose(im2.get_array(), angles.reshape(cm.shape), atol=1e-3)
+
+        plt.close("all")
 
     @pytest.mark.parametrize(
         "crystal_map_input",
@@ -130,6 +136,8 @@ class TestCrystalMapPlot:
             fig = plt.figure()
             ax = fig.add_subplot(projection=PLOT_MAP)
             _ = ax.plot_map(cm[cm.phase_id == i])
+
+        plt.close("all")
 
     @pytest.mark.parametrize(
         "crystal_map_input",
@@ -160,6 +168,8 @@ class TestCrystalMapPlot:
         assert np.allclose(im1_data, expected_data_im1)
         assert np.allclose(im2_data, expected_data_im2)
 
+        plt.close("all")
+
 
 class TestCrystalMapPlotUtilities:
     def test_init_projection(self):
@@ -171,6 +181,8 @@ class TestCrystalMapPlotUtilities:
         # Option 2 (`label` to suppress warning of non-unique figure objects)
         ax2 = plt.subplot(projection=PLOT_MAP, label="unique")
         assert isinstance(ax2, CrystalMapPlot)
+
+        plt.close("all")
 
     @pytest.mark.parametrize(
         "crystal_map_input, idx_to_change, axes, depth, expected_plot_shape",
@@ -196,6 +208,8 @@ class TestCrystalMapPlotUtilities:
 
         assert ax._data_shape == expected_plot_shape
         assert np.allclose(np.unique(im.get_array()), np.array([0, 1]))
+
+        plt.close("all")
 
     @pytest.mark.parametrize("to_plot", ["scalar", "rgb"])
     @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
@@ -229,6 +243,8 @@ class TestCrystalMapPlotUtilities:
             im_data[:, :, i] *= rescaled_overlay
 
         assert np.allclose(im_data, im_data2)
+
+        plt.close("all")
 
     @pytest.mark.parametrize(
         "phase_names, phase_colors, legend_properties",
@@ -268,6 +284,8 @@ class TestCrystalMapPlotUtilities:
 
         for k, v in legend_properties.items():
             assert legend.__getattribute__(k) == v
+
+        plt.close("all")
 
     @pytest.mark.parametrize("with_colorbar", [True, False])
     @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
@@ -311,6 +329,8 @@ class TestCrystalMapPlotUtilities:
             subplot_params.left,
         ) == expected_subplot_params
 
+        plt.close("all")
+
     @pytest.mark.parametrize("cmap", ["viridis", "cividis", "inferno"])
     @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
     def test_set_colormap(self, crystal_map, cmap):
@@ -319,6 +339,8 @@ class TestCrystalMapPlotUtilities:
         im = ax.plot_map(crystal_map, cmap=cmap)
 
         assert im.cmap.name == cmap
+
+        plt.close("all")
 
     @pytest.mark.parametrize(
         "cmap, label, position",
@@ -342,6 +364,8 @@ class TestCrystalMapPlotUtilities:
         assert cbar.ax.get_ylabel() == new_label
 
         assert cbar.ax.yaxis.labelpad == 15
+
+        plt.close("all")
 
     @pytest.mark.parametrize(
         "value, unit, expected_value, expected_unit, expected_factor",
@@ -372,6 +396,8 @@ class TestStatusBar:
         # Check that silencing of default status bar is successful
         assert ax.format_coord(0, 0) == ""
 
+        plt.close("all")
+
     @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
     def test_status_bar_silence_default_format_coord(self, crystal_map):
         fig = plt.figure()
@@ -380,11 +406,15 @@ class TestStatusBar:
 
         assert ax.format_coord(0, 0) == ""
 
+        plt.close("all")
+
     @pytest.mark.parametrize("to_plot", ["rgb", "scalar"])
     @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
     def test_status_bar(self, crystal_map, to_plot):
         fig = plt.figure()
         ax = fig.add_subplot(projection=PLOT_MAP)
+
+        fig.canvas.draw()
 
         if to_plot == "rgb":
             im = ax.plot_map(crystal_map)
@@ -417,6 +447,8 @@ class TestStatusBar:
             assert np.allclose(cursor_data[3], point.phases_in_data.colors_rgb)
         else:  # scalar
             assert np.allclose(cursor_data[3], point.id)
+
+        plt.close("all")
 
 
 class TestScalebar:
@@ -472,6 +504,8 @@ class TestScalebar:
                 sbar_attr = sbar.__getattribute__(attr_loc)
             assert sbar_attr == v
 
+        plt.close("all")
+
     @pytest.mark.parametrize(
         (
             "crystal_map_input, unit, expected_coordinate_axes, expected_width_px, "
@@ -525,6 +559,8 @@ class TestScalebar:
             == f"{expected_width_unit} {expected_unit}"
         )
 
+        plt.close("all")
+
     @pytest.mark.parametrize(
         "crystal_map_input, warns",
         [
@@ -544,3 +580,5 @@ class TestScalebar:
                 _ = ax.plot_map(cm)
         else:
             _ = ax.plot_map(cm)
+
+        plt.close("all")

--- a/orix/tests/test_crystal_map_properties.py
+++ b/orix/tests/test_crystal_map_properties.py
@@ -31,7 +31,7 @@ class TestCrystalMapProperties:
             ({}, np.arange(5), np.array([1, 1, 0, 1, 1], dtype=bool)),
         ],
     )
-    def test_init_crystal_map_properties(self, dictionary, id, is_in_data):
+    def test_init_properties(self, dictionary, id, is_in_data):
         props = CrystalMapProperties(
             dictionary=dictionary, id=id, is_in_data=is_in_data
         )
@@ -42,7 +42,7 @@ class TestCrystalMapProperties:
             is_in_data = np.ones(id.size, dtype=bool)
         assert np.allclose(props.is_in_data, is_in_data)
 
-    def test_set_crystal_map_property_item(self):
+    def test_set_item(self):
         map_size = 10
         is_in_data = np.ones(map_size, dtype=bool)
         is_in_data[5] = False
@@ -61,13 +61,21 @@ class TestCrystalMapProperties:
         expected_array2[5] = expected_array[5]
         assert np.allclose(props.get("iq"), expected_array2)
 
-    def test_set_crystal_map_property_item_error(self):
+    def test_set_item_error(self):
         map_size = 10
         is_in_data = np.ones(map_size, dtype=bool)
-        is_in_data[5] = False
+        id_to_change = 3
+        is_in_data[id_to_change] = False
+
         d = {"iq": np.arange(map_size)}
         props = CrystalMapProperties(d, id=np.arange(map_size), is_in_data=is_in_data)
 
         # Set array with an array
         with pytest.raises(ValueError, match="NumPy boolean array indexing assignment"):
             props["iq"] = np.arange(map_size) + 1
+
+        # Set new 2D array
+        props.is_in_data[id_to_change] = True
+        with pytest.raises(TypeError, match="NumPy boolean array indexing assignment"):
+            new_shape = (10 // 2, 10 // 5)
+            props["dp"] = np.arange(map_size).reshape(new_shape)

--- a/orix/tests/test_crystal_map_properties.py
+++ b/orix/tests/test_crystal_map_properties.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 The pyXem developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class TestCrystalMapProperties:
+    pass

--- a/orix/tests/test_crystal_map_properties.py
+++ b/orix/tests/test_crystal_map_properties.py
@@ -16,6 +16,58 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
+import numpy as np
+import pytest
+
+from orix.crystal_map.crystal_map_properties import CrystalMapProperties
+
 
 class TestCrystalMapProperties:
-    pass
+    @pytest.mark.parametrize(
+        "dictionary, id, is_in_data",
+        [
+            ({}, np.arange(10), np.ones(10, dtype=bool)),
+            ({"iq": np.arange(10), "dp": np.zeros(10)}, np.arange(10), None,),
+            ({}, np.arange(5), np.array([1, 1, 0, 1, 1], dtype=bool)),
+        ],
+    )
+    def test_init_crystal_map_properties(self, dictionary, id, is_in_data):
+        props = CrystalMapProperties(
+            dictionary=dictionary, id=id, is_in_data=is_in_data
+        )
+
+        assert props == dictionary
+        assert np.allclose(props.id, id)
+        if is_in_data is None:
+            is_in_data = np.ones(id.size, dtype=bool)
+        assert np.allclose(props.is_in_data, is_in_data)
+
+    def test_set_crystal_map_property_item(self):
+        map_size = 10
+        is_in_data = np.ones(map_size, dtype=bool)
+        is_in_data[5] = False
+        d = {"iq": np.arange(map_size)}
+        props = CrystalMapProperties(d, id=np.arange(map_size), is_in_data=is_in_data)
+
+        # Set array with an array
+        n_in_data = map_size - len(np.where(~is_in_data)[0])
+        props["iq"] = np.arange(n_in_data) + 1
+        expected_array = np.array([1, 2, 3, 4, 5, 5, 6, 7, 8, 9])
+        assert np.allclose(props.get("iq"), expected_array)
+
+        # Set array with one value
+        props["iq"] = 2
+        expected_array2 = np.ones(map_size) * 2
+        expected_array2[5] = expected_array[5]
+        assert np.allclose(props.get("iq"), expected_array2)
+
+    def test_set_crystal_map_property_item_error(self):
+        map_size = 10
+        is_in_data = np.ones(map_size, dtype=bool)
+        is_in_data[5] = False
+        d = {"iq": np.arange(map_size)}
+        props = CrystalMapProperties(d, id=np.arange(map_size), is_in_data=is_in_data)
+
+        # Set array with an array
+        with pytest.raises(ValueError, match="NumPy boolean array indexing assignment"):
+            props["iq"] = np.arange(map_size) + 1

--- a/orix/tests/test_io.py
+++ b/orix/tests/test_io.py
@@ -483,7 +483,7 @@ class TestAngReader:
         ],
     )
     def test_get_phases_from_header(
-        self, temp_ang_file, header_phase_part, expected_names, expected_symmetries
+        self, header_phase_part, expected_names, expected_symmetries
     ):
         hkl_families = [
             "# NumberFamilies    4",

--- a/orix/tests/test_io.py
+++ b/orix/tests/test_io.py
@@ -57,16 +57,16 @@ from orix.tests.conftest import (
             ),
             np.array(
                 [
-                    [0.77861956, 0.12501022, -0.44104243, -0.42849224],
-                    [-0.46256046, -0.13302712, -0.03524667, -0.87584204],
-                    [-0.46256046, -0.13302712, -0.03524667, -0.87584204],
-                    [-0.46256046, -0.13302712, -0.03524667, -0.87584204],
-                    [0.05331986, -0.95051048, -0.28534763, 0.11074093],
-                    [-0.45489991, -0.13271448, -0.03640618, -0.87984517],
-                    [0.8752001, 0.02905178, -0.10626836, -0.47104969],
-                    [0.3039118, -0.01972273, 0.92612154, -0.22259272],
-                    [0.3039118, -0.01972273, 0.92612154, -0.22259272],
-                    [0.8752001, 0.02905178, -0.10626836, -0.47104969],
+                    [0.77861956, -0.12501022, 0.44104243, 0.42849224],
+                    [0.46256046, -0.13302712, -0.03524667, -0.87584204],
+                    [0.46256046, -0.13302712, -0.03524667, -0.87584204],
+                    [0.46256046, -0.13302712, -0.03524667, -0.87584204],
+                    [0.05331986, 0.95051048, 0.28534763, -0.11074093],
+                    [0.45489991, -0.13271448, -0.03640618, -0.87984517],
+                    [0.8752001, -0.02905178, 0.10626836, 0.47104969],
+                    [0.3039118, 0.01972273, -0.92612154, 0.22259272],
+                    [0.3039118, 0.01972273, -0.92612154, 0.22259272],
+                    [0.8752001, -0.02905178, 0.10626836, 0.47104969],
                 ]
             ),
         ),
@@ -76,11 +76,6 @@ from orix.tests.conftest import (
 def test_loadang(angfile_astar, expected_data):
     loaded_data = io.loadang(angfile_astar)
     assert np.allclose(loaded_data.data, expected_data)
-
-
-def test_load_ang(angfile):
-    """ This testing is improved in v0.3.0"""
-    loaded_data = io.loadang(angfile)
 
 
 def test_loadctf():
@@ -113,7 +108,7 @@ class TestAngReader:
                 np.zeros(5 * 3, dtype=int),
                 5,
                 np.array(
-                    [[1.59942, 2.37748, 4.53419], [1.59331, 2.37417, 4.53628],]
+                    [[1.59942, 2.37748, -1.74690], [1.59331, 2.37417, -1.74899],]
                 ),  # rotations as rows of Euler angle triplets
             ),
             (
@@ -131,7 +126,7 @@ class TestAngReader:
                 np.zeros(8 * 4, dtype=int),
                 5,
                 np.array(
-                    [[5.81107, 2.34188, 4.47345], [6.16205, 0.79936, 1.31702],]
+                    [[-0.12113, 2.34188, 1.31702], [-0.47211, 0.79936, -1.80973],]
                 ),  # rotations as rows of Euler angle triplets
             ),
         ],
@@ -186,11 +181,12 @@ class TestAngReader:
 
         # Rotations
         rot_unique = np.unique(cm["indexed"].rotations.to_euler(), axis=0)
-        assert np.allclose(np.sort(rot_unique, axis=0), np.sort(example_rot, axis=0))
+        assert np.allclose(
+            np.sort(rot_unique, axis=0), np.sort(example_rot, axis=0), atol=1e-5)
         assert np.allclose(
             cm["not_indexed"].rotations.to_euler()[0],
             np.array([np.pi, 0, np.pi]),
-            atol=1e-6,
+            atol=1e-5,
         )
 
         # Phases
@@ -240,7 +236,7 @@ class TestAngReader:
                 (10, 10),
                 np.ones(11 * 13, dtype=int),
                 np.array(
-                    [[1.621760, 2.368935, 4.559324], [1.604481, 2.367539, 4.541870],]
+                    [[1.621760, 2.368935, -1.723861], [1.604481, 2.367539, -1.741315],]
                 ),
             ),
         ],
@@ -276,7 +272,8 @@ class TestAngReader:
 
         # Rotations
         rot_unique = np.unique(cm.rotations.to_euler(), axis=0)
-        assert np.allclose(np.sort(rot_unique, axis=0), np.sort(example_rot, axis=0))
+        assert np.allclose(
+            np.sort(rot_unique, axis=0), np.sort(example_rot, axis=0), atol=1e-6)
 
         # Phases
         assert cm.phases.size == 1
@@ -331,8 +328,8 @@ class TestAngReader:
                     ),  # phase_id
                     np.array(
                         [
-                            [1.621760, 2.368935, 4.559324],
-                            [1.604481, 2.367539, 4.541870],
+                            [1.62176, 2.36894, -1.72386],
+                            [1.60448, 2.36754, -1.72386],
                         ]
                     ),
                 ),
@@ -345,7 +342,7 @@ class TestAngReader:
                     )
                 ),
                 np.array(
-                    [[1.621760, 2.368935, 4.559324], [1.604481, 2.367539, 4.541870],]
+                    [[1.62176, 2.36894, -1.72386], [1.60448, 2.36754, -1.72386],]
                 ),
             ),
         ],
@@ -378,7 +375,8 @@ class TestAngReader:
 
         # Rotations
         rot_unique = np.unique(cm.rotations.to_euler(), axis=0)
-        assert np.allclose(np.sort(rot_unique, axis=0), np.sort(example_rot, axis=0))
+        assert np.allclose(
+            np.sort(rot_unique, axis=0), np.sort(example_rot, axis=0), atol=1e-5)
 
         # Phases (change if file header is changed!)
         phases_in_data = cm["indexed"].phases_in_data

--- a/orix/tests/test_io.py
+++ b/orix/tests/test_io.py
@@ -1,37 +1,28 @@
-import pytest
-import numpy as np
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 The pyXem developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
 import os
 
+import pytest
+import numpy as np
+
 from orix import io
-
-
-@pytest.fixture(
-    params=[
-        """4.485496 0.952426 0.791507     0.000     0.000   22.2  0.060  1       6
-1.343904 0.276111 0.825890    19.000     0.000   16.3  0.020  1       2""",
-    ]
-)
-def angfile(tmpdir, request):
-    f = tmpdir.mkdir("angfiles").join("angfile.ang")
-    f.write(
-        """# File created from ACOM RES results
-# ni-dislocations.res
-#
-#
-# MaterialName      Nickel
-# Formula
-# Symmetry          43
-# LatticeConstants  3.520  3.520  3.520  90.000  90.000  90.000
-# NumberFamilies    4
-# hklFamilies       1  1  1 1 0.000000
-# hklFamilies       2  0  0 1 0.000000
-# hklFamilies       2  2  0 1 0.000000
-# hklFamilies       3  1  1 1 0.000000
-#
-# GRID: SqrGrid#"""
-    )
-    f.write(request.param)
-    return str(f)
+from orix.io import load_ang, load_emsoft
 
 
 @pytest.mark.parametrize(
@@ -66,14 +57,44 @@ def angfile(tmpdir, request):
     ],
     indirect=["angfile"],
 )
-def test_load_ang(angfile, expected_data):
+def test_loadang(angfile, expected_data):
     loaded_data = io.loadang(angfile)
     assert np.allclose(loaded_data.data, expected_data)
 
 
-def test_load_ctf():
+def test_loadctf():
     """ Crude test of the ctf loader """
     z = np.random.rand(100, 8)
     np.savetxt("temp.ctf", z)
     z_loaded = io.loadctf("temp.ctf")
     os.remove("temp.ctf")
+
+
+class TestAngReader:
+    def test_load_ang_tsl(self):
+        pass
+
+    def test_load_ang_astar(self):
+        pass
+
+    def test_load_ang_emsoft(self):
+        pass
+
+    def test_get_header(self):
+        pass
+
+    # With different vendor header as input
+    def test_vendor_columns(self):
+        pass
+
+    # With different vendor header as input
+    def test_get_phases_from_header(self):
+        pass
+
+
+class TestEMsoftReader:
+    def test_load_emsoft(self):
+        pass
+
+    def test_get_properties(self):
+        pass

--- a/orix/tests/test_io.py
+++ b/orix/tests/test_io.py
@@ -102,7 +102,7 @@ class TestAngReader:
                     5,  # n_unknown_columns
                     np.array(
                         [[1.59942, 2.37748, 4.53419], [1.59331, 2.37417, 4.53628],]
-                    ),  # example_rotations as rows of Euler angle triplets
+                    ),  # rotations as rows of Euler angle triplets
                 ),
                 (5, 3),
                 (0.1, 0.1),
@@ -110,7 +110,7 @@ class TestAngReader:
                 5,
                 np.array(
                     [[1.59942, 2.37748, 4.53419], [1.59331, 2.37417, 4.53628],]
-                ),  # example_rotations as rows of Euler angle triplets
+                ),  # rotations as rows of Euler angle triplets
             ),
             (
                 (
@@ -120,7 +120,7 @@ class TestAngReader:
                     5,  # n_unknown_columns
                     np.array(
                         [[5.81107, 2.34188, 4.47345], [6.16205, 0.79936, 1.31702],]
-                    ),  # example_rotations as rows of Euler angle triplets
+                    ),  # rotations as rows of Euler angle triplets
                 ),
                 (8, 4),
                 (1.5, 1.5),
@@ -128,7 +128,7 @@ class TestAngReader:
                 5,
                 np.array(
                     [[5.81107, 2.34188, 4.47345], [6.16205, 0.79936, 1.31702],]
-                ),  # example_rotations as rows of Euler angle triplets
+                ),  # rotations as rows of Euler angle triplets
             ),
         ],
         indirect=["angfile_tsl"],
@@ -528,7 +528,7 @@ class TestEMsoftReader:
                             [6.148271, 0.792205, 1.324879],
                             [6.155951, 0.793078, 1.325229],
                         ]
-                    ),  # example_rotations as rows of Euler angle triplets
+                    ),  # rotations as rows of Euler angle triplets
                     50,  # n_top_matches
                     True,  # refined
                 ),

--- a/orix/tests/test_io.py
+++ b/orix/tests/test_io.py
@@ -18,13 +18,13 @@
 
 import os
 
-import h5py
 import pytest
 import numpy as np
 
 from orix import io
 from orix.io import load_ang, load_emsoft
 from orix.io.ang import _get_header, _get_phases_from_header, _get_vendor_columns
+from orix.io.emsoft_h5ebsd import _get_properties
 
 from orix.tests.conftest import (
     ANGFILE_TSL_HEADER,
@@ -601,6 +601,3 @@ class TestEMsoftReader:
         actual_props.sort()
         expected_props.sort()
         assert actual_props == expected_props
-
-    def test_get_properties(self):
-        pass

--- a/orix/tests/test_io.py
+++ b/orix/tests/test_io.py
@@ -485,18 +485,19 @@ class TestAngReader:
     def test_get_phases_from_header(
         self, header_phase_part, expected_names, expected_symmetries
     ):
+        # Create header from parts
+        header = [
+            "# File created from ACOM RES results",
+            "# ni-dislocations.res",
+            "#     ",
+            "#     ",
+        ]
         hkl_families = [
             "# NumberFamilies    4",
             "# hklFamilies       1  1  1 1 0.000000",
             "# hklFamilies       2  0  0 1 0.000000",
             "# hklFamilies       2  2  0 1 0.000000",
             "# hklFamilies       3  1  1 1 0.000000",
-        ]
-        header = [
-            "# File created from ACOM RES results",
-            "# ni-dislocations.res",
-            "#     ",
-            "#     ",
         ]
         for phase in header_phase_part:
             header += phase + hkl_families

--- a/orix/tests/test_io.py
+++ b/orix/tests/test_io.py
@@ -96,17 +96,17 @@ class TestAngReader:
             (
                 # Read by angfile_tsl() via request.param (passed via `indirect` below)
                 (
-                    (10, 10),  # map_shape
+                    (5, 3),  # map_shape
                     (0.1, 0.1),  # step_sizes
-                    np.zeros(10 * 10, dtype=int),  # phase_id
+                    np.zeros(5 * 3, dtype=int),  # phase_id
                     5,  # n_unknown_columns
                     np.array(
                         [[1.59942, 2.37748, 4.53419], [1.59331, 2.37417, 4.53628],]
                     ),  # example_rotations as rows of Euler angle triplets
                 ),
-                (10, 10),
+                (5, 3),
                 (0.1, 0.1),
-                np.zeros(10 * 10, dtype=int),
+                np.zeros(5 * 3, dtype=int),
                 5,
                 np.array(
                     [[1.59942, 2.37748, 4.53419], [1.59331, 2.37417, 4.53628],]
@@ -114,17 +114,17 @@ class TestAngReader:
             ),
             (
                 (
-                    (23, 42),  # map_shape
+                    (8, 4),  # map_shape
                     (1.5, 1.5),  # step_sizes
-                    np.zeros(23 * 42, dtype=int),  # phase_id
+                    np.zeros(8 * 4, dtype=int),  # phase_id
                     5,  # n_unknown_columns
                     np.array(
                         [[5.81107, 2.34188, 4.47345], [6.16205, 0.79936, 1.31702],]
                     ),  # example_rotations as rows of Euler angle triplets
                 ),
-                (23, 42),
+                (8, 4),
                 (1.5, 1.5),
-                np.zeros(23 * 42, dtype=int),
+                np.zeros(8 * 4, dtype=int),
                 5,
                 np.array(
                     [[5.81107, 2.34188, 4.47345], [6.16205, 0.79936, 1.31702],]
@@ -203,9 +203,9 @@ class TestAngReader:
                 # Read by angfile_astar() via request.param (passed via `indirect`
                 # below)
                 (
-                    (10, 10),  # map_shape
+                    (9, 3),  # map_shape
                     (4.5, 4.5),  # step_sizes
-                    np.ones(10 * 10, dtype=int),  # phase_id
+                    np.ones(9 * 3, dtype=int),  # phase_id
                     np.array(
                         [
                             [1.895079, 0.739496, 1.413542],
@@ -213,18 +213,18 @@ class TestAngReader:
                         ]
                     ),
                 ),
-                (10, 10),
+                (9, 3),
                 (4.5, 4.5),
-                np.ones(10 * 10, dtype=int),
+                np.ones(9 * 3, dtype=int),
                 np.array(
                     [[1.895079, 0.739496, 1.413542], [1.897871, 0.742638, 1.413717],]
                 ),
             ),
             (
                 (
-                    (23, 42),  # map_shape
+                    (11, 13),  # map_shape
                     (10, 10),  # step_sizes
-                    np.ones(23 * 42, dtype=int),  # phase_id
+                    np.ones(11 * 13, dtype=int),  # phase_id
                     np.array(
                         [
                             [1.621760, 2.368935, 4.559324],
@@ -232,9 +232,9 @@ class TestAngReader:
                         ]
                     ),
                 ),
-                (23, 42),
+                (11, 13),
                 (10, 10),
-                np.ones(23 * 42, dtype=int),
+                np.ones(11 * 13, dtype=int),
                 np.array(
                     [[1.621760, 2.368935, 4.559324], [1.604481, 2.367539, 4.541870],]
                 ),
@@ -288,12 +288,12 @@ class TestAngReader:
                 # Read by angfile_emsoft() via request.param (passed via `indirect`
                 # below)
                 (
-                    (10, 10),  # map_shape
+                    (10, 11),  # map_shape
                     (4.5, 4.5),  # step_sizes
                     np.concatenate(
                         (
-                            np.ones(int(np.ceil((10 * 10) / 2))),
-                            np.ones(int(np.floor((10 * 10) / 2))) * 2,
+                            np.ones(int(np.ceil((10 * 11) / 2))),
+                            np.ones(int(np.floor((10 * 11) / 2))) * 2,
                         )
                     ),  # phase_id
                     np.array(
@@ -303,12 +303,12 @@ class TestAngReader:
                         ]
                     ),
                 ),
-                (10, 10),
+                (10, 11),
                 (4.5, 4.5),
                 np.concatenate(
                     (
-                        np.ones(int(np.ceil((10 * 10) / 2))),
-                        np.ones(int(np.floor((10 * 10) / 2))) * 2,
+                        np.ones(int(np.ceil((10 * 11) / 2))),
+                        np.ones(int(np.floor((10 * 11) / 2))) * 2,
                     )
                 ),
                 np.array(
@@ -317,12 +317,12 @@ class TestAngReader:
             ),
             (
                 (
-                    (23, 42),  # map_shape
+                    (3, 6),  # map_shape
                     (10, 10),  # step_sizes
                     np.concatenate(
                         (
-                            np.ones(int(np.ceil((23 * 42) / 2))),
-                            np.ones(int(np.floor((23 * 42) / 2))) * 2,
+                            np.ones(int(np.ceil((3 * 6) / 2))),
+                            np.ones(int(np.floor((3 * 6) / 2))) * 2,
                         )
                     ),  # phase_id
                     np.array(
@@ -332,12 +332,12 @@ class TestAngReader:
                         ]
                     ),
                 ),
-                (23, 42),
+                (3, 6),
                 (10, 10),
                 np.concatenate(
                     (
-                        np.ones(int(np.ceil((23 * 42) / 2))),
-                        np.ones(int(np.floor((23 * 42) / 2))) * 2,
+                        np.ones(int(np.ceil((3 * 6) / 2))),
+                        np.ones(int(np.floor((3 * 6) / 2))) * 2,
                     )
                 ),
                 np.array(
@@ -521,7 +521,7 @@ class TestEMsoftReader:
         [
             (
                 (
-                    (42, 13),  # map_shape
+                    (7, 3),  # map_shape
                     (1.5, 1.5),  # step_sizes
                     np.array(
                         [
@@ -532,7 +532,7 @@ class TestEMsoftReader:
                     50,  # n_top_matches
                     True,  # refined
                 ),
-                (42, 13),
+                (7, 3),
                 (1.5, 1.5),
                 np.array(
                     [[6.148271, 0.792205, 1.324879], [6.155951, 0.793078, 1.325229],]

--- a/orix/tests/test_io.py
+++ b/orix/tests/test_io.py
@@ -23,22 +23,38 @@ import numpy as np
 
 from orix import io
 from orix.io import load_ang
+from orix.io.ang import _get_header, _get_phases_from_header, _get_vendor_columns
+
+from orix.tests.conftest import (
+    ANGFILE_TSL_HEADER,
+    ANGFILE_ASTAR_HEADER,
+    ANGFILE_EMSOFT_HEADER,
+)
 
 
 @pytest.mark.parametrize(
     "angfile_astar, expected_data",
     [
         (
-            """4.485496 0.952426 0.791507     0.000     0.000   22.2  0.060  1       6
-1.343904 0.276111 0.825890    19.000     0.000   16.3  0.020  1       2
-1.343904 0.276111 0.825890    38.000     0.000   18.5  0.030  1       3
-1.343904 0.276111 0.825890    57.000     0.000   17.0  0.060  1       6
-4.555309 2.895152 3.972020    76.000     0.000   20.5  0.020  1       2
-1.361357 0.276111 0.825890    95.000     0.000   16.3  0.010  1       1
-4.485496 0.220784 0.810182   114.000     0.000   20.5  0.010  1       1
-0.959931 2.369110 4.058938   133.000     0.000   16.5  0.030  1       3
-0.959931 2.369110 4.058938   152.000     0.000   16.1  0.030  1       3
-4.485496 0.220784 0.810182   171.000     0.000   17.4  0.020  1       2""",
+            (
+                (2, 5),
+                (1, 1),
+                np.ones(2 * 5, dtype=int),
+                np.array(
+                    [
+                        [4.485496, 0.952426, 0.791507],
+                        [1.343904, 0.276111, 0.825890],
+                        [1.343904, 0.276111, 0.825890],
+                        [1.343904, 0.276111, 0.825890],
+                        [4.555309, 2.895152, 3.972020],
+                        [1.361357, 0.276111, 0.825890],
+                        [4.485496, 0.220784, 0.810182],
+                        [0.959931, 2.369110, 4.058938],
+                        [0.959931, 2.369110, 4.058938],
+                        [4.485496, 0.220784, 0.810182],
+                    ],
+                ),
+            ),
             np.array(
                 [
                     [0.77861956, 0.12501022, -0.44104243, -0.42849224],
@@ -65,26 +81,35 @@ def test_loadang(angfile_astar, expected_data):
 def test_loadctf():
     """ Crude test of the ctf loader """
     z = np.random.rand(100, 8)
-    np.savetxt("temp.ctf", z)
-    z_loaded = io.loadctf("temp.ctf")
-    os.remove("temp.ctf")
+    fname = "temp.ctf"
+    np.savetxt(fname, z)
+
+    _ = io.loadctf(fname)
+    os.remove(fname)
 
 
 class TestAngReader:
     @pytest.mark.parametrize(
-        "angfile_tsl, map_shape, step_sizes, phase_id, n_unknown_columns",
+        "angfile_tsl, map_shape, step_sizes, phase_id, n_unknown_columns, example_rot",
         [
             (
+                # Read by angfile_tsl() via request.param (passed via `indirect` below)
                 (
                     (10, 10),  # map_shape
                     (0.1, 0.1),  # step_sizes
                     np.zeros(10 * 10, dtype=int),  # phase_id
                     5,  # n_unknown_columns
+                    np.array(
+                        [[1.59942, 2.37748, 4.53419], [1.59331, 2.37417, 4.53628],]
+                    ),  # example_rotations as rows of Euler angle triplets
                 ),
                 (10, 10),
                 (0.1, 0.1),
                 np.zeros(10 * 10, dtype=int),
                 5,
+                np.array(
+                    [[1.59942, 2.37748, 4.53419], [1.59331, 2.37417, 4.53628],]
+                ),  # example_rotations as rows of Euler angle triplets
             ),
             (
                 (
@@ -92,17 +117,29 @@ class TestAngReader:
                     (1.5, 1.5),  # step_sizes
                     np.zeros(23 * 42, dtype=int),  # phase_id
                     5,  # n_unknown_columns
+                    np.array(
+                        [[5.81107, 2.34188, 4.47345], [6.16205, 0.79936, 1.31702],]
+                    ),  # example_rotations as rows of Euler angle triplets
                 ),
                 (23, 42),
                 (1.5, 1.5),
                 np.zeros(23 * 42, dtype=int),
                 5,
+                np.array(
+                    [[5.81107, 2.34188, 4.47345], [6.16205, 0.79936, 1.31702],]
+                ),  # example_rotations as rows of Euler angle triplets
             ),
         ],
         indirect=["angfile_tsl"],
     )
     def test_load_ang_tsl(
-        self, angfile_tsl, map_shape, step_sizes, phase_id, n_unknown_columns
+        self,
+        angfile_tsl,
+        map_shape,
+        step_sizes,
+        phase_id,
+        n_unknown_columns,
+        example_rot,
     ):
         cm = load_ang(angfile_tsl)
 
@@ -128,33 +165,349 @@ class TestAngReader:
         assert np.allclose(cm.x, np.tile(np.arange(nx) * dx, ny))
         assert np.allclose(cm.y, np.sort(np.tile(np.arange(ny) * dy, nx)))
 
-        # Ensure that values in columns are within expected ranges or have a certain
-        # value
+        # Map shape and size
+        assert cm.shape == map_shape
+        assert cm.size == np.prod(map_shape)
+
+        # Attributes are within expected ranges or have a certain value
         assert cm.prop["ci"].max() <= 1
         assert cm["indexed"].fit.max() <= 3
+        assert all(cm["not_indexed"].fit == 180)
         assert all(cm["not_indexed"].ci == -1)
+
+        # Phase IDs (accounting for non-indexed points)
+        phase_id[cm["not_indexed"].id] = -1
+        assert np.allclose(cm.phase_id, phase_id)
+
+        # Rotations
+        rot_unique = np.unique(cm["indexed"].rotations.to_euler(), axis=0)
+        assert np.allclose(np.sort(rot_unique, axis=0), np.sort(example_rot, axis=0))
         assert np.allclose(
             cm["not_indexed"].rotations.to_euler()[0],
             np.array([np.pi, 0, np.pi]),
             atol=1e-6,
         )
 
-    def test_load_ang_astar(self):
-        pass
+        # Phases
+        assert cm.phases.size == 2  # Including non-indexed
+        assert cm.phases.phase_ids == [-1, 0]
+        phase = cm.phases[0]
+        assert phase.name == "Aluminum"
+        assert phase.symmetry.name == "432"
 
-    def test_load_ang_emsoft(self):
-        pass
+    @pytest.mark.parametrize(
+        "angfile_astar, map_shape, step_sizes, phase_id, example_rot",
+        [
+            (
+                # Read by angfile_astar() via request.param (passed via `indirect`
+                # below)
+                (
+                    (10, 10),  # map_shape
+                    (4.5, 4.5),  # step_sizes
+                    np.ones(10 * 10, dtype=int),  # phase_id
+                    np.array(
+                        [
+                            [1.895079, 0.739496, 1.413542],
+                            [1.897871, 0.742638, 1.413717],
+                        ]
+                    ),
+                ),
+                (10, 10),
+                (4.5, 4.5),
+                np.ones(10 * 10, dtype=int),
+                np.array(
+                    [[1.895079, 0.739496, 1.413542], [1.897871, 0.742638, 1.413717],]
+                ),
+            ),
+            (
+                (
+                    (23, 42),  # map_shape
+                    (10, 10),  # step_sizes
+                    np.ones(23 * 42, dtype=int),  # phase_id
+                    np.array(
+                        [
+                            [1.621760, 2.368935, 4.559324],
+                            [1.604481, 2.367539, 4.541870],
+                        ]
+                    ),
+                ),
+                (23, 42),
+                (10, 10),
+                np.ones(23 * 42, dtype=int),
+                np.array(
+                    [[1.621760, 2.368935, 4.559324], [1.604481, 2.367539, 4.541870],]
+                ),
+            ),
+        ],
+        indirect=["angfile_astar"],
+    )
+    def test_load_ang_astar(
+        self, angfile_astar, map_shape, step_sizes, phase_id, example_rot,
+    ):
+        cm = load_ang(angfile_astar)
 
-    def test_get_header(self):
-        pass
+        # Properties
+        assert list(cm.prop.keys()) == ["ind", "rel", "relx100"]
 
-    # With different vendor header as input
-    def test_vendor_columns(self):
-        pass
+        # Coordinates
+        ny, nx = map_shape
+        dy, dx = step_sizes
+        assert np.allclose(cm.x, np.tile(np.arange(nx) * dx, ny))
+        assert np.allclose(cm.y, np.sort(np.tile(np.arange(ny) * dy, nx)))
 
-    # With different vendor header as input
-    def test_get_phases_from_header(self):
-        pass
+        # Map shape and size
+        assert cm.shape == map_shape
+        assert cm.size == np.prod(map_shape)
+
+        # Attributes are within expected ranges or have a certain value
+        assert cm.prop["ind"].max() <= 100
+        assert cm.prop["rel"].max() <= 1
+        assert cm.prop["relx100"].max() <= 100
+        relx100 = (cm.prop["rel"] * 100).astype(int)
+        assert np.allclose(cm.prop["relx100"], relx100)
+
+        # Phase IDs
+        assert np.allclose(cm.phase_id, phase_id)
+
+        # Rotations
+        rot_unique = np.unique(cm.rotations.to_euler(), axis=0)
+        assert np.allclose(np.sort(rot_unique, axis=0), np.sort(example_rot, axis=0))
+
+        # Phases
+        assert cm.phases.size == 1
+        assert cm.phases.phase_ids == [1]
+        phase = cm.phases[1]
+        assert phase.name == "Nickel"
+        assert phase.symmetry.name == "432"
+
+    @pytest.mark.parametrize(
+        "angfile_emsoft, map_shape, step_sizes, phase_id, example_rot",
+        [
+            (
+                # Read by angfile_emsoft() via request.param (passed via `indirect`
+                # below)
+                (
+                    (10, 10),  # map_shape
+                    (4.5, 4.5),  # step_sizes
+                    np.concatenate(
+                        (
+                            np.ones(int(np.ceil((10 * 10) / 2))),
+                            np.ones(int(np.floor((10 * 10) / 2))) * 2,
+                        )
+                    ),  # phase_id
+                    np.array(
+                        [
+                            [1.895079, 0.739496, 1.413542],
+                            [1.897871, 0.742638, 1.413717],
+                        ]
+                    ),
+                ),
+                (10, 10),
+                (4.5, 4.5),
+                np.concatenate(
+                    (
+                        np.ones(int(np.ceil((10 * 10) / 2))),
+                        np.ones(int(np.floor((10 * 10) / 2))) * 2,
+                    )
+                ),
+                np.array(
+                    [[1.895079, 0.739496, 1.413542], [1.897871, 0.742638, 1.413717],]
+                ),
+            ),
+            (
+                (
+                    (23, 42),  # map_shape
+                    (10, 10),  # step_sizes
+                    np.concatenate(
+                        (
+                            np.ones(int(np.ceil((23 * 42) / 2))),
+                            np.ones(int(np.floor((23 * 42) / 2))) * 2,
+                        )
+                    ),  # phase_id
+                    np.array(
+                        [
+                            [1.621760, 2.368935, 4.559324],
+                            [1.604481, 2.367539, 4.541870],
+                        ]
+                    ),
+                ),
+                (23, 42),
+                (10, 10),
+                np.concatenate(
+                    (
+                        np.ones(int(np.ceil((23 * 42) / 2))),
+                        np.ones(int(np.floor((23 * 42) / 2))) * 2,
+                    )
+                ),
+                np.array(
+                    [[1.621760, 2.368935, 4.559324], [1.604481, 2.367539, 4.541870],]
+                ),
+            ),
+        ],
+        indirect=["angfile_emsoft"],
+    )
+    def test_load_ang_emsoft(
+        self, angfile_emsoft, map_shape, step_sizes, phase_id, example_rot,
+    ):
+        cm = load_ang(angfile_emsoft)
+
+        # Properties
+        assert list(cm.prop.keys()) == ["iq", "dp"]
+
+        # Coordinates
+        ny, nx = map_shape
+        dy, dx = step_sizes
+        assert np.allclose(cm.x, np.tile(np.arange(nx) * dx, ny))
+        assert np.allclose(cm.y, np.sort(np.tile(np.arange(ny) * dy, nx)))
+
+        # Map shape and size
+        assert cm.shape == map_shape
+        assert cm.size == np.prod(map_shape)
+
+        # Attributes are within expected ranges or have a certain value
+        assert cm.prop["iq"].max() <= 100
+        assert cm.prop["dp"].max() <= 1
+
+        # Phase IDs
+        assert np.allclose(cm.phase_id, phase_id)
+
+        # Rotations
+        rot_unique = np.unique(cm.rotations.to_euler(), axis=0)
+        assert np.allclose(np.sort(rot_unique, axis=0), np.sort(example_rot, axis=0))
+
+        # Phases (change if file header is changed!)
+        phases_in_data = cm["indexed"].phases_in_data
+        assert phases_in_data.size == 2
+        assert phases_in_data.phase_ids == [1, 2]
+        assert phases_in_data.names == ["austenite", "ferrite"]
+        assert [i.name for i in phases_in_data.symmetries] == ["432",] * 2
+
+    def test_get_header(self, temp_ang_file):
+        temp_ang_file.write(ANGFILE_ASTAR_HEADER)
+        temp_ang_file.close()
+        assert _get_header(open(temp_ang_file.name)) == [
+            "# File created from ACOM RES results",
+            "# ni-dislocations.res",
+            "#     ".rstrip(),
+            "#     ".rstrip(),
+            "# MaterialName      Nickel",
+            "# Formula",
+            "# Symmetry          43",
+            "# LatticeConstants  3.520  3.520  3.520  90.000  90.000  90.000",
+            "# NumberFamilies    4",
+            "# hklFamilies       1  1  1 1 0.000000",
+            "# hklFamilies       2  0  0 1 0.000000",
+            "# hklFamilies       2  2  0 1 0.000000",
+            "# hklFamilies       3  1  1 1 0.000000",
+            "#",
+            "# GRID: SqrGrid#",
+        ]
+
+    @pytest.mark.parametrize(
+        "expected_vendor, expected_columns, vendor_header",
+        [
+            (
+                "tsl",
+                [
+                    "iq",
+                    "ci",
+                    "phase_id",
+                    "unknown1",
+                    "fit",
+                    "unknown2",
+                    "unknown3",
+                    "unknown4",
+                    "unknown5",
+                ],
+                ANGFILE_TSL_HEADER,
+            ),
+            ("astar", ["ind", "rel", "phase_id", "relx100"], ANGFILE_ASTAR_HEADER),
+            ("emsoft", ["iq", "dp", "phase_id"], ANGFILE_EMSOFT_HEADER),
+        ],
+    )
+    def test_get_vendor_columns(
+        self, expected_vendor, expected_columns, vendor_header, temp_ang_file
+    ):
+        expected_columns = ["euler1", "euler2", "euler3", "x", "y"] + expected_columns
+        n_cols_file = len(expected_columns)
+
+        temp_ang_file.write(vendor_header)
+        temp_ang_file.close()
+        header = _get_header(open(temp_ang_file.name))
+        vendor, column_names = _get_vendor_columns(header, n_cols_file)
+
+        assert vendor == expected_vendor
+        assert column_names == expected_columns
+
+    @pytest.mark.parametrize("n_cols_file", [15, 20])
+    def test_get_vendor_columns_unknown(self, temp_ang_file, n_cols_file):
+        temp_ang_file.write("Look at me!\nI'm Mr. .ang file!\n")
+        temp_ang_file.close()
+        header = _get_header(open(temp_ang_file.name))
+        with pytest.warns(UserWarning, match=f"Number of columns, {n_cols_file}, "):
+            vendor, column_names = _get_vendor_columns(header, n_cols_file)
+            assert vendor == "unknown"
+            expected_columns = [
+                "euler1",
+                "euler2",
+                "euler3",
+                "x",
+                "y",
+                "unknown1",
+                "unknown2",
+                "phase_id",
+            ] + ["unknown" + str(i + 3) for i in range(n_cols_file - 8)]
+            assert column_names == expected_columns
+
+    @pytest.mark.parametrize(
+        "header_phase_part, expected_names, expected_symmetries",
+        [
+            (
+                [
+                    [
+                        "# MaterialName      Nickel",
+                        "# Formula",
+                        "# Symmetry          43",
+                        "# LatticeConstants  3.520  3.520  3.520  90.000  90.000  90.000",
+                    ],
+                    [
+                        "# MaterialName      Aluminium",
+                        "# Formula  Al",
+                        "# Symmetry          m3m",
+                        "# LatticeConstants  3.520  3.520  3.520  90.000  90.000  90.000",
+                    ],
+                ],
+                ["Nickel", "Aluminium"],
+                ["43", "m3m"],
+            ),
+        ],
+    )
+    def test_get_phases_from_header(
+        self, temp_ang_file, header_phase_part, expected_names, expected_symmetries
+    ):
+        hkl_families = [
+            "# NumberFamilies    4",
+            "# hklFamilies       1  1  1 1 0.000000",
+            "# hklFamilies       2  0  0 1 0.000000",
+            "# hklFamilies       2  2  0 1 0.000000",
+            "# hklFamilies       3  1  1 1 0.000000",
+        ]
+        header = [
+            "# File created from ACOM RES results",
+            "# ni-dislocations.res",
+            "#     ",
+            "#     ",
+        ]
+        for phase in header_phase_part:
+            header += phase + hkl_families
+        header += [
+            "#",
+            "# GRID: SqrGrid#",
+        ]
+        names, symmetries = _get_phases_from_header(header)
+
+        assert names == expected_names
+        assert symmetries == expected_symmetries
 
 
 class TestEMsoftReader:

--- a/orix/tests/test_orientation.py
+++ b/orix/tests/test_orientation.py
@@ -79,7 +79,6 @@ def test_orientation_persistence(symmetry, vector):
 @pytest.mark.filterwarnings(
     "ignore::DeprecationWarning"
 )  # speed=1 deprecated, will be removed in 0.3.0
-
 def test_distance_1(orientation, symmetry, expected):
     o = orientation.set_symmetry(symmetry)
     distance = o.distance(speed=1, verbose=True)

--- a/orix/tests/test_orientation.py
+++ b/orix/tests/test_orientation.py
@@ -1,8 +1,9 @@
-import pytest
 import numpy as np
+import pytest
 
 from orix.quaternion.orientation import Orientation, Misorientation
-from orix.quaternion.symmetry import *
+from orix.quaternion.symmetry import C1, C2, C3, C4, D2, D3, D6, T, O
+from orix.vector import Vector3d
 
 
 @pytest.fixture
@@ -142,11 +143,11 @@ def test_repr():
 def test_sub():
     m = Orientation([1, 1, 1, 1])  # any will do
     m.set_symmetry(C4)  # only one as it a O
-    mis = m - m  # this should give a set of zeroes
+    _ = m - m  # this should give a set of zeroes
     return None
 
 
 @pytest.mark.xfail(strict=True, reason=TypeError)
 def test_sub_orientation_and_other():
     m = Orientation([1, 1, 1, 1])  # any will do
-    mis = m - 3
+    _ = m - 3

--- a/orix/tests/test_phase_list.py
+++ b/orix/tests/test_phase_list.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 The pyXem developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class TestPhase:
+    pass
+
+
+class TestPhaseList:
+    pass

--- a/orix/tests/test_phase_list.py
+++ b/orix/tests/test_phase_list.py
@@ -20,6 +20,7 @@ import numpy as np
 import pytest
 
 from orix.crystal_map.phase_list import Phase, PhaseList
+from orix.quaternion.symmetry import Symmetry, O
 
 
 class TestPhase:
@@ -29,7 +30,7 @@ class TestPhase:
             (None, "m-3m", None, "tab:blue", (0.121568, 0.466666, 0.705882)),
             (None, "1", "blue", "b", (0, 0, 1)),
             ("al", "43", "xkcd:salmon", "xkcd:salmon", (1, 0.474509, 0.423529)),
-            ("My awes0me phase!", "432", "C1", "tab:orange", (1, 0.498039, 0.054901)),
+            ("My awes0me phase!", O, "C1", "tab:orange", (1, 0.498039, 0.054901)),
         ],
     )
     def test_init_phase(self, name, symmetry, color, color_alias, color_rgb):
@@ -39,6 +40,8 @@ class TestPhase:
 
         if symmetry == "43":
             symmetry = "432"
+        if isinstance(symmetry, Symmetry):
+            symmetry = symmetry.name
         assert p.symmetry.name == symmetry
 
         assert p.color == color_alias

--- a/orix/tests/test_phase_list.py
+++ b/orix/tests/test_phase_list.py
@@ -16,10 +16,156 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
+import numpy as np
+import pytest
+
+from orix.crystal_map.phase_list import Phase, PhaseList
+
 
 class TestPhase:
-    pass
+    @pytest.mark.parametrize(
+        "name, symmetry, color, color_alias, color_rgb",
+        [
+            (None, "m-3m", None, "tab:blue", (0.121568, 0.466666, 0.705882)),
+            (None, "1", "blue", "b", (0, 0, 1)),
+            ("al", "43", "xkcd:salmon", "xkcd:salmon", (1, 0.474509, 0.423529)),
+            ("My awes0me phase!", "432", "C1", "tab:orange", (1, 0.498039, 0.054901)),
+        ],
+    )
+    def test_init_phase(self, name, symmetry, color, color_alias, color_rgb):
+        p = Phase(name, symmetry, color)
+
+        assert p.name == str(name)
+
+        if symmetry == "43":
+            symmetry = "432"
+        assert p.symmetry.name == symmetry
+
+        assert p.color == color_alias
+        assert np.allclose(p.color_rgb, color_rgb, atol=1e-6)
+
+    @pytest.mark.parametrize("name", [None, "al", 1, np.arange(2)])
+    def test_set_phase_name(self, name):
+        p = Phase(name=name)
+        assert p.name == str(name)
+
+    @pytest.mark.parametrize(
+        "color, color_alias, color_rgb, fails",
+        [
+            ("some-color", None, None, True),
+            ("c1", None, None, True),
+            ("C1", "tab:orange", (1, 0.498039, 0.054901), False),
+        ],
+    )
+    def test_set_phase_color(self, color, color_alias, color_rgb, fails):
+        p = Phase()
+        if fails:
+            with pytest.raises(ValueError, match="Invalid RGBA argument: "):
+                p.color = color
+        else:
+            p.color = color
+            assert p.color == color_alias
+            assert np.allclose(p.color_rgb, color_rgb, atol=1e-6)
+
+    @pytest.mark.parametrize(
+        "symmetry, symmetry_name, fails",
+        [
+            (43, "432", False),
+            ("4321", None, True),
+            ("m3m", "m-3m", False),
+            ("43", "432", False),
+        ],
+    )
+    def test_set_phase_symmetry(self, symmetry, symmetry_name, fails):
+        p = Phase()
+        if fails:
+            with pytest.raises(ValueError, match=f"{symmetry} must be of type"):
+                p.symmetry = symmetry
+        else:
+            p.symmetry = symmetry
+            assert p.symmetry.name == symmetry_name
+
+    @pytest.mark.parametrize("name, symmetry", [("al", None), (None, "m-3m")])
+    def test_phase_repr_str(self, name, symmetry):
+        p = Phase(name=name, symmetry=symmetry, color="C0")
+        representation = (
+            "<name: "
+            + str(name)
+            + ". symmetry: "
+            + str(symmetry)
+            + ". color: tab:blue>"
+        )
+        assert p.__repr__() == representation
+        assert p.__str__() == representation
+
+    def test_phase_deepcopy(self):
+        p = Phase("al", "m-3m", "C1")
+        p2 = p.deepcopy()
+
+        assert p.__repr__() == "<name: al. symmetry: m-3m. color: tab:orange>"
+        p.name = "austenite"
+        p.symmetry = 43
+        p.color = "C2"
+
+        assert p.__repr__() == "<name: austenite. symmetry: 432. color: tab:green>"
+        assert p2.__repr__() == "<name: al. symmetry: m-3m. color: tab:orange>"
+
+    def test_phase_shallowcopy(self):
+        p = Phase("al", "m-3m", "C1")
+        p2 = p
+
+        p2.name = "austenite"
+        p2.symmetry = 43
+        p2.color = "C2"
+
+        assert p.__repr__() == p2.__repr__()
 
 
 class TestPhaseList:
-    pass
+    def test_init_phaselist(self):
+        pass
+
+    def test_get_phaselist_names(self):
+        pass
+
+    def test_get_phaselist_colors(self):
+        pass
+
+    def test_get_phaselist_colors_rgb(self):
+        pass
+
+    def test_get_phaselist_symmetries(self):
+        pass
+
+    def test_get_phaselist_size(self):
+        pass
+
+    def test_get_phaselist_ids(self):
+        pass
+
+    def test_get_phase_from_phaselist(self):
+        pass
+
+    def test_set_phase_in_phaselist(self):
+        pass
+
+    def test_del_phase_in_phaselist(self):
+        pass
+
+    def test_iterate_phaselist(self):
+        pass
+
+    def test_phaselist_repr(self):
+        pass
+
+    def test_phaselist_deepcopy(self):
+        pass
+
+    def test_phaselist_shallowcopy(self):
+        pass
+
+    def test_add_not_indexed_to_phaselist(self):
+        pass
+
+    def test_sort_phaselist_by_id(self):
+        pass

--- a/orix/tests/test_rotation.py
+++ b/orix/tests/test_rotation.py
@@ -1,7 +1,6 @@
 from math import cos, sin, tan, pi
 import numpy as np
 import pytest
-import itertools
 
 from orix.quaternion import Quaternion
 from orix.quaternion.rotation import Rotation

--- a/orix/tests/test_rotation_plot.py
+++ b/orix/tests/test_rotation_plot.py
@@ -19,7 +19,7 @@
 from matplotlib import pyplot as plt
 import numpy as np
 
-from orix.plot.rotation_plot import RotationPlot, RodriguesPlot, AxAnglePlot
+from orix.plot.rotation_plot import RodriguesPlot, AxAnglePlot
 from orix.quaternion.orientation import Misorientation
 from orix.quaternion.symmetry import D6, C1
 from orix.quaternion.orientation_region import OrientationRegion
@@ -57,4 +57,4 @@ def test_RotationPlot_methods():
 
 def test_full_region_plot():
     empty = OrientationRegion.from_symmetry(C1, C1)
-    plot_data = empty.get_plot_data()
+    _ = empty.get_plot_data()

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "scipy",
         "matplotlib",
         "tqdm",
+        "h5py",
     ],
     # fmt: on
     package_data={"": ["LICENSE", "readme.rst"], "orix": ["*.py"],},

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author=__author__,
     author_email=__author_email__,
     description=__description__,
-    long_description=open('README.rst').read(),
+    long_description=open("README.rst").read(),
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
@@ -22,15 +22,14 @@ setup(
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Physics",
     ],
-    packages=find_packages(exclude=['orix/tests']),
+    packages=find_packages(exclude=["orix/tests"]),
+    # fmt: off
     install_requires=[
         "numpy",
         "scipy",
         "matplotlib",
-        "tqdm"
+        "tqdm",
     ],
-    package_data={
-        "": ["LICENSE", "readme.rst"],
-        "orix": ["*.py"],
-    },
+    # fmt: on
+    package_data={"": ["LICENSE", "readme.rst"], "orix": ["*.py"],},
 )

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
         "numpy",
         "scipy",
         "matplotlib",
-        "tqdm"
+        "tqdm",
+        "h5py",
     ],
     package_data={
         "": ["LICENSE", "readme.rst"],

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,7 @@ setup(
         "numpy",
         "scipy",
         "matplotlib",
-        "tqdm",
-        "h5py",
+        "tqdm"
     ],
     package_data={
         "": ["LICENSE", "readme.rst"],


### PR DESCRIPTION
This PR aims to implement a light-weight `CrystalMap` class storing rotations, orientations, phases and any measurement properties/quality metrics. It is modelled on [MTEX' `EBSD` class](https://github.com/mtex-toolbox/mtex/blob/develop/EBSDAnalysis/%40EBSD/EBSD.m).

See #48 for initial discussions.

Started writing this a couple hours ago, highly work-in-progress, but decided to push now because of a https://github.com/pyxem/orix/issues/48#issuecomment-595195680 from @pc494 .

Briefly, I want initialization of a `CrystalMap` object to be done the following way:
```python
>>> import matplotlib.pyplot as plt
>>> from orix.crystal_map import CrystalMap
>>> from orix.io import load_ang, load_emsoft

>>> cm = load_ang("my_file.ang")

# Or reading of data from ANG/CTF/H5EBSD manually...

>>> cm = CrystalMap(
    rotations=euler,  # Rotation object
    x=x,  # Array of shape (# pixels, )
    y=y,  # Array of shape (# pixels, )
    phase_id=phase_id,  # Array of shape (# pixels, )
    phase_name=["austenite", "ferrite"],    
    symmetries=['432', '432'],
    props=properties,  # Dictionary of numpy arrays of shape (# pixels, )
)

>>> cm
Phase   Orientations       Name  Symmetry       Color
    1   5657 (48.4%)  austenite       432    tab:blue
    2   6043 (51.6%)    ferrite       432  tab:orange
Properties: iq, dp
Scan unit: um
```

This initialization will typically be done internally via loading of different data formats, however should be (fairly) easy to directly initialize as well.

To-do:
- [x] Determine necessary attributes (see class attribute list in code, e.g. what about MTEX' `mineral` attribute, which is the phase name?)
- [x] Determine shape of attributes
- [x] Figure out intuitive mapping between phases and crystal symmetries
- [x] Set crystal symmetries nicely (e.g. point group 432 is stored as 43 in ang files, this complicates finding the crystal symmetry from `orix.quaternion.symmetry._groups`: create aliases?)
- [x] Create a nice `__repr__` (copy MTEX'? Started on this)
- [x] Create pixel indexing function (like `Rotation` has) 
- [x] Explanatory docstring(s)
- [x] Make sound default values in `CrystalMap.__init__()`
- [x] Initialize `PhaseList` from a `list` of `Phase` objects
- [x] Account for n number of rotations per map pixel (when keeping n best matches after indexing)
- [x] Enable setting parameters (e.g. feature IDs) based upon masking (replace previous point)
- [x] Write tests
- [x] Write documentation -> notebook

Non-exhaustive to do-list, please add/remove/change/tick as you maintainers see fit. However, I think we should just add basic initialization in this PR, with other class methods in other PRs.