### PR TITLE
Minor clarity/syntax improvements

### DIFF
--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -50,6 +50,24 @@ from orix.quaternion.orientation_region import OrientationRegion
 
 
 def _distance(misorientation, verbose, split_size=100):
+    """ private function to find the symmetry reduced distance between all
+    pairs of (mis)orientations
+    
+    Parameters
+    ----------
+    misorientation : orix.Misorientation object
+        The misorientation to be considered.
+    verbose : bool
+        Output progress bar while computing.
+    split_size : int
+        Size of block to compute at a time.
+
+    Returns
+    -------
+    distance : np.array
+        2D matrix containing the angular distance between every
+        orientation, considering symmetries.
+    """
     num_orientations = misorientation.shape[0]
     S_1, S_2 = misorientation._symmetry
     distance = np.full(misorientation.shape + misorientation.shape, np.infty)

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -130,7 +130,7 @@ class Misorientation(Rotation):
         o_inside._symmetry = (Gl, Gr)
         return o_inside
 
-    def distance(self, speed=2, verbose=False, split_size=100):
+    def distance(self, verbose=False, split_size=100):
         """Symmetry reduced distance
 
         Compute the shortest distance between all orientations considering
@@ -138,8 +138,6 @@ class Misorientation(Rotation):
 
         Parameters
         ---------
-        speed : int
-            Variant of distance function to use.
         verbose : bool
             Output progress bar while computing.
         split_size : int
@@ -162,14 +160,7 @@ class Misorientation(Rotation):
         array([[3.14159265, 1.57079633],
                [1.57079633, 0.        ]])
         """
-        if speed == 1:
-            warnings.warn(
-                "This method is inferior and be removed in 0.3.0; use speed=2 instead",
-                RuntimeWarning,
-            )
-            distance = _distance_1(self, verbose)
-        else:
-            distance = _distance_2(self, verbose, split_size)
+        distance = _distance_2(self, verbose, split_size)
         return distance.reshape(self.shape + self.shape)
 
     def __repr__(self):
@@ -236,30 +227,6 @@ class Orientation(Misorientation):
             ).squeeze()
             return m_inside
         return NotImplemented
-
-
-def _distance_1(misorientation, verbose):
-
-    warnings.warn("Use _distance_2 instead", DeprecationWarning)
-    s_1, s_2 = misorientation._symmetry
-    distance = np.empty((misorientation.size, misorientation.size))
-    index_pairs = icombinations(range(misorientation.size), 2)
-    if verbose:
-        from tqdm import tqdm
-
-        index_pairs = tqdm(index_pairs, total=misorientation.size ** 2)
-    for i, j in index_pairs:
-        idxi = np.unravel_index(i, misorientation.shape)
-        idxj = np.unravel_index(j, misorientation.shape)
-        m_1, m_2 = misorientation[idxi], misorientation[idxj]
-        mis2orientation = s_2.outer(~m_1).outer(s_1).outer(s_1).outer(m_2).outer(s_2)
-
-        axis = (0, len(misorientation.shape) + 1, len(misorientation.shape) + 2, -1)
-        d = mis2orientation.angle.data.min(axis=axis)
-        distance[i, j] = d
-        distance[j, i] = d
-    return distance
-
 
 def _distance_2(misorientation, verbose, split_size=100):
     num_orientations = misorientation.shape[0]

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -48,6 +48,45 @@ from orix.quaternion.symmetry import C1
 from orix.quaternion.orientation_region import OrientationRegion
 
 
+def _distance(misorientation, verbose, split_size=100):
+    num_orientations = misorientation.shape[0]
+    S_1, S_2 = misorientation._symmetry
+    distance = np.full(misorientation.shape + misorientation.shape, np.infty)
+    split_size = split_size // S_1.shape[0]
+    outer_range = range(0, num_orientations, split_size)
+    if verbose:
+        from tqdm import tqdm
+
+        outer_range = tqdm(outer_range, total=np.ceil(num_orientations / split_size))
+    S_1_outer_S_1 = S_1.outer(S_1)
+
+    # Calculate the upper half of the distance matrix block by block
+    for start_index_b in outer_range:
+        # we use slice object for compactness
+        index_slice_b = slice(
+            start_index_b, min(num_orientations, start_index_b + split_size)
+        )
+        o_sub_b = misorientation[index_slice_b]
+        for start_index_a in range(0, start_index_b + split_size, split_size):
+            index_slice_a = slice(
+                start_index_a, min(num_orientations, start_index_a + split_size)
+            )
+            o_sub_a = misorientation[index_slice_a]
+            axis = (len(o_sub_a.shape), len(o_sub_a.shape) + 1)
+            mis2orientation = (~o_sub_a).outer(S_1_outer_S_1).outer(o_sub_b)
+            # This works through all the identity rotations
+            for s_2_1, s_2_2 in icombinations(S_2, 2):
+                m = s_2_1 * mis2orientation * s_2_2
+                angle = m.angle.data.min(axis=axis)
+                distance[index_slice_a, index_slice_b] = np.minimum(
+                    distance[index_slice_a, index_slice_b], angle
+                )
+    # Symmetrize the matrix for convenience
+    i_lower = np.tril_indices(distance.shape[0], -1)
+    distance[i_lower] = distance.T[i_lower]
+    return distance
+
+
 class Misorientation(Rotation):
     """Misorientation object.
 
@@ -160,7 +199,7 @@ class Misorientation(Rotation):
         array([[3.14159265, 1.57079633],
                [1.57079633, 0.        ]])
         """
-        distance = _distance_2(self, verbose, split_size)
+        distance = _distance(self, verbose, split_size)
         return distance.reshape(self.shape + self.shape)
 
     def __repr__(self):
@@ -227,41 +266,3 @@ class Orientation(Misorientation):
             ).squeeze()
             return m_inside
         return NotImplemented
-
-def _distance_2(misorientation, verbose, split_size=100):
-    num_orientations = misorientation.shape[0]
-    S_1, S_2 = misorientation._symmetry
-    distance = np.full(misorientation.shape + misorientation.shape, np.infty)
-    split_size = split_size // S_1.shape[0]
-    outer_range = range(0, num_orientations, split_size)
-    if verbose:
-        from tqdm import tqdm
-
-        outer_range = tqdm(outer_range, total=np.ceil(num_orientations / split_size))
-    S_1_outer_S_1 = S_1.outer(S_1)
-
-    # Calculate the upper half of the distance matrix block by block
-    for start_index_b in outer_range:
-        # we use slice object for compactness
-        index_slice_b = slice(
-            start_index_b, min(num_orientations, start_index_b + split_size)
-        )
-        o_sub_b = misorientation[index_slice_b]
-        for start_index_a in range(0, start_index_b + split_size, split_size):
-            index_slice_a = slice(
-                start_index_a, min(num_orientations, start_index_a + split_size)
-            )
-            o_sub_a = misorientation[index_slice_a]
-            axis = (len(o_sub_a.shape), len(o_sub_a.shape) + 1)
-            mis2orientation = (~o_sub_a).outer(S_1_outer_S_1).outer(o_sub_b)
-            # This works through all the identity rotations
-            for s_2_1, s_2_2 in icombinations(S_2, 2):
-                m = s_2_1 * mis2orientation * s_2_2
-                angle = m.angle.data.min(axis=axis)
-                distance[index_slice_a, index_slice_b] = np.minimum(
-                    distance[index_slice_a, index_slice_b], angle
-                )
-    # Symmetrize the matrix for convenience
-    i_lower = np.tril_indices(distance.shape[0], -1)
-    distance[i_lower] = distance.T[i_lower]
-    return distance

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -52,7 +52,7 @@ from orix.quaternion.orientation_region import OrientationRegion
 def _distance(misorientation, verbose, split_size=100):
     """ private function to find the symmetry reduced distance between all
     pairs of (mis)orientations
-    
+
     Parameters
     ----------
     misorientation : orix.Misorientation object
@@ -172,7 +172,7 @@ class Misorientation(Rotation):
         """
         symmetry_pairs = iproduct(Gl, Gr)
         if verbose:
-            symmetry_pairs = tqdm.tqdm(symmetry_pairs, total=Gl.size * Gr.size)
+            symmetry_pairs = tqdm(symmetry_pairs, total=Gl.size * Gr.size)
 
         orientation_region = OrientationRegion.from_symmetry(Gl, Gr)
         o_inside = self.__class__.identity(self.shape)

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -154,9 +154,8 @@ class Misorientation(Rotation):
         """
         symmetry_pairs = iproduct(Gl, Gr)
         if verbose:
-            import tqdm
-
             symmetry_pairs = tqdm.tqdm(symmetry_pairs, total=Gl.size * Gr.size)
+
         orientation_region = OrientationRegion.from_symmetry(Gl, Gr)
         o_inside = self.__class__.identity(self.shape)
         outside = np.ones(self.shape, dtype=bool)

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -41,6 +41,7 @@ from itertools import product as iproduct
 from itertools import combinations_with_replacement as icombinations
 import numpy as np
 import warnings
+from tqdm import tqdm
 
 
 from orix.quaternion.rotation import Rotation
@@ -55,9 +56,8 @@ def _distance(misorientation, verbose, split_size=100):
     split_size = split_size // S_1.shape[0]
     outer_range = range(0, num_orientations, split_size)
     if verbose:
-        from tqdm import tqdm
-
         outer_range = tqdm(outer_range, total=np.ceil(num_orientations / split_size))
+
     S_1_outer_S_1 = S_1.outer(S_1)
 
     # Calculate the upper half of the distance matrix block by block

--- a/orix/quaternion/orientation_region.py
+++ b/orix/quaternion/orientation_region.py
@@ -112,7 +112,6 @@ def get_proper_groups(Gl, Gr):
 
 class OrientationRegion(Rotation):
     """A set of :obj:`Rotation`s which are the normals of an orientation region.
-
     """
 
     @classmethod
@@ -177,6 +176,11 @@ class OrientationRegion(Rotation):
         return faces
 
     def __gt__(self, other):
+        """
+        overidden greater than method. Applying this to an Orientation
+        will return only orientations those that lie within the OrientationRegion
+        """
+
         c = Quaternion(self).dot_outer(Quaternion(other)).data
         inside = np.logical_or(
             np.all(np.greater_equal(c, -EPSILON), axis=0),

--- a/orix/quaternion/orientation_region.py
+++ b/orix/quaternion/orientation_region.py
@@ -127,8 +127,6 @@ class OrientationRegion(Rotation):
         s1, s2 = get_proper_groups(s1, s2)
         large_cell_normals = _get_large_cell_normals(s1, s2)
         disjoint = s1 & s2
-        # if s1._tuples == s2._tuples:
-        #     disjoint = disjoint.laue
         fundamental_sector = disjoint.fundamental_sector()
         fundamental_sector_normals = Rotation.from_neo_euler(
             AxAngle.from_axes_angles(fundamental_sector, np.pi)

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -355,9 +355,6 @@ class Rotation(Quaternion):
             )
             data = qalpha * qbeta * qgamma
 
-            if direction == "lab2crystal":
-                data = ~data
-
             rot = cls(data.data)
             rot.improper = zero
             return rot

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -330,6 +330,11 @@ class Rotation(Quaternion):
         direction : str
             'lab2crystal' or 'crystal2lab'
         """
+        if convention not in  ["bunge","Krakow_Hielscher"]:
+            raise ValuerError("The chosen convention is not one of the allowed options")
+        if direction not in ["lab2crystal", "crystal2lab"]:
+            raise ValueError("The chosen direction is not one of the allowed options")
+
         if convention == "Krakow_Hielscher":
             # To be applied to the data found at:
             # https://www.repository.cam.ac.uk/handle/1810/263510
@@ -349,47 +354,47 @@ class Rotation(Quaternion):
                 np.stack((np.cos(gamma / 2), zero, zero, np.sin(gamma / 2)), axis=-1)
             )
             data = qalpha * qbeta * qgamma
+
+            if direction == "lab2crystal":
+                data = ~data
+
             rot = cls(data.data)
             rot.improper = zero
             return rot
 
-        if convention != "bunge":
-            raise ValuerError("Only 'bunge' is an acceptable convention")
-        if direction not in ["lab2crystal", "crystal2lab"]:
-            raise ValueError("The chosen direction is not one of the allowed options")
+        elif convention == "bunge":
+            euler = np.array(euler)
+            n = euler.shape[:-1]
 
-        euler = np.array(euler)
-        n = euler.shape[:-1]
+            # Uses A.5 & A.6 from Modelling Simul. Mater. Sci. Eng. 23 (2015) 083501
 
-        # Uses A.5 & A.6 from Modelling Simul. Mater. Sci. Eng. 23 (2015) 083501
+            alpha = euler[..., 0]  # psi1
+            beta = euler[..., 1]  # Psi
+            gamma = euler[..., 2]  # psi3
 
-        alpha = euler[..., 0]  # psi1
-        beta = euler[..., 1]  # Psi
-        gamma = euler[..., 2]  # psi3
+            sigma = 0.5 * np.add(alpha, gamma)
+            delta = 0.5 * np.subtract(alpha, gamma)
+            c = np.cos(beta / 2)
+            s = np.sin(beta / 2)
 
-        sigma = 0.5 * np.add(alpha, gamma)
-        delta = 0.5 * np.subtract(alpha, gamma)
-        c = np.cos(beta / 2)
-        s = np.sin(beta / 2)
+            # Using P = 1 from A.6
+            q = np.zeros(n + (4,))
+            q[..., 0] = c * np.cos(sigma)
+            q[..., 1] = -s * np.cos(delta)
+            q[..., 2] = -s * np.sin(delta)
+            q[..., 3] = -c * np.sin(sigma)
 
-        # Using P = 1 from A.6
-        q = np.zeros(n + (4,))
-        q[..., 0] = c * np.cos(sigma)
-        q[..., 1] = -s * np.cos(delta)
-        q[..., 2] = -s * np.sin(delta)
-        q[..., 3] = -c * np.sin(sigma)
+            for i in [1, 2, 3, 0]:  # flip the zero element last
+                q[..., i] = np.where(q[..., 0] < 0, -q[..., i], q[..., i])
 
-        for i in [1, 2, 3, 0]:  # flip the zero element last
-            q[..., i] = np.where(q[..., 0] < 0, -q[..., i], q[..., i])
+            data = Quaternion(q)
 
-        data = Quaternion(q)
+            if direction == "lab2crystal":
+                data = ~data
 
-        if direction == "lab2crystal":
-            data = ~data
-
-        rot = cls(data.data)
-        rot.improper = np.zeros((n))
-        return rot
+            rot = cls(data.data)
+            rot.improper = np.zeros((n))
+            return rot
 
     @classmethod
     def identity(cls, shape=(1,)):

--- a/orix/tests/test_orientation.py
+++ b/orix/tests/test_orientation.py
@@ -55,7 +55,6 @@ def test_orientation_persistence(symmetry, vector):
     v2 = Vector3d(v2.data.round(4))
     assert v1._tuples == v2._tuples
 
-
 @pytest.mark.parametrize(
     "orientation, symmetry, expected",
     [
@@ -77,39 +76,9 @@ def test_orientation_persistence(symmetry, vector):
     ],
     indirect=["orientation"],
 )
-@pytest.mark.filterwarnings(
-    "ignore::DeprecationWarning"
-)  # speed=1 deprecated, will be removed in 0.3.0
-def test_distance_1(orientation, symmetry, expected):
+def test_distance(orientation, symmetry, expected):
     o = orientation.set_symmetry(symmetry)
-    distance = o.distance(speed=1, verbose=True)
-    assert np.allclose(distance, expected, atol=1e-3)
-
-
-@pytest.mark.parametrize(
-    "orientation, symmetry, expected",
-    [
-        ((1, 0, 0, 0), C1, [0]),
-        ([(1, 0, 0, 0), (0.7071, 0.7071, 0, 0)], C1, [[0, np.pi / 2], [np.pi / 2, 0]]),
-        ([(1, 0, 0, 0), (0.7071, 0.7071, 0, 0)], C4, [[0, np.pi / 2], [np.pi / 2, 0]]),
-        ([(1, 0, 0, 0), (0.7071, 0, 0, 0.7071)], C4, [[0, 0], [0, 0]]),
-        (
-            [
-                [(1, 0, 0, 0), (0.7071, 0, 0, 0.7071)],
-                [(0, 0, 0, 1), (0.9239, 0, 0, 0.3827)],
-            ],
-            C4,
-            [
-                [[[0, 0], [0, np.pi / 4]], [[0, 0], [0, np.pi / 4]]],
-                [[[0, 0], [0, np.pi / 4]], [[np.pi / 4, np.pi / 4], [np.pi / 4, 0]]],
-            ],
-        ),
-    ],
-    indirect=["orientation"],
-)
-def test_distance_2(orientation, symmetry, expected):
-    o = orientation.set_symmetry(symmetry)
-    distance = o.distance(speed=2, verbose=True)
+    distance = o.distance(verbose=True)
     assert np.allclose(distance, expected, atol=1e-3)
 
 


### PR DESCRIPTION
Clears up a few things that came up reading through the code:

- `.from_euler() ` has been shuffled about a bit to make it easier to read, no change to external functionality
- The old distance method has been removed as suggested when the new one was merged in (see #39)
- `tqdm` being available everywhere is exploited for some syntax clarity.
- adds some docstrings
