### PR TITLE
Add diffpy.structure.Structure to Phase object + update IO

### DIFF
--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -163,7 +163,7 @@ class CrystalMap:
         ...     phase_id=phase_id,
         ...     x=x,
         ...     y=y,
-        ...     phase_name=["austenite", "ferrite"],  # Overridden by Structure.title
+        ...     phase_name=["austenite", "ferrite"],  # Overwrites Structure.title
         ...     symmetry=["432", "432"],
         ...     structure=structures,
         ...     prop=properties,

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -137,6 +137,40 @@ class CrystalMap:
             phase.
         prop : dict of numpy.ndarray, optional
             Dictionary of properties of each data point.
+
+        Examples
+        --------
+        >>> from diffpy.structure import Atom, Lattice, Structure
+        >>> import numpy as np
+        >>> from orix.crystal_map import CrystalMap
+        >>> from orix.quaternion.rotation import Rotation
+        >>> euler1, euler2, euler3, x, y, iq, dp, phase_id = np.loadtxt(
+        ...     "/some/file.ang", unpack=True)
+        >>> euler_angles = np.column_stack((euler1, euler2, euler3))
+        >>> rotations = Rotation.from_euler(euler_angles)
+        >>> properties = {"iq": iq, "dp": dp}
+        >>> structures = [
+        ...     Structure(
+        ...         title="austenite",
+        ...         atoms=[Atom("fe", [0] * 3)],
+        ...         lattice=Lattice(0.360, 0.360, 0.360, 90, 90, 90)
+        ...     ),
+        ...     Structure(
+        ...         title="ferrite",
+        ...         atoms=[Atom("fe", [0] * 3)],
+        ...         lattice=Lattice(0.287, 0.287, 0.287, 90, 90, 90)
+        ...     )
+        ... ]
+        >>> cm = CrystalMap(
+        ...     rotations=rotations,
+        ...     phase_id=phase_id,
+        ...     x=x,
+        ...     y=y,
+        ...     phase_name=["austenite", "ferrite"],  # Overridden by Structure.title
+        ...     symmetry=["432", "432"],
+        ...     structure=structures,
+        ...     prop=properties,
+        ... )
         """
         # Set rotations
         if not isinstance(rotations, Rotation):

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -17,7 +17,6 @@
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
 import copy
-from typing import Any, Dict, List, Optional, Tuple, Union
 
 from diffpy.structure import Structure
 import numpy as np
@@ -88,17 +87,15 @@ class CrystalMap:
 
     def __init__(
         self,
-        rotations: Rotation,
-        phase_id: Optional[np.ndarray] = None,
-        x: Optional[np.ndarray] = None,
-        y: Optional[np.ndarray] = None,
-        z: Optional[np.ndarray] = None,
-        phase_name: Union[None, str, List[str]] = None,
-        symmetry: Union[
-            None, str, int, Symmetry, List[Union[str, list, Symmetry]]
-        ] = None,
-        structure: Union[None, Structure, List[Structure]] = None,
-        prop: Optional[Dict[str, np.ndarray]] = None,
+        rotations,
+        phase_id=None,
+        x=None,
+        y=None,
+        z=None,
+        phase_name=None,
+        symmetry=None,
+        structure=None,
+        prop=None,
     ):
         """
         Parameters
@@ -240,27 +237,27 @@ class CrystalMap:
         self._original_shape = self._data_shape_from_coordinates()
 
     @property
-    def id(self) -> np.ndarray:
+    def id(self):
         """ID of points in data."""
         return self._id[self.is_in_data]
 
     @property
-    def size(self) -> int:
+    def size(self):
         """Total number of points in data."""
         return np.count_nonzero(self.is_in_data)
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self):
         """Shape of points in data."""
         return self._data_shape_from_coordinates()
 
     @property
-    def ndim(self) -> int:
+    def ndim(self):
         """Number of data dimensions of points in data."""
         return len(self.shape)
 
     @property
-    def x(self) -> Union[None, np.ndarray]:
+    def x(self):
         """X coordinates of points in data."""
         if self._x is None or len(np.unique(self._x)) == 1:
             return None
@@ -268,7 +265,7 @@ class CrystalMap:
             return self._x[self.is_in_data]
 
     @property
-    def y(self) -> Union[None, np.ndarray]:
+    def y(self):
         """Y coordinates of points in data."""
         if self._y is None or len(np.unique(self._y)) == 1:
             return None
@@ -276,7 +273,7 @@ class CrystalMap:
             return self._y[self.is_in_data]
 
     @property
-    def z(self) -> Union[None, np.ndarray]:
+    def z(self):
         """Z coordinates of points in data."""
         if self._z is None or len(np.unique(self._z)) == 1:
             return None
@@ -284,31 +281,31 @@ class CrystalMap:
             return self._z[self.is_in_data]
 
     @property
-    def dx(self) -> float:
+    def dx(self):
         return self._step_size_from_coordinates(self._x)
 
     @property
-    def dy(self) -> float:
+    def dy(self):
         return self._step_size_from_coordinates(self._y)
 
     @property
-    def dz(self) -> float:
+    def dz(self):
         return self._step_size_from_coordinates(self._z)
 
     @property
-    def phase_id(self) -> np.ndarray:
+    def phase_id(self):
         """Phase IDs of points in data."""
         return self._phase_id[self.is_in_data]
 
     @phase_id.setter
-    def phase_id(self, value: Union[np.ndarray, int]):
+    def phase_id(self, value):
         """Set phase ID of points in data by passing an int to `value`."""
         self._phase_id[self.is_in_data] = value
         if value == -1 and "not_indexed" not in self.phases.names:
             self.phases.add_not_indexed()
 
     @property
-    def phases_in_data(self) -> PhaseList:
+    def phases_in_data(self):
         """List of phases in data.
 
         Needed because it can be useful to have phases not in data but in
@@ -325,17 +322,17 @@ class CrystalMap:
             return phase_list
 
     @property
-    def rotations(self) -> Rotation:
+    def rotations(self):
         """Rotations in data."""
         return self._rotations[self.is_in_data]
 
     @property
-    def rotations_per_point(self) -> int:
+    def rotations_per_point(self):
         """Number of rotations per data point in data."""
         return self.rotations.size // self.is_indexed.size
 
     @property
-    def rotations_shape(self) -> tuple:
+    def rotations_shape(self):
         """Shape of rotation object.
 
         Map shape and possible multiple rotations per point are accounted
@@ -344,7 +341,7 @@ class CrystalMap:
         return tuple(i for i in self.shape + (self.rotations_per_point,) if i != 1)
 
     @property
-    def orientations(self) -> Orientation:
+    def orientations(self):
         """Rotations, respecting symmetry, in data."""
         # TODO: Consider whether orientations should be calculated upon
         #  loading since computing orientations are slow (should benefit
@@ -364,17 +361,17 @@ class CrystalMap:
             )
 
     @property
-    def is_indexed(self) -> bool:
+    def is_indexed(self):
         """Whether points in data are indexed."""
         return self.phase_id != -1
 
     @property
-    def all_indexed(self) -> bool:
+    def all_indexed(self):
         """Whether all points in data are indexed."""
         return np.count_nonzero(self.is_indexed) == self.is_indexed.size
 
     @property
-    def prop(self) -> CrystalMapProperties:
+    def prop(self):
         """:class:`~orix.crystal_map.CrystalMapProperties` dictionary with
         data properties in each data point.
         """
@@ -383,28 +380,28 @@ class CrystalMap:
         return self._prop
 
     @property
-    def _coordinates(self) -> dict:
+    def _coordinates(self):
         """Dictionary of coordinates of points in data."""
         # TODO: Make this "dynamic"/dependable when enabling specimen
         #  reference frame
         return {"z": self.z, "y": self.y, "x": self.x}
 
     @property
-    def _step_sizes(self) -> dict:
+    def _step_sizes(self):
         """Dictionary of step sizes of dimensions in data."""
         # TODO: Make this "dynamic"/dependable when enabling specimen
         #  reference frame
         return {"z": self.dz, "y": self.dy, "x": self.dx}
 
     @property
-    def _coordinate_axes(self) -> dict:
+    def _coordinate_axes(self):
         """Dictionary of which data axis corresponds to which cartesian
         coordinate.
         """
         present_coordinates = [k for k, v in self._coordinates.items() if v is not None]
         return {i: coord for i, coord in zip(range(self.ndim), present_coordinates)}
 
-    def __getattr__(self, item: str):
+    def __getattr__(self, item):
         """Get an attribute in the `prop` dictionary directly from the
         CrystalMap object.
 
@@ -417,7 +414,7 @@ class CrystalMap:
         else:
             return object.__getattribute__(self, item)
 
-    def __setattr__(self, name: str, value: Any):
+    def __setattr__(self, name, value):
         """Set a class instance attribute."""
         if hasattr(self, "_prop") and name in self._prop:
             # Calls CrystalMapProperties.__setitem__()
@@ -425,7 +422,7 @@ class CrystalMap:
         else:
             return object.__setattr__(self, name, value)
 
-    def __getitem__(self, key: Union[str, slice, tuple, int, np.ndarray]):
+    def __getitem__(self, key):
         """Get a masked copy of the CrystalMap object.
 
         Parameters
@@ -585,7 +582,7 @@ class CrystalMap:
 
         return new_map
 
-    def __repr__(self) -> str:
+    def __repr__(self):
         """Print a nice representation of the data."""
         if self.size == 0:
             return "No data."
@@ -642,12 +639,7 @@ class CrystalMap:
 
         return representation
 
-    def get_map_data(
-        self,
-        item: Union[str, np.ndarray],
-        decimals: int = 3,
-        fill_value: Union[None, int, float] = None,
-    ) -> np.ndarray:
+    def get_map_data(self, item, decimals=3, fill_value=None):
         """Return an array of a class instance attribute, with values
         equal to ``False`` in ``self.is_in_data`` set to `fill_value`, of
         map data shape.
@@ -741,7 +733,7 @@ class CrystalMap:
         return copy.deepcopy(self)
 
     @staticmethod
-    def _step_size_from_coordinates(coordinates: np.ndarray) -> float:
+    def _step_size_from_coordinates(coordinates):
         """Return step size in input `coordinates` array.
 
         Parameters
@@ -760,7 +752,7 @@ class CrystalMap:
             step_size = unique_sorted[1] - unique_sorted[0]
         return step_size
 
-    def _data_slices_from_coordinates(self) -> Tuple[slice, ...]:
+    def _data_slices_from_coordinates(self):
         """Return a tuple of slices defining the current data extent in
         all directions.
 
@@ -783,7 +775,7 @@ class CrystalMap:
 
         return tuple(slices)
 
-    def _data_shape_from_coordinates(self) -> Tuple[int, ...]:
+    def _data_shape_from_coordinates(self):
         """Return data shape based upon coordinate arrays.
 
         Returns

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -87,6 +87,25 @@ class Phase:
         color : str, optional
             Phase color. If None is passed (default), it is set to
             'tab:blue' (first among the default Matplotlib colors).
+
+        Examples
+        --------
+        >>> from diffpy.structure import Atom, Lattice, Structure
+        >>> from orix.crystal_map import Phase
+        >>> p = Phase(
+        ...     name="al",
+        ...     symmetry="m-3m",
+        ...     structure=Structure(
+        ...         atoms=[Atom("al", [0, 0, 0])],
+        ...         lattice=Lattice(0.405, 0.405, 0.405, 90, 90, 90)
+        ...     )
+        ... )
+        >>> p
+        <name: al. symmetry: m-3m. color: tab:blue>
+        >>> p.structure
+        [al   0.000000 0.000000 0.000000 1.0000]
+        >>> p.structure.lattice
+        Lattice(a=0.405, b=0.405, c=0.405, alpha=90, beta=90, gamma=90)
         """
         self.structure = structure if structure is not None else Structure()
         if name is not None:
@@ -245,6 +264,31 @@ class PhaseList:
             is passed (default), a default
             :class:`diffpy.structure.Structure` object is created for each
             phase.
+
+        Examples
+        --------
+        >>> from diffpy.structure import Atom, Lattice, Structure
+        >>> from orix.crystal_map import Phase, PhaseList
+        >>> pl = PhaseList(
+        ...     names=["al", "cu"],
+        ...     symmetries=["m-3m"] * 2,
+        ...     structures=[
+        ...         Structure(
+        ...             atoms=[Atom("al", [0] * 3)],
+        ...             lattice=Lattice(0.405, 0.405, 0.405, 90, 90, 90)
+        ...         ),
+        ...         Structure(
+        ...             atoms=[Atom("cu", [0] * 3)],
+        ...             lattice=Lattice(0.361, 0.361, 0.361, 90, 90, 90)
+        ...         ),
+        ...     ]
+        ... )
+        >>> pl
+        Id  Name  Symmetry       Color
+         0    al      m-3m    tab:blue
+         1    cu      m-3m  tab:orange
+        >>> pl["al"].structure
+        [al   0.000000 0.000000 0.000000 1.0000]
         """
         d = {}
         if isinstance(phases, list):

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -122,6 +122,8 @@ class Phase:
     def structure(self, value: Structure):
         """Set phase structure."""
         if isinstance(value, Structure):
+            if value.title == "" and hasattr(self, "_structure"):
+                value.title = self.name
             self._structure = value
         else:
             raise ValueError(f"{value} must be a diffpy.structure.Structure object.")
@@ -424,7 +426,7 @@ class PhaseList:
         """List of phase structures."""
         return [phase.structure for _, phase in self]
 
-    def __getitem__(self, key: Union[int, str, slice, Tuple, List[int], np.ndarray]):
+    def __getitem__(self, key: Union[int, str, slice, Tuple, List[int]]):
         """Return a PhaseList or a Phase object, depending on the number
         of phases in the list matches the `key`.
 
@@ -518,8 +520,8 @@ class PhaseList:
         else:
             return PhaseList(d)
 
-    def __setitem__(self, key: str, value: Union[None, str, Symmetry]):
-        """Add a phase to the list with a name and symmetry."""
+    def __setitem__(self, key: Union[int, str], value: Union[None, str, Symmetry]):
+        """Add a phase to the list with a name, symmetry and structure."""
         if key not in self.names:
             # Make sure the new phase gets a new color
             color_new = None

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -19,8 +19,10 @@
 from collections import OrderedDict
 import copy
 from itertools import islice
-from numbers import Number
 
+from typing import Any, List, Optional, Tuple, Union
+
+from diffpy.structure import Structure
 import matplotlib.colors as mcolors
 import numpy as np
 
@@ -33,8 +35,8 @@ for k, v in {**mcolors.BASE_COLORS, **mcolors.CSS4_COLORS}.items():
 ALL_COLORS.update(mcolors.XKCD_COLORS)
 
 # Point group alias mapping
-# Why is this needed? Well, e.g. in EDAX TSL OIM Analysis 7.2, point group 432 is
-# entered as 43...
+# Why is this needed? Well, e.g. in EDAX TSL OIM Analysis 7.2, point
+# group 432 is entered as 43...
 POINT_GROUP_ALIASES = {
     "432": "43",
 }
@@ -52,6 +54,8 @@ class Phase:
         RGB values of phase color, obtained from the color name.
     name : str
         Phase name.
+    structure : diffpy.structure.Structure
+        Unit cell with atoms and lattice.
     symmetry : orix.quaternion.symmetry.Symmetry
         Crystal symmetries of the phase.
 
@@ -59,51 +63,69 @@ class Phase:
     -------
     deepcopy()
         Return a deep copy using :py:func:`~copy.deepcopy` function.
-
     """
 
-    def __init__(self, name=None, symmetry=None, color=None):
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        structure: Optional[Structure] = None,
+        symmetry: Union[None, str, int, Symmetry] = None,
+        color: Optional[str] = None,
+    ):
         """
         Parameters
         ----------
         name : str, optional
-            Phase name. If ``None`` is passed (default), name is set to
-            ``None``.
+            Phase name. Overwrites the name in the `structure` object.
+        structure : diffpy.structure.Structure, optional
+            Unit cell with atoms and a lattice. If None is passed
+            (default), a default :class:`diffpy.structure.Structure`
+            object is created.
         symmetry : str or orix.quaternion.symmetry.Symmetry, optional
-            Point group of phase's crystal symmetry. If ``None`` is passed
-            (default), it set to ``None``.
+            Point group of phase's crystal symmetry. If None is passed
+            (default), it set to None.
         color : str, optional
-            Phase color. If ``None`` is passed (default), it is set to
+            Phase color. If None is passed (default), it is set to
             'tab:blue' (first among the default Matplotlib colors).
-
         """
-        self.name = name
+        self.structure = structure if structure is not None else Structure()
+        if name is not None:
+            self.name = name
         self.symmetry = symmetry
-        if color is None:
-            self.color = "tab:blue"
-        else:
-            self.color = color
+        self.color = color if color is not None else "tab:blue"
 
     @property
-    def name(self):
+    def structure(self) -> Structure:
+        """Phase unit cell."""
+        return self._structure
+
+    @structure.setter
+    def structure(self, value: Structure):
+        """Set phase structure."""
+        if isinstance(value, Structure):
+            self._structure = value
+        else:
+            raise ValueError(f"{value} must be a diffpy.structure.Structure object.")
+
+    @property
+    def name(self) -> str:
         """Phase name."""
-        return self._name
+        return self.structure.title
 
     @name.setter
-    def name(self, value):
+    def name(self, value: Any):
         """Set phase name as string."""
-        self._name = str(value)
+        self.structure.title = str(value)
 
     @property
-    def color(self):
+    def color(self) -> str:
         """Name of phase color."""
         return self._color
 
     @color.setter
-    def color(self, value):
+    def color(self, value: str):
         """Set phase color from something considered a valid color by
         :func:`matplotlib.colors.is_color_like`.
-
         """
         value_hex = mcolors.to_hex(value)
         for name, color_hex in ALL_COLORS.items():
@@ -112,19 +134,19 @@ class Phase:
                 break
 
     @property
-    def color_rgb(self):
+    def color_rgb(self) -> Tuple[float]:
         """Phase color as RGB tuple."""
         return mcolors.to_rgb(self.color)
 
     @property
-    def symmetry(self):
+    def symmetry(self) -> Union[None, Symmetry]:
         """Crystal symmetry of phase."""
         return self._symmetry
 
     @symmetry.setter
-    def symmetry(self, value):
+    def symmetry(self, value: Union[None, int, str, Symmetry]):
         """Set crystal symmetry of phase."""
-        if isinstance(value, Number):
+        if isinstance(value, int):
             value = str(value)
         if isinstance(value, str):
             for correct, alias in POINT_GROUP_ALIASES.items():
@@ -143,7 +165,7 @@ class Phase:
         else:
             self._symmetry = value
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.symmetry:
             symmetry_name = self.symmetry.name
         else:
@@ -169,9 +191,12 @@ class PhaseList:
     names : list of str
         List of phase names.
     phase_ids : list of int
-        List of unique phase indices in a crystallographic map as imported.
+        List of unique phase indices in a crystallographic map as
+        imported.
     size : int
         Number of phases in list.
+    structures : list of diffpy.structure.Structure
+        List of unit cells with atoms and the lattice of phase.
     symmetries : list of orix.quaternion.symmetry.Symmetry
         List of phase crystal symmetries.
 
@@ -185,21 +210,28 @@ class PhaseList:
         Get phase ID from phase name.
     sort_by_id()
         Sort list according to phase ID.
-
     """
 
     def __init__(
-        self, phases=None, names=None, symmetries=None, colors=None, phase_ids=None
+        self,
+        phases: Union[None, Phase, List[Phase], dict] = None,
+        names: Union[None, str, List[str]] = None,
+        symmetries: Union[
+            None, str, int, Symmetry, List[Union[str, int, Symmetry]]
+        ] = None,
+        colors: Union[None, str, List[str]] = None,
+        phase_ids: Union[None, int, List[int], np.ndarray] = None,
+        structures: Union[None, Structure, List[Structure]] = None,
     ):
         """
         Parameters
         ----------
         phases : orix.crystal_map.Phase, a list of orix.crystal_map.Phase\
                 or a dictionary of orix.crystal_map.Phase, optional
-            A list or dict of phases or a single phase. The other arguments
-            are ignored if this is passed.
+            A list or dict of phases or a single phase. The other
+            arguments are ignored if this is passed.
         names : str or list of str, optional
-            Phase names.
+            Phase names. Overwrites the names in the `structure` objects.
         symmetries : str, int, orix.quaternion.symmetry.Symmetry or list\
                 of str, int or orix.quaternion.symmetry.Symmetry, optional
             Point group symmetries.
@@ -207,7 +239,12 @@ class PhaseList:
             Phase colors.
         phase_ids : int, list of int or numpy.ndarray of int, optional
             Phase IDs.
-
+        structures : diffpy.structure.Structure or list of
+                diffpy.structure.Structure, optional
+            Unit cells with atoms and a lattice of each phase. If None
+            is passed (default), a default
+            :class:`diffpy.structure.Structure` object is created for each
+            phase.
         """
         d = {}
         if isinstance(phases, list):
@@ -229,7 +266,8 @@ class PhaseList:
                 phase_ids = 0
             d = {phase_ids: phases}
         else:
-            # Ensure possible single strings have iterables of length 1
+            # Ensure possible single strings or single objects have
+            # iterables of length 1
             if isinstance(names, str):
                 names = list((names,))
             if isinstance(symmetries, str) or isinstance(symmetries, Symmetry):
@@ -237,14 +275,17 @@ class PhaseList:
             if isinstance(colors, str) or isinstance(colors, tuple):
                 colors = list((colors,))
             if isinstance(phase_ids, int):
-                phase_ids = [
-                    phase_ids,
-                ]
+                phase_ids = [phase_ids]
+            if isinstance(structures, Structure):
+                structures = [structures]
 
             # Get the maximum number of entries in the input lists (also
             # handling the case where some lists are None)
             max_entries = max(
-                [len(i) if i is not None else 0 for i in [names, symmetries, phase_ids]]
+                [
+                    len(i) if i is not None else 0
+                    for i in [names, symmetries, phase_ids, structures]
+                ]
             )
 
             if phase_ids is None:
@@ -288,7 +329,15 @@ class PhaseList:
                     phase_id = max(phase_ids) + phase_id_iter + 1
                     phase_id_iter += 1
 
-                d[phase_id] = Phase(name=name, symmetry=symmetry, color=color)
+                # Get a structure or None
+                try:
+                    structure = structures[i]
+                except (IndexError, TypeError):
+                    structure = None
+
+                d[phase_id] = Phase(
+                    name=name, symmetry=symmetry, color=color, structure=structure
+                )
 
                 # To ensure color aliases are added to `used_colors`
                 used_colors.append(d[phase_id].color)
@@ -297,36 +346,41 @@ class PhaseList:
         self._dict = OrderedDict(sorted(d.items()))
 
     @property
-    def names(self):
+    def names(self) -> List[str]:
         """List of phase names in the list."""
         return [phase.name for _, phase in self]
 
     @property
-    def symmetries(self):
+    def symmetries(self) -> List[Union[None, Symmetry]]:
         """List of crystal symmetries of phases in the list."""
         return [phase.symmetry for _, phase in self]
 
     @property
-    def colors(self):
+    def colors(self) -> List[str]:
         """List of phase color names in the list."""
         return [phase.color for _, phase in self]
 
     @property
-    def colors_rgb(self):
+    def colors_rgb(self) -> List[Tuple[float]]:
         """List of phase color RGB values in the list."""
         return [phase.color_rgb for _, phase in self]
 
     @property
-    def size(self):
+    def size(self) -> int:
         """Number of phases in the list."""
         return len(self._dict.items())
 
     @property
-    def phase_ids(self):
+    def phase_ids(self) -> List[int]:
         """Unique phase IDs in the list of phases."""
         return list(self._dict.keys())
 
-    def __getitem__(self, key):
+    @property
+    def structures(self) -> List[Structure]:
+        """List of phase structures."""
+        return [phase.structure for _, phase in self]
+
+    def __getitem__(self, key: Union[int, str, slice, Tuple, List[int], np.ndarray]):
         """Return a PhaseList or a Phase object, depending on the number
         of phases in the list matches the `key`.
 
@@ -367,7 +421,6 @@ class PhaseList:
         Id  Name  Symmetry  Color
         0   a     1         tab:blue
         1   b     3         tab:orange
-
         """
         # Make key iterable if it isn't already
         if (
@@ -386,7 +439,8 @@ class PhaseList:
             and isinstance(key_iter[0], str)
             or (isinstance(key_iter, list) and isinstance(key_iter[0], str))
         ):
-            for key_name in list(set(key_iter)):  # Use set to remove duplicates
+            # Use set to remove duplicates
+            for key_name in list(set(key_iter)):
                 for i, phase in self._dict.items():
                     if key_name == phase.name:
                         d[i] = phase
@@ -405,7 +459,8 @@ class PhaseList:
             ids_in_slice = [i for i in sliced_arr if i in self.phase_ids]
             d = {i: self._dict[i] for i in ids_in_slice}
 
-        # Raise KeyError if key is missing (not in the container), per Python docs:
+        # Raise KeyError if key is missing (not in the container), per
+        # Python docs:
         # https://docs.python.org/3/reference/datamodel.html#object.__getitem__
         if d == {}:
             raise KeyError(f"{key} was not found in the phase list.")
@@ -419,7 +474,7 @@ class PhaseList:
         else:
             return PhaseList(d)
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: Union[None, str, Symmetry]):
         """Add a phase to the list with a name and symmetry."""
         if key not in self.names:
             # Make sure the new phase gets a new color
@@ -439,14 +494,13 @@ class PhaseList:
         else:
             raise ValueError(f"{key} is already in the phase list {self.names}.")
 
-    def __delitem__(self, key):
+    def __delitem__(self, key: Union[int, str]):
         """Delete a phase from the phase list.
 
         Parameters
         ----------
         key : int or str
             ID or name of a phase in the phase list.
-
         """
         if isinstance(key, int):
             self._dict.pop(key)
@@ -463,14 +517,13 @@ class PhaseList:
         else:
             raise TypeError(f"{key} is an invalid phase.")
 
-    def __iter__(self):
+    def __iter__(self) -> Tuple[int, Phase]:
         """Return a tuple with phase ID and Phase object, in that order.
-
         """
         for phase_id, phase in self._dict.items():
             yield phase_id, phase
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.size == 0:
             return "No phases."
 
@@ -519,9 +572,8 @@ class PhaseList:
     def add_not_indexed(self):
         """Add a dummy phase to assign to not indexed data points.
 
-        The phase, named "not_indexed", has a "symmetry" equal to None, and
-        a white color when plotted.
-
+        The phase, named "not_indexed", has a "symmetry" equal to None,
+        and a white color when plotted.
         """
         self._dict[-1] = Phase(name="not_indexed", symmetry=None, color="white")
         self.sort_by_id()
@@ -530,14 +582,13 @@ class PhaseList:
         """Sort list according to phase ID."""
         self._dict = OrderedDict(sorted(self._dict.items()))
 
-    def id_from_name(self, name):
+    def id_from_name(self, name: str) -> int:
         """Get phase ID from phase name.
 
         Parameters
         ----------
         name : str
             Phase name.
-
         """
         for phase_id, phase in self:
             if name == phase.name:

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -20,8 +20,6 @@ from collections import OrderedDict
 import copy
 from itertools import islice
 
-from typing import Any, List, Optional, Tuple, Union
-
 from diffpy.structure import Structure
 import matplotlib.colors as mcolors
 import numpy as np
@@ -65,13 +63,7 @@ class Phase:
         Return a deep copy using :py:func:`~copy.deepcopy` function.
     """
 
-    def __init__(
-        self,
-        name: Optional[str] = None,
-        structure: Optional[Structure] = None,
-        symmetry: Union[None, str, int, Symmetry] = None,
-        color: Optional[str] = None,
-    ):
+    def __init__(self, name=None, structure=None, symmetry=None, color=None):
         """
         Parameters
         ----------
@@ -114,12 +106,12 @@ class Phase:
         self.color = color if color is not None else "tab:blue"
 
     @property
-    def structure(self) -> Structure:
+    def structure(self):
         """Phase unit cell."""
         return self._structure
 
     @structure.setter
-    def structure(self, value: Structure):
+    def structure(self, value):
         """Set phase structure."""
         if isinstance(value, Structure):
             if value.title == "" and hasattr(self, "_structure"):
@@ -129,22 +121,22 @@ class Phase:
             raise ValueError(f"{value} must be a diffpy.structure.Structure object.")
 
     @property
-    def name(self) -> str:
+    def name(self):
         """Phase name."""
         return self.structure.title
 
     @name.setter
-    def name(self, value: Any):
+    def name(self, value):
         """Set phase name as string."""
         self.structure.title = str(value)
 
     @property
-    def color(self) -> str:
+    def color(self):
         """Name of phase color."""
         return self._color
 
     @color.setter
-    def color(self, value: str):
+    def color(self, value):
         """Set phase color from something considered a valid color by
         :func:`matplotlib.colors.is_color_like`.
         """
@@ -155,17 +147,17 @@ class Phase:
                 break
 
     @property
-    def color_rgb(self) -> Tuple[float]:
+    def color_rgb(self):
         """Phase color as RGB tuple."""
         return mcolors.to_rgb(self.color)
 
     @property
-    def symmetry(self) -> Union[None, Symmetry]:
+    def symmetry(self):
         """Crystal symmetry of phase."""
         return self._symmetry
 
     @symmetry.setter
-    def symmetry(self, value: Union[None, int, str, Symmetry]):
+    def symmetry(self, value):
         """Set crystal symmetry of phase."""
         if isinstance(value, int):
             value = str(value)
@@ -186,7 +178,7 @@ class Phase:
         else:
             self._symmetry = value
 
-    def __repr__(self) -> str:
+    def __repr__(self):
         if self.symmetry:
             symmetry_name = self.symmetry.name
         else:
@@ -235,14 +227,12 @@ class PhaseList:
 
     def __init__(
         self,
-        phases: Union[None, Phase, List[Phase], dict] = None,
-        names: Union[None, str, List[str]] = None,
-        symmetries: Union[
-            None, str, int, Symmetry, List[Union[str, int, Symmetry]]
-        ] = None,
-        colors: Union[None, str, List[str]] = None,
-        phase_ids: Union[None, int, List[int], np.ndarray] = None,
-        structures: Union[None, Structure, List[Structure]] = None,
+        phases=None,
+        names=None,
+        symmetries=None,
+        colors=None,
+        phase_ids=None,
+        structures=None,
     ):
         """
         Parameters
@@ -392,41 +382,41 @@ class PhaseList:
         self._dict = OrderedDict(sorted(d.items()))
 
     @property
-    def names(self) -> List[str]:
+    def names(self):
         """List of phase names in the list."""
         return [phase.name for _, phase in self]
 
     @property
-    def symmetries(self) -> List[Union[None, Symmetry]]:
+    def symmetries(self):
         """List of crystal symmetries of phases in the list."""
         return [phase.symmetry for _, phase in self]
 
     @property
-    def colors(self) -> List[str]:
+    def colors(self):
         """List of phase color names in the list."""
         return [phase.color for _, phase in self]
 
     @property
-    def colors_rgb(self) -> List[Tuple[float]]:
+    def colors_rgb(self):
         """List of phase color RGB values in the list."""
         return [phase.color_rgb for _, phase in self]
 
     @property
-    def size(self) -> int:
+    def size(self):
         """Number of phases in the list."""
         return len(self._dict.items())
 
     @property
-    def phase_ids(self) -> List[int]:
+    def phase_ids(self):
         """Unique phase IDs in the list of phases."""
         return list(self._dict.keys())
 
     @property
-    def structures(self) -> List[Structure]:
+    def structures(self):
         """List of phase structures."""
         return [phase.structure for _, phase in self]
 
-    def __getitem__(self, key: Union[int, str, slice, Tuple, List[int]]):
+    def __getitem__(self, key):
         """Return a PhaseList or a Phase object, depending on the number
         of phases in the list matches the `key`.
 
@@ -520,7 +510,7 @@ class PhaseList:
         else:
             return PhaseList(d)
 
-    def __setitem__(self, key: Union[int, str], value: Union[None, str, Symmetry]):
+    def __setitem__(self, key, value):
         """Add a phase to the list with a name, symmetry and structure."""
         if key not in self.names:
             # Make sure the new phase gets a new color
@@ -540,7 +530,7 @@ class PhaseList:
         else:
             raise ValueError(f"{key} is already in the phase list {self.names}.")
 
-    def __delitem__(self, key: Union[int, str]):
+    def __delitem__(self, key):
         """Delete a phase from the phase list.
 
         Parameters
@@ -563,13 +553,13 @@ class PhaseList:
         else:
             raise TypeError(f"{key} is an invalid phase.")
 
-    def __iter__(self) -> Tuple[int, Phase]:
+    def __iter__(self):
         """Return a tuple with phase ID and Phase object, in that order.
         """
         for phase_id, phase in self._dict.items():
             yield phase_id, phase
 
-    def __repr__(self) -> str:
+    def __repr__(self):
         if self.size == 0:
             return "No phases."
 
@@ -628,7 +618,7 @@ class PhaseList:
         """Sort list according to phase ID."""
         self._dict = OrderedDict(sorted(self._dict.items()))
 
-    def id_from_name(self, name: str) -> int:
+    def id_from_name(self, name):
         """Get phase ID from phase name.
 
         Parameters

--- a/orix/io/__init__.py
+++ b/orix/io/__init__.py
@@ -31,7 +31,7 @@ from orix.io.emsoft_h5ebsd import load_emsoft
 from orix.io.ang import load_ang
 
 
-def loadang(file_string: str):
+def loadang(file_string):
     """Load ``.ang`` files.
 
     Parameters
@@ -53,7 +53,7 @@ def loadang(file_string: str):
     return rotation
 
 
-def loadctf(file_string: str):
+def loadctf(file_string):
     """Load ``.ang`` files.
 
     Parameters

--- a/orix/io/ang.py
+++ b/orix/io/ang.py
@@ -273,7 +273,6 @@ def _get_phases_from_header(
                 group = re.split("[ \t]", match.group(2).lstrip(" ").rstrip(" "))
                 group = list(filter(None, group))
                 if key == "lattice_constants":
-                    print(group)
                     group = [float(i) for i in group]
                 else:
                     group = group[0]

--- a/orix/io/ang.py
+++ b/orix/io/ang.py
@@ -17,7 +17,6 @@
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-from typing import List, Tuple
 import warnings
 
 from diffpy.structure import Lattice, Structure
@@ -32,7 +31,7 @@ from orix.crystal_map import CrystalMap
 # https://github.com/mtex-toolbox/mtex/blob/develop/interfaces/loadEBSD_ACOM.m
 
 
-def load_ang(filename: str) -> CrystalMap:
+def load_ang(filename):
     """Return a :class:`orix.crystal_map.CrystalMap` object from EDAX
     TSL's .ang file format. The map in the input file is assumed to be 2D.
 
@@ -109,7 +108,7 @@ def load_ang(filename: str) -> CrystalMap:
     )
 
 
-def _get_header(file) -> List[str]:
+def _get_header(file):
     """Return the first lines starting with '#' in an .ang file.
 
     Parameters
@@ -130,7 +129,7 @@ def _get_header(file) -> List[str]:
     return header
 
 
-def _get_vendor_columns(header: list, n_cols_file: int) -> Tuple[str, List[str]]:
+def _get_vendor_columns(header, n_cols_file):
     """Return the .ang file column names and vendor, determined from the
     header.
 
@@ -232,9 +231,7 @@ def _get_vendor_columns(header: list, n_cols_file: int) -> Tuple[str, List[str]]
     return vendor, column_names[vendor]
 
 
-def _get_phases_from_header(
-    header: list,
-) -> Tuple[List[str], List[str], List[List[float]]]:
+def _get_phases_from_header(header):
     """Return phase names and symmetries detected in an .ang file
     header.
 

--- a/orix/io/emsoft_h5ebsd.py
+++ b/orix/io/emsoft_h5ebsd.py
@@ -17,7 +17,6 @@
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-from typing import Tuple
 
 from diffpy.structure import Lattice, Structure
 import h5py
@@ -27,7 +26,7 @@ from orix.quaternion.rotation import Rotation
 from orix.crystal_map import CrystalMap
 
 
-def load_emsoft(filename: str, refined: bool = False, **kwargs) -> CrystalMap:
+def load_emsoft(filename, refined=False, **kwargs):
     """Return a CrystalMap object from EMsoft's dictionary indexing dot
     product files.
 
@@ -100,7 +99,7 @@ def load_emsoft(filename: str, refined: bool = False, **kwargs) -> CrystalMap:
     )
 
 
-def _get_properties(data_group: h5py.Group, n_top_matches: int, map_size: int) -> dict:
+def _get_properties(data_group, n_top_matches, map_size):
     """Return a dictionary of properties within an EMsoft h5ebsd file, with
     property names as the dictionary key and arrays as the values.
 
@@ -147,7 +146,7 @@ def _get_properties(data_group: h5py.Group, n_top_matches: int, map_size: int) -
     return properties
 
 
-def _get_phase(data_group: h5py.Group) -> Tuple[str, str, Structure]:
+def _get_phase(data_group):
     """Return phase information from a phase data group in an EMsoft dot
     product file.
 

--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -16,22 +16,18 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Optional, Tuple
 import warnings
 
-from matplotlib import colorbar
 import matplotlib.font_manager as fm
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
 from matplotlib.image import AxesImage
-from matplotlib.patches import Patch
 from matplotlib.projections import register_projection
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from mpl_toolkits.axes_grid1.anchored_artists import AnchoredSizeBar
 import numpy as np
 
-from orix.crystal_map import CrystalMap
 from orix.scalar import Scalar
 from orix.vector import Vector3d
 
@@ -68,14 +64,14 @@ class CrystalMapPlot(Axes):
 
     def plot_map(
         self,
-        crystal_map: CrystalMap,
-        value: Optional[np.ndarray] = None,
-        scalebar: bool = True,
-        scalebar_properties: Optional[dict] = None,
-        legend: bool = True,
-        legend_properties: Optional[dict] = None,
-        axes: Optional[Tuple[int, ...]] = None,
-        depth: Optional[int] = None,
+        crystal_map,
+        value=None,
+        scalebar=True,
+        scalebar_properties=None,
+        legend=True,
+        legend_properties=None,
+        axes=None,
+        depth=None,
         **kwargs,
     ) -> AxesImage:
         """Plot a 2D map with any CrystalMap attribute as map values.
@@ -228,7 +224,7 @@ class CrystalMapPlot(Axes):
 
         return im
 
-    def add_scalebar(self, crystal_map: CrystalMap, **kwargs) -> AnchoredSizeBar:
+    def add_scalebar(self, crystal_map, **kwargs):
         """Add a scalebar to the axes object via `AnchoredSizeBar`.
 
         To find an appropriate scalebar width, this snippet from MTEX
@@ -331,7 +327,7 @@ class CrystalMapPlot(Axes):
 
         return bar
 
-    def add_overlay(self, crystal_map: CrystalMap, item: str):
+    def add_overlay(self, crystal_map, item):
         """Use a crystal map property as gray scale values of a phase map.
 
         The property's range is adjusted to [0, 1] for maximum contrast.
@@ -379,10 +375,10 @@ class CrystalMapPlot(Axes):
 
         image.set_data(image_data)
 
-    def add_colorbar(self, label: Optional[str] = None, **kwargs) -> colorbar:
+    def add_colorbar(self, label=None, **kwargs):
         """Add an opinionated colorbar to the figure.
 
-        Parameters ko   
+        Parameters
         ----------
         label : str, optional
             Colorbar title, default is ``None``.
@@ -461,12 +457,7 @@ class CrystalMapPlot(Axes):
             right = 1
         self.figure.subplots_adjust(top=1, bottom=0, right=right, left=0)
 
-    def _set_plot_shape(
-        self,
-        crystal_map: CrystalMap,
-        axes: Optional[List[int]] = None,
-        depth: Optional[int] = None,
-    ):
+    def _set_plot_shape(self, crystal_map, axes=None, depth=None):
         """Set `CrystalMapPlot` attributes describing which data axes to
         plot.
 
@@ -509,7 +500,7 @@ class CrystalMapPlot(Axes):
         self._data_slices = tuple(slices)
         self._data_shape = tuple(data_shape)
 
-    def _add_legend(self, patches: List[Patch], **kwargs):
+    def _add_legend(self, patches, **kwargs):
         """Add a legend to the axes object.
 
         Parameters
@@ -529,9 +520,7 @@ class CrystalMapPlot(Axes):
         [kwargs.setdefault(k, v) for k, v in d.items()]
         self.legend(handles=patches, **kwargs)
 
-    def _override_status_bar(
-        self, image: AxesImage, crystal_map: CrystalMap
-    ) -> AxesImage:
+    def _override_status_bar(self, image, crystal_map):
         """Display coordinates, a property value (if scalar values are
         plotted), and Euler angles (in radians) per data point in the
         status bar.
@@ -607,7 +596,7 @@ class CrystalMapPlot(Axes):
 register_projection(CrystalMapPlot)
 
 
-def convert_unit(value: float, unit: str) -> Tuple[float, str, float]:
+def convert_unit(value, unit):
     """Return the data with a suitable, not too large, unit.
 
     This algorithm is taken directly from MTEX [Bachmann2010]_

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -326,12 +326,12 @@ class Rotation(Quaternion):
         euler : array-like
             Euler angles in the Bunge convention.
         convention : str
-            Only 'bunge' is currently suppported for new data
+            Only 'bunge' is currently supported for new data
         direction : str
             'lab2crystal' or 'crystal2lab'
         """
-        if convention not in  ["bunge","Krakow_Hielscher"]:
-            raise ValuerError("The chosen convention is not one of the allowed options")
+        if convention not in ["bunge", "Krakow_Hielscher"]:
+            raise ValueError("The chosen convention is not one of the allowed options")
         if direction not in ["lab2crystal", "crystal2lab"]:
             raise ValueError("The chosen direction is not one of the allowed options")
 

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -450,6 +450,12 @@ def temp_emsoft_h5ebsd_file(tmpdir, request):
     for name, data in [
         ("Point Group", "Cubic (Oh) [m3m]"),
         ("MaterialName", "austenite/austenite"),
+        ("Lattice Constant a", "3.595"),
+        ("Lattice Constant b", "3.595"),
+        ("Lattice Constant c", "3.595"),
+        ("Lattice Constant alpha", "90.000"),
+        ("Lattice Constant beta", "90.000"),
+        ("Lattice Constant gamma", "90.000"),
     ]:
         phase_group.create_dataset(name, data=np.array([data], dtype=np.dtype("S")))
 

--- a/orix/tests/test_orientation.py
+++ b/orix/tests/test_orientation.py
@@ -55,6 +55,7 @@ def test_orientation_persistence(symmetry, vector):
     v2 = Vector3d(v2.data.round(4))
     assert v1._tuples == v2._tuples
 
+
 @pytest.mark.parametrize(
     "orientation, symmetry, expected",
     [

--- a/orix/tests/test_phase_list.py
+++ b/orix/tests/test_phase_list.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
+from diffpy.structure import Lattice, Structure
 import numpy as np
 import pytest
 
@@ -25,18 +26,42 @@ from orix.quaternion.symmetry import Symmetry, O
 
 class TestPhase:
     @pytest.mark.parametrize(
-        "name, symmetry, color, color_alias, color_rgb",
+        "name, symmetry, color, color_alias, color_rgb, structure",
         [
-            (None, "m-3m", None, "tab:blue", (0.121568, 0.466666, 0.705882)),
-            (None, "1", "blue", "b", (0, 0, 1)),
-            ("al", "43", "xkcd:salmon", "xkcd:salmon", (1, 0.474509, 0.423529)),
-            ("My awes0me phase!", O, "C1", "tab:orange", (1, 0.498039, 0.054901)),
+            (
+                None,
+                "m-3m",
+                None,
+                "tab:blue",
+                (0.121568, 0.466666, 0.705882),
+                Structure(title="Super", lattice=Lattice(1, 1, 1, 90, 90, 90)),
+            ),
+            (None, "1", "blue", "b", (0, 0, 1), Structure()),
+            (
+                "al",
+                "43",
+                "xkcd:salmon",
+                "xkcd:salmon",
+                (1, 0.474509, 0.423529),
+                Structure(title="ni", lattice=Lattice(1, 2, 3, 90, 90, 90)),
+            ),
+            (
+                "My awes0me phase!",
+                O,
+                "C1",
+                "tab:orange",
+                (1, 0.498039, 0.054901),
+                None,
+            ),
         ],
     )
-    def test_init_phase(self, name, symmetry, color, color_alias, color_rgb):
-        p = Phase(name, symmetry, color)
+    def test_init_phase(self, name, symmetry, color, color_alias, color_rgb, structure):
+        p = Phase(name=name, symmetry=symmetry, structure=structure, color=color)
 
-        assert p.name == str(name)
+        if name is None:
+            assert p.name == structure.title
+        else:
+            assert p.name == str(name)
 
         if symmetry == "43":
             symmetry = "432"
@@ -47,9 +72,16 @@ class TestPhase:
         assert p.color == color_alias
         assert np.allclose(p.color_rgb, color_rgb, atol=1e-6)
 
+        if structure is not None:
+            assert p.structure == structure
+        else:
+            assert p.structure == Structure()
+
     @pytest.mark.parametrize("name", [None, "al", 1, np.arange(2)])
     def test_set_phase_name(self, name):
         p = Phase(name=name)
+        if name is None:
+            name = ""
         assert p.name == str(name)
 
     @pytest.mark.parametrize(
@@ -88,7 +120,21 @@ class TestPhase:
             p.symmetry = symmetry
             assert p.symmetry.name == symmetry_name
 
-    @pytest.mark.parametrize("name, symmetry", [("al", None), (None, "m-3m")])
+    @pytest.mark.parametrize(
+        "structure", [Structure(), Structure(lattice=Lattice(1, 2, 3, 90, 120, 90))]
+    )
+    def test_set_structure(self, structure):
+        p = Phase()
+        p.structure = structure
+
+        assert p.structure == structure
+
+    def test_set_structure_raises(self):
+        p = Phase()
+        with pytest.raises(ValueError, match=".* must be a diffpy.structure.Structure"):
+            p.structure = [1, 2, 3, 90, 90, 90]
+
+    @pytest.mark.parametrize("name, symmetry", [("al", None), ("", "m-3m")])
     def test_phase_repr_str(self, name, symmetry):
         p = Phase(name=name, symmetry=symmetry, color="C0")
         representation = (
@@ -102,7 +148,7 @@ class TestPhase:
         assert p.__str__() == representation
 
     def test_deepcopy_phase(self):
-        p = Phase("al", "m-3m", "C1")
+        p = Phase(name="al", symmetry="m-3m", color="C1")
         p2 = p.deepcopy()
 
         assert p.__repr__() == "<name: al. symmetry: m-3m. color: tab:orange>"
@@ -114,7 +160,7 @@ class TestPhase:
         assert p2.__repr__() == "<name: al. symmetry: m-3m. color: tab:orange>"
 
     def test_shallowcopy_phase(self):
-        p = Phase("al", "m-3m", "C1")
+        p = Phase(name="al", symmetry="m-3m", color="C1")
         p2 = p
 
         p2.name = "austenite"
@@ -139,14 +185,15 @@ class TestPhaseList:
         pl = PhaseList(phase_ids=phase_ids)
 
         assert pl.phase_ids == phase_ids
-        assert pl.names == ["None",] * 2
-        assert pl.symmetries == [None,] * 2
+        assert pl.names == [""] * 2
+        assert pl.symmetries == [None] * 2
         assert pl.colors == ["tab:blue", "tab:orange"]
+        assert pl.structures == [Structure()] * 2
 
     @pytest.mark.parametrize("phase_collection", ["dict", "list"])
     def test_init_phaselist_from_phases(self, phase_collection):
-        p1 = Phase("austenite", 432, None)
-        p2 = Phase("ferrite", "432", "C1")
+        p1 = Phase(name="austenite", symmetry=432, color=None)
+        p2 = Phase(name="ferrite", symmetry="432", color="C1")
         if phase_collection == "dict":
             phases = {1: p1, 2: p2}
         else:  # phase_collection == "list":
@@ -160,7 +207,7 @@ class TestPhaseList:
         assert pl.colors_rgb == [p.color_rgb for p in [p1, p2]]
 
     def test_init_phaselist_from_phase(self):
-        p = Phase("austenite", "432", "C2")
+        p = Phase(name="austenite", symmetry="432", color="C2")
         pl = PhaseList(p)
 
         assert pl.names == [p.name]
@@ -176,9 +223,9 @@ class TestPhaseList:
         [
             (
                 ["al", "ni"],
-                [43,],
+                [43],
                 [None, "C1"],
-                [1,],
+                [1],
                 ["al", "ni"],
                 ["432", None],
                 ["tab:blue", "tab:orange"],
@@ -188,18 +235,18 @@ class TestPhaseList:
                 ["al", None],
                 [432, "m3m"],
                 (1, 0, 0),
-                [100,],
-                ["al", "None"],
+                [100],
+                ["al", ""],
                 ["432", "m-3m"],
                 ["r", "tab:blue"],
                 [100, 101],
             ),
             (
-                [None,],
+                [None],
                 [None, None],
                 ["green", "black"],
                 1,
-                ["None", "None"],
+                ["", ""],
                 [None, None],
                 ["g", "k"],
                 [1, 2],
@@ -209,7 +256,7 @@ class TestPhaseList:
                 ["m-3m", 3, None],
                 ["C0", None, "C0"],
                 None,
-                ["al", "Ni", "None"],
+                ["al", "Ni", ""],
                 ["m-3m", "3", None],
                 ["tab:blue", "tab:orange", "tab:blue"],
                 [0, 1, 2],
@@ -387,16 +434,24 @@ class TestPhaseList:
         names = ["al", "ni", "sigma"]
         symmetries = [3, 432, "m-3m"]
         colors = ["g", "b", "r"]
+        structures = [
+            Structure(),
+            Structure(lattice=Lattice(1, 2, 3, 90, 90, 90)),
+            Structure(),
+        ]
 
-        pl = PhaseList(names=names, symmetries=symmetries, colors=colors)
+        pl = PhaseList(
+            names=names, symmetries=symmetries, colors=colors, structures=structures
+        )
 
-        for i, ((phase_id, phase), n, s, c) in enumerate(
-            zip(pl, names, symmetries, colors)
+        for i, ((phase_id, phase), n, s, c, structure) in enumerate(
+            zip(pl, names, symmetries, colors, structures)
         ):
             assert phase_id == i
             assert phase.name == n
             assert phase.symmetry.name == str(s)
             assert phase.color == c
+            assert phase.structure == structure
 
     def test_deepcopy_phaselist(self, phase_list):
         names = phase_list.names

--- a/orix/tests/test_phase_list.py
+++ b/orix/tests/test_phase_list.py
@@ -129,6 +129,13 @@ class TestPhase:
 
         assert p.structure == structure
 
+    def test_set_structure_phase_name(self):
+        name = "al"
+        p = Phase(name=name)
+        p.structure = Structure(lattice=Lattice(*([0.405] * 3 + [90] * 3)))
+        assert p.name == name
+        assert p.structure.title == name
+
     def test_set_structure_raises(self):
         p = Phase()
         with pytest.raises(ValueError, match=".* must be a diffpy.structure.Structure"):
@@ -400,6 +407,7 @@ class TestPhaseList:
         assert pl.phase_ids == [0, 1]
         assert pl.names == [str(n) for n in names]
         assert [s.name for s in pl.symmetries] == [str(s) for s in symmetries]
+        assert pl.structures == [Structure()] * 2
 
     @pytest.mark.parametrize(
         "key_del, invalid_phase, error_type, error_msg",

--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,12 @@ setup(
     packages=find_packages(exclude=["orix/tests"]),
     # fmt: off
     install_requires=[
+        "diffpy.structure >= 3",
+        "h5py",
+        "matplotlib",
         "numpy",
         "scipy",
-        "matplotlib",
         "tqdm",
-        "h5py",
     ],
     # fmt: on
     package_data={"": ["LICENSE", "readme.rst"], "orix": ["*.py"],},


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

Closes #65 and relates to discussion in #58.

Add unit cell information (lattice and atoms) to `Phase` objects (available directly or via `PhaseList` or `CrystalMap.phases`) as `diffpy.structure.Structure` objects in a `Phase.structure` attribute. `Phase.__init__()` has a new `structure` argument, which can be `None` (an empty `Structure()` object is used) or a `Structure` object. The `Phase.__init__()` `name` argument overrides the `Structure.title` attribute upon initialization.

`PhaseList.__init__()` also now has a `structure` argument.

`load_ang()` and `load_emsoft` are updated accordingly to fetch lattice parameters from the files and pass these on to `CrystalMap.__init__()` via a new `structure` argument. Thus, when specifying phases in a `CrystalMap`, the user can pass `phase_name`, `symmetry` and `structure` to `__init__()`.

```python
>>> from diffpy.structure import Atom, Lattice, Structure
>>> import numpy as np
>>> from orix.crystal_map import CrystalMap, Phase, PhaseList
>>> from orix.quaternion.rotation import Rotation

# Create a phase

>>> p = Phase(
...     name="al",
...     symmetry="m-3m",
...     structure=Structure(
...         atoms=[Atom("al", [0] * 3])],
...         lattice=Lattice(0.405, 0.405, 0.405, 90, 90, 90)
...     )
... )
>>> p
<name: al. symmetry: m-3m. color: tab:blue>
>>> p.structure
[al   0.000000 0.000000 0.000000 1.0000]
>>> p.structure.lattice
Lattice(a=0.405, b=0.405, c=0.405, alpha=90, beta=90, gamma=90)

# Create a phase list

>>> pl = PhaseList(
...     names=["al", "cu"],
...     symmetries=["m-3m"] * 2,
...     structures=[
...         Structure(
...             atoms=[Atom("al", [0] * 3)],
...             lattice=Lattice(0.405, 0.405, 0.405, 90, 90, 90)
...         ),
...         Structure()
...     ]
... )
>>> pl
Id  Name  Symmetry       Color
 0    al      m-3m    tab:blue
 1    cu      m-3m  tab:orange
>>> pl["cu"].structure = Structure(
...     atoms=[Atom("cu", [0] * 3)],
...     lattice=Lattice(0.361, 0.361, 0.361, 90, 90, 90)
... )
>>> pl["cu"].structure
[cu   0.000000 0.000000 0.000000 1.0000]

# Create CrystalMap

>>> euler1, euler2, euler3, x, y, iq, dp, phase_id = np.loadtxt(
...     "/some/file.ang", unpack=True)
>>> euler_angles = np.column_stack((euler1, euler2, euler3))
>>> rotations = Rotation.from_euler(euler_angles)
>>> properties = {"iq": iq, "dp": dp}
>>> structures = [
...     Structure(
...         title="austenite",
...         atoms=[Atom("fe", [0] * 3)],
...         lattice=Lattice(0.360, 0.360, 0.360, 90, 90, 90)
...     ),
...     Structure(
...         title="ferrite",
...         atoms=[Atom("fe", [0] * 3)],
...         lattice=Lattice(0.287, 0.287, 0.287, 90, 90, 90)
...     )
... ]
>>> cm = CrystalMap(
...     rotations=rotations,
...     phase_id=phase_id,
...     x=x,
...     y=y,
...     phase_name=["austenite", "ferrite"],
...     symmetry=["432", "432"],
...     structure=structures,
...     prop=properties,
... )
```

Have also started using type hints in function and method signatures. Have decided to leave the docstring type hints in, we might decide to remove these later. The signature type hints are picked up by PyCharm (which I use) so that my editor tells me when I'm trying to pass something of the "wrong" type or using a return argument in the wrong way. I find this quite useful when coding.

Adds `diffpy.structure >= 3` dependency via `setup.py`.