### PR TITLE
HDF5 reader and writer of CrystalMap objects

### DIFF
--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -569,16 +569,12 @@ class CrystalMap:
         elif isinstance(key, np.ndarray) and key.dtype == np.bool_:
             # From boolean numpy array
             is_in_data = key
-        elif (
-            isinstance(key, slice)
-            or isinstance(key, int)
-            or (
-                isinstance(key, tuple)
-                and any([(isinstance(i, slice) or isinstance(i, int)) for i in key])
-            )
+        elif isinstance(key, (slice, int)) or (
+            isinstance(key, tuple)
+            and any([(isinstance(i, slice) or isinstance(i, int)) for i in key])
         ):
             # From slice(s) or int
-            if isinstance(key, slice) or isinstance(key, int):
+            if isinstance(key, (slice, int)):
                 key = (key,)
 
             slices = [slice(None, None, None)] * self.ndim

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -22,7 +22,6 @@ from diffpy.structure import Structure
 import numpy as np
 
 from orix.crystal_map.crystal_map_properties import CrystalMapProperties
-from orix.io import _save
 from orix.crystal_map.phase_list import Phase, PhaseList
 from orix.quaternion.orientation import Orientation
 from orix.quaternion.rotation import Rotation
@@ -92,10 +91,10 @@ class CrystalMap:
         x=None,
         y=None,
         z=None,
-        phase_name=None,
-        symmetry=None,
-        structure=None,
+        phase_list=None,
         prop=None,
+        scan_unit=None,
+        is_in_data=None,
     ):
         """
         Parameters
@@ -108,32 +107,32 @@ class CrystalMap:
             axis' size.
         phase_id : numpy.ndarray, optional
             Phase ID of each pixel. IDs equal to -1 are considered not
-            indexed. If ``None`` is passed (default), all points are
+            indexed. If None is passed (default), all points are
             considered to belong to one phase with ID 0.
         x : numpy.ndarray, optional
-            Map x coordinate of each data point. If ``None`` is passed,
+            Map x coordinate of each data point. If None is passed,
             the map is assumed to be 1D, and it is set to an array of
             increasing integers from 0 to the length of the `phase_id`
             array.
         y : numpy.ndarray, optional
-            Map y coordinate of each data point. If ``None`` is passed,
-            the map is assumed to be 1D, and it is set to ``None``.
+            Map y coordinate of each data point. If None is passed,
+            the map is assumed to be 1D, and it is set to None.
         z : numpy.ndarray, optional
-            Map z coordinate of each data point. If ``None`` is passed,
-            the map is assumed to be 2D or 1D, and it is set to ``None``.
-        phase_name : str or list of str, optional
-            Name of phase(s).
-        symmetry : str, int, orix.quaternion.symmetry.Symmetry or list\
-                of str, int or orix.quaternion.symmetry.Symmetry, optional
-            Point group of crystal symmetries of phases in the map.
-        structure : diffpy.structure.Structure or list of
-                diffpy.structure.Structure, optional
-            Unit cells with atoms and a lattice of each phase. If None
-            is passed (default), a default
-            :class:`diffpy.structure.Structure` object is created for each
-            phase.
+            Map z coordinate of each data point. If None is passed, the
+            map is assumed to be 2D or 1D, and it is set to None.
+        phase_list : PhaseList, optional
+            A list of phases in the data with their with names,
+            symmetries and structures. The order of the phases in the
+            list, and not the IDs, is used to link the phases to the input
+            `phase_id` if the IDs aren't exactly the same as in
+            `phase_id`. If None (default), a phase list with as many
+            phases as there are unique phase IDs in `phase_id` is created.
         prop : dict of numpy.ndarray, optional
             Dictionary of properties of each data point.
+        scan_unit : str, optional
+            Length unit of the data. If None (default), "px" is used.
+        is_in_data : np.ndarray, optional
+            Array of booleans signifying whether a point is in the data.
 
         Examples
         --------
@@ -204,12 +203,27 @@ class CrystalMap:
             include_not_indexed = True
             unique_phase_ids = unique_phase_ids[1:]
         # Also sorted in ascending order
-        self.phases = PhaseList(
-            names=phase_name,
-            symmetries=symmetry,
-            phase_ids=unique_phase_ids,
-            structures=structure,
-        )
+        if phase_list is None:
+            self.phases = PhaseList(ids=unique_phase_ids)
+        else:
+            phase_list = copy.deepcopy(phase_list)
+            phase_ids = phase_list.ids
+            n_different = len(phase_ids) - len(unique_phase_ids)
+            if n_different > 0:
+                # Remove superfluous phase IDs
+                for i in phase_list.ids[::-1][:n_different]:
+                    del phase_list[i]
+            elif n_different < 0:
+                # Create new phase list adding the missing phases with
+                # default initial values
+                phase_list = PhaseList(
+                    names=phase_list.names,
+                    symmetries=phase_list.symmetries,
+                    colors=phase_list.colors,
+                    structures=phase_list.structures,
+                    ids=unique_phase_ids,
+                )
+            self.phases = phase_list
 
         # Set whether measurements are indexed
         is_indexed = np.ones(data_size, dtype=bool)
@@ -222,10 +236,14 @@ class CrystalMap:
             self._phase_id[~is_indexed] = -1
 
         # Set array with True for points in data
-        self.is_in_data = np.ones(data_size, dtype=bool)
+        if is_in_data is None:
+            is_in_data = np.ones(data_size, dtype=bool)
+        self.is_in_data = is_in_data
 
         # Set scan unit
-        self.scan_unit = "px"
+        if scan_unit is None:
+            scan_unit = "px"
+        self.scan_unit = scan_unit
 
         # Set properties
         if prop is None:
@@ -312,12 +330,12 @@ class CrystalMap:
         `self.phases`.
         """
         unique_ids = np.unique(self.phase_id)
-        phase_list = self.phases[np.intersect1d(unique_ids, self.phases.phase_ids)]
+        phase_list = self.phases[np.intersect1d(unique_ids, self.phases.ids)]
         if isinstance(phase_list, Phase):  # One phase in data
             # Get phase ID so it carries over to the new `PhaseList` object
             phase = phase_list  # Since it's actually a single phase
             phase_id = self.phases.id_from_name(phase.name)
-            return PhaseList(phases=phase, phase_ids=phase_id)
+            return PhaseList(phases=phase, ids=phase_id)
         else:  # Multiple phases in data
             return phase_list
 
@@ -645,7 +663,8 @@ class CrystalMap:
         map data shape.
 
         If `item` is "orientations"/"rotations" and there are multiple
-        rotations per point, only the first rotation is used.
+        rotations per point, only the first rotation is used. Rotations
+        are returned as Euler angles.
 
         Parameters
         ----------
@@ -787,19 +806,3 @@ class CrystalMap:
         for dim_slice in self._data_slices_from_coordinates():
             data_shape.append(dim_slice.stop - dim_slice.start)
         return tuple(data_shape)
-
-    def save(self, filename, overwrite=None, **kwargs):
-        """Write the crystal map to a supported file format.
-
-        Parameters
-        ----------
-        filename : str
-            Name of file to write to.
-        overwrite : bool, optional
-            If None and the file exists, the user is queried. If True
-            (False) the file is (not) overwritten if it exists.
-        kwargs
-            Keyword arguments passed to the corresponding orix writer. See
-            their individual docstrings for available arguments.
-        """
-        _save(filename=filename, object2write=self, overwrite=overwrite, **kwargs)

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -24,6 +24,7 @@ from orix.quaternion.rotation import Rotation
 from orix.quaternion.orientation import Orientation
 from orix.crystal_map.phase_list import PhaseList, Phase
 from orix.crystal_map.crystal_map_properties import CrystalMapProperties
+from orix.io import _save
 
 
 class CrystalMap:
@@ -740,3 +741,19 @@ class CrystalMap:
         for dim_slice in self._data_slices_from_coordinates():
             data_shape.append(dim_slice.stop - dim_slice.start)
         return tuple(data_shape)
+
+    def save(self, filename, overwrite=None, **kwargs):
+        """Write the crystal map to a supported file format.
+
+        Parameters
+        ----------
+        filename : str
+            Name of file to write to.
+        overwrite : bool, optional
+            If None and the file exists, the user is queried. If True
+            (False) the file is (not) overwritten if it exists.
+        kwargs
+            Keyword arguments passed to the corresponding orix writer. See
+            their individual docstrings for available arguments.
+        """
+        _save(filename=filename, object2write=self, overwrite=overwrite, **kwargs)

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -122,8 +122,9 @@ class CrystalMap:
             map is assumed to be 2D or 1D, and it is set to None.
         phase_list : PhaseList, optional
             A list of phases in the data with their with names,
-            symmetries and structures. The order of the phases in the
-            list, and not the IDs, is used to link the phases to the input
+            symmetries and structures. The order in which the phases
+            appear in the list is important, as it is this, and not the
+            phases' IDs, that is used to link the phases to the input
             `phase_id` if the IDs aren't exactly the same as in
             `phase_id`. If None (default), a phase list with as many
             phases as there are unique phase IDs in `phase_id` is created.
@@ -210,7 +211,7 @@ class CrystalMap:
             phase_ids = phase_list.ids
             n_different = len(phase_ids) - len(unique_phase_ids)
             if n_different > 0:
-                # Remove superfluous phase IDs
+                # Remove superfluous phases
                 for i in phase_list.ids[::-1][:n_different]:
                     del phase_list[i]
             elif n_different < 0:
@@ -223,6 +224,9 @@ class CrystalMap:
                     structures=phase_list.structures,
                     ids=unique_phase_ids,
                 )
+            # Ensure phase list IDs correspond to IDs in phase_id array
+            new_ids = list(unique_phase_ids.astype(int))
+            phase_list._dict = dict(zip(new_ids, phase_list._dict.values()))
             self.phases = phase_list
 
         # Set whether measurements are indexed

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -306,13 +306,9 @@ class PhaseList:
             # iterables of length 1
             if isinstance(names, str):
                 names = list((names,))
-            if (
-                isinstance(symmetries, str)
-                or isinstance(symmetries, Symmetry)
-                or isinstance(symmetries, int)
-            ):
+            if isinstance(symmetries, (str, Symmetry, int)):
                 symmetries = list((symmetries,))
-            if isinstance(colors, str) or isinstance(colors, tuple):
+            if isinstance(colors, (str, tuple)):
                 colors = list((colors,))
             if isinstance(ids, int):
                 ids = [ids]
@@ -463,12 +459,7 @@ class PhaseList:
         1   b     3         tab:orange
         """
         # Make key iterable if it isn't already
-        if (
-            not isinstance(key, tuple)
-            and not isinstance(key, slice)
-            and not isinstance(key, list)
-            and not isinstance(key, np.ndarray)
-        ):
+        if not isinstance(key, (tuple, slice, list, np.ndarray)):
             key_iter = (key,)
         else:
             key_iter = key
@@ -484,12 +475,7 @@ class PhaseList:
                 for i, phase in self._dict.items():
                     if key_name == phase.name:
                         d[i] = phase
-        elif (
-            isinstance(key_iter, int)
-            or isinstance(key_iter, tuple)
-            or isinstance(key_iter, list)
-            or isinstance(key_iter, np.ndarray)
-        ):
+        elif isinstance(key_iter, (int, tuple, list, np.ndarray)):
             for i in list(set(key_iter)):  # Use set to remove duplicates
                 d[i] = self._dict[i]
         elif isinstance(key_iter, slice):

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -172,7 +172,7 @@ class Phase:
                     break
         if not isinstance(value, Symmetry) and value is not None:
             raise ValueError(
-                f"{value} must be of type {Symmetry}, the name of a valid point"
+                f"'{value}' must be of type {Symmetry}, the name of a valid point"
                 " group as a string, or None."
             )
         else:
@@ -203,7 +203,7 @@ class PhaseList:
         List of tuples with three entries, RGB, defining phase colors.
     names : list of str
         List of phase names.
-    phase_ids : list of int
+    ids : list of int
         List of unique phase indices in a crystallographic map as
         imported.
     size : int
@@ -231,7 +231,7 @@ class PhaseList:
         names=None,
         symmetries=None,
         colors=None,
-        phase_ids=None,
+        ids=None,
         structures=None,
     ):
         """
@@ -248,7 +248,7 @@ class PhaseList:
             Point group symmetries.
         colors : str or list of str, optional
             Phase colors.
-        phase_ids : int, list of int or numpy.ndarray of int, optional
+        ids : int, list of int or numpy.ndarray of int, optional
             Phase IDs.
         structures : diffpy.structure.Structure or list of
                 diffpy.structure.Structure, optional
@@ -286,9 +286,9 @@ class PhaseList:
         if isinstance(phases, list):
             try:
                 if isinstance(next(iter(phases)), Phase):
-                    if phase_ids is None:
-                        phase_ids = np.arange(len(phases))
-                    d = dict(zip(phase_ids, phases))
+                    if ids is None:
+                        ids = np.arange(len(phases))
+                    d = dict(zip(ids, phases))
             except StopIteration:
                 pass
         elif isinstance(phases, dict):
@@ -298,20 +298,24 @@ class PhaseList:
             except StopIteration:
                 pass
         elif isinstance(phases, Phase):
-            if phase_ids is None:
-                phase_ids = 0
-            d = {phase_ids: phases}
+            if ids is None:
+                ids = 0
+            d = {ids: phases}
         else:
             # Ensure possible single strings or single objects have
             # iterables of length 1
             if isinstance(names, str):
                 names = list((names,))
-            if isinstance(symmetries, str) or isinstance(symmetries, Symmetry):
+            if (
+                isinstance(symmetries, str)
+                or isinstance(symmetries, Symmetry)
+                or isinstance(symmetries, int)
+            ):
                 symmetries = list((symmetries,))
             if isinstance(colors, str) or isinstance(colors, tuple):
                 colors = list((colors,))
-            if isinstance(phase_ids, int):
-                phase_ids = [phase_ids]
+            if isinstance(ids, int):
+                ids = [ids]
             if isinstance(structures, Structure):
                 structures = [structures]
 
@@ -320,12 +324,12 @@ class PhaseList:
             max_entries = max(
                 [
                     len(i) if i is not None else 0
-                    for i in [names, symmetries, phase_ids, structures]
+                    for i in [names, symmetries, ids, structures]
                 ]
             )
 
-            if phase_ids is None:
-                phase_ids = list(np.arange(max_entries))
+            if ids is None:
+                ids = list(np.arange(max_entries))
 
             # Get first 2 * n entries in color list (for good measure)
             all_colors = list(islice(ALL_COLORS.keys(), 2 * max_entries))[::-1]
@@ -360,9 +364,9 @@ class PhaseList:
 
                 # Get a phase_id (always)
                 try:
-                    phase_id = phase_ids[i]
+                    phase_id = ids[i]
                 except IndexError:
-                    phase_id = max(phase_ids) + phase_id_iter + 1
+                    phase_id = max(ids) + phase_id_iter + 1
                     phase_id_iter += 1
 
                 # Get a structure or None
@@ -407,7 +411,7 @@ class PhaseList:
         return len(self._dict.items())
 
     @property
-    def phase_ids(self):
+    def ids(self):
         """Unique phase IDs in the list of phases."""
         return list(self._dict.keys())
 
@@ -490,9 +494,10 @@ class PhaseList:
                 d[i] = self._dict[i]
         elif isinstance(key_iter, slice):
             # Dicts cannot be sliced, hence this work-around
-            id_arr = np.arange(max(self.phase_ids) + 1)
+            id_arr_start = -1 if self.ids[0] == -1 else 0
+            id_arr = np.arange(id_arr_start, max(self.ids) + 1)
             sliced_arr = id_arr[key_iter]
-            ids_in_slice = [i for i in sliced_arr if i in self.phase_ids]
+            ids_in_slice = [i for i in sliced_arr if i in self.ids]
             d = {i: self._dict[i] for i in ids_in_slice}
 
         # Raise KeyError if key is missing (not in the container), per
@@ -521,8 +526,8 @@ class PhaseList:
                     break
 
             # Create new ID
-            if self.phase_ids:
-                new_phase_id = max(self.phase_ids) + 1
+            if self.ids:
+                new_phase_id = max(self.ids) + 1
             else:  # `self.phase_ids` is an empty list
                 new_phase_id = 0
 
@@ -538,7 +543,7 @@ class PhaseList:
         key : int or str
             ID or name of a phase in the phase list.
         """
-        if isinstance(key, int):
+        if np.issubdtype(type(key), np.signedinteger):
             self._dict.pop(key)
         elif isinstance(key, str):
             matching_phase_id = None
@@ -551,7 +556,7 @@ class PhaseList:
             else:
                 self._dict.pop(matching_phase_id)
         else:
-            raise TypeError(f"{key} is an invalid phase.")
+            raise TypeError(f"{key} is an invalid phase ID or name.")
 
     def __iter__(self):
         """Return a tuple with phase ID and Phase object, in that order.
@@ -591,7 +596,7 @@ class PhaseList:
         )
 
         # Overview of each phase
-        for i, phase_id in enumerate(self.phase_ids):
+        for i, phase_id in enumerate(self.ids):
             representation += (
                 f"\n{phase_id:{align}{id_len}}  "
                 + f"{names[i]:{align}{name_len}}  "
@@ -629,4 +634,4 @@ class PhaseList:
         for phase_id, phase in self:
             if name == phase.name:
                 return phase_id
-        raise KeyError(f"{name} is not among the phase names {self.names}.")
+        raise KeyError(f"'{name}' is not among the phase names {self.names}.")

--- a/orix/io/__init__.py
+++ b/orix/io/__init__.py
@@ -122,8 +122,9 @@ def load(filename, **kwargs):
 
 
 def _plugin_from_footprints(filename, plugins):
-    """Get correct HDF5 plugin from a list of potential plugins based on
-    their unique footprints.
+    """Find the correct plugin in a list of HDF5 plugins to read a file's
+    content by finding a matching pattern between a plugin's "footprint"
+    and the file.
 
     The unique footprint is a list of strings that can take on either of
     two formats:
@@ -135,9 +136,9 @@ def _plugin_from_footprints(filename, plugins):
     Parameters
     ----------
     filename : str
-        Input file name.
+        Name of the file to find the correct plugin for.
     plugins : list
-        List of potential plugins.
+        List of potential HDF5 plugins.
 
     Returns
     -------

--- a/orix/io/__init__.py
+++ b/orix/io/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2019 The pyXem developers
+# Copyright 2018-2020 The pyXem developers
 #
 # This file is part of orix.
 #

--- a/orix/io/__init__.py
+++ b/orix/io/__init__.py
@@ -25,13 +25,12 @@
 
 """
 
-from inspect import getmembers
+from importlib import import_module
 import os
 from warnings import warn
 
 import numpy as np
 
-from orix import crystal_map
 from orix.io.plugins import plugins
 
 extensions = [plugin.file_extensions for plugin in plugins if plugin.writes]
@@ -119,7 +118,7 @@ def load(filename, **kwargs):
     data_dict = reader.file_reader(filename, **kwargs)
 
     # Get class to return
-    class_to_use = dict(getmembers(crystal_map))[reader.format_type]
+    class_to_use = getattr(import_module(reader.module), reader.format_type)
 
     return class_to_use(**data_dict)
 

--- a/orix/io/plugins/__init__.py
+++ b/orix/io/plugins/__init__.py
@@ -18,7 +18,7 @@
 
 from orix.io.plugins import ang, emsoft_h5ebsd, orix_hdf5
 
-plugins = [
+plugin_list = [
     ang,
     emsoft_h5ebsd,
     orix_hdf5,

--- a/orix/io/plugins/__init__.py
+++ b/orix/io/plugins/__init__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2019 The pyXem developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+from orix.io.plugins import ang, emsoft_h5ebsd
+
+plugins = [
+    ang,
+    emsoft_h5ebsd,
+]

--- a/orix/io/plugins/__init__.py
+++ b/orix/io/plugins/__init__.py
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-from orix.io.plugins import ang, emsoft_h5ebsd
+from orix.io.plugins import ang, emsoft_h5ebsd, orix_hdf5
 
 plugins = [
     ang,
     emsoft_h5ebsd,
+    orix_hdf5,
 ]

--- a/orix/io/plugins/__init__.py
+++ b/orix/io/plugins/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2019 The pyXem developers
+# Copyright 2018-2020 The pyXem developers
 #
 # This file is part of orix.
 #

--- a/orix/io/plugins/ang.py
+++ b/orix/io/plugins/ang.py
@@ -24,8 +24,8 @@ import numpy as np
 
 from orix.quaternion.rotation import Rotation
 
-# MTEX has this format sorted out, check out their readers when fixing issues and
-# adapting to other versions of this file format in the future:
+# MTEX has this format sorted out, check out their readers when fixing
+# issues and adapting to other versions of this file format in the future:
 # https://github.com/mtex-toolbox/mtex/blob/develop/interfaces/loadEBSD_ang.m
 # https://github.com/mtex-toolbox/mtex/blob/develop/interfaces/loadEBSD_ACOM.m
 
@@ -38,7 +38,8 @@ writes = False
 
 
 def file_reader(filename):
-    """Return a :class:`orix.crystal_map.CrystalMap` object from EDAX
+    """Return a dictionary with items to initialize a
+    :class:`~orix.crystal_map.crystal_map.CrystalMap` object from EDAX
     TSL's .ang file format. The map in the input file is assumed to be 2D.
 
     Many vendors produce an .ang file. Supported vendors are:
@@ -87,6 +88,7 @@ def file_reader(filename):
         "prop": {},
         "phase_name": phase_names,
         "symmetry": symmetries,
+        "structure": structures,
     }
     for column, name in enumerate(column_names):
         if name in data_dict.keys():

--- a/orix/io/plugins/ang.py
+++ b/orix/io/plugins/ang.py
@@ -31,6 +31,7 @@ from orix.quaternion.rotation import Rotation
 # Plugin description
 format_name = "ang"
 file_extensions = ["ang"]
+module = "orix.crystal_map"
 format_type = "CrystalMap"
 writes = False
 

--- a/orix/io/plugins/ang.py
+++ b/orix/io/plugins/ang.py
@@ -38,9 +38,9 @@ writes_this = CrystalMap
 
 
 def file_reader(filename):
-    """Return a dictionary with items to initialize a
-    :class:`~orix.crystal_map.crystal_map.CrystalMap` object from EDAX
-    TSL's .ang file format. The map in the input file is assumed to be 2D.
+    """Return a :class:`~orix.crystal_map.crystal_map.CrystalMap` object
+    from a file in EDAX TLS's .ang format. The map in the input is assumed
+    to be 2D.
 
     Many vendors produce an .ang file. Supported vendors are:
         * EDAX TSL
@@ -58,7 +58,7 @@ def file_reader(filename):
 
     Returns
     -------
-    dict
+    CrystalMap
     """
     # Get file header
     with open(filename) as f:

--- a/orix/io/plugins/ang.py
+++ b/orix/io/plugins/ang.py
@@ -29,8 +29,12 @@ from orix.crystal_map import CrystalMap
 # https://github.com/mtex-toolbox/mtex/blob/develop/interfaces/loadEBSD_ang.m
 # https://github.com/mtex-toolbox/mtex/blob/develop/interfaces/loadEBSD_ACOM.m
 
+# Plugin description
+format_name = "ang"
+file_extensions = ["ang"]
 
-def load_ang(filename):
+
+def file_reader(filename: str) -> CrystalMap:
     """Return a :class:`orix.crystal_map.CrystalMap` object from EDAX
     TSL's .ang file format. The map in the input file is assumed to be 2D.
 
@@ -48,6 +52,9 @@ def load_ang(filename):
     filename : str
         Path and file name.
 
+    Returns
+    -------
+    CrystalMap
     """
     # Get file header
     with open(filename) as f:

--- a/orix/io/plugins/emsoft_h5ebsd.py
+++ b/orix/io/plugins/emsoft_h5ebsd.py
@@ -22,14 +22,15 @@ from diffpy.structure import Lattice, Structure
 from h5py import File
 import numpy as np
 
+from orix.crystal_map import CrystalMap, Phase, PhaseList
 from orix.quaternion.rotation import Rotation
 
 # Plugin description
 format_name = "emsoft_h5ebsd"
 file_extensions = ["h5", "hdf5", "h5ebsd"]
-module = "orix.crystal_map"
-format_type = "CrystalMap"
 writes = False
+writes_this = CrystalMap
+footprint = ["Scan 1"]  # Unique HDF5 footprint
 
 
 def file_reader(filename, refined=False, **kwargs):
@@ -77,9 +78,10 @@ def file_reader(filename, refined=False, **kwargs):
         # Get phase IDs
         "phase_id": data_group["Phase"][:],
         # Get phase name, crystal symmetry and structure (lattice)
-        "phase_name": phase_name,
-        "symmetry": symmetry,
-        "structure": structure,
+        "phase_list": PhaseList(
+            Phase(name=phase_name, symmetry=symmetry, structure=structure)
+        ),
+        "scan_unit": "um",
     }
 
     # Get rotations
@@ -101,7 +103,7 @@ def file_reader(filename, refined=False, **kwargs):
 
     f.close()
 
-    return data_dict
+    return CrystalMap(**data_dict)
 
 
 def _get_properties(data_group, n_top_matches, map_size):

--- a/orix/io/plugins/emsoft_h5ebsd.py
+++ b/orix/io/plugins/emsoft_h5ebsd.py
@@ -34,22 +34,21 @@ footprint = ["Scan 1"]  # Unique HDF5 footprint
 
 
 def file_reader(filename, refined=False, **kwargs):
-    """Return a dictionary with items to initialize a
-    :class:`~orix.crystal_map.crystal_map.CrystalMap` object from EMsoft's
-    dictionary indexing dot product files.
+    """Return a :class:`~orix.crystal_map.crystal_map.CrystalMap` object
+    from a file in EMsoft's dictionary indexing dot product file format.
 
     Parameters
     ----------
     filename : str
         Path and file name.
     refined : bool, optional
-        Whether to return refined orientations (default is ``False``).
+        Whether to return refined orientations (default is False).
     kwargs
         Keyword arguments passed to :func:`h5py.File`.
 
     Returns
     -------
-    dict
+    CrystalMap
     """
     mode = kwargs.pop("mode", "r")
     f = File(filename, mode=mode, **kwargs)

--- a/orix/io/plugins/emsoft_h5ebsd.py
+++ b/orix/io/plugins/emsoft_h5ebsd.py
@@ -24,8 +24,12 @@ import numpy as np
 from orix.quaternion.rotation import Rotation
 from orix.crystal_map import CrystalMap
 
+# Plugin description
+format_name = "emsoft_h5ebsd"
+file_extensions = ["h5", "hdf5", "h5ebsd"]
 
-def load_emsoft(filename, refined=False, **kwargs):
+
+def file_reader(filename: str, refined: bool = False, **kwargs) -> CrystalMap:
     """Return a CrystalMap object from EMsoft's dictionary indexing dot
     product files.
 
@@ -35,10 +39,13 @@ def load_emsoft(filename, refined=False, **kwargs):
         Path and file name.
     refined : bool, optional
         Whether to return refined orientations (default is ``False``).
-    kwargs :
+    kwargs
         Keyword arguments passed to :func:`h5py.File`.
-    """
 
+    Returns
+    -------
+    CrystalMap
+    """
     mode = kwargs.pop("mode", "r")
     f = h5py.File(filename, mode=mode, **kwargs)
 
@@ -99,7 +106,7 @@ def load_emsoft(filename, refined=False, **kwargs):
     )
 
 
-def _get_properties(data_group, n_top_matches, map_size):
+def _get_properties(data_group: h5py.Group, n_top_matches: int, map_size: int) -> dict:
     """Return a dictionary of properties within an EMsoft h5ebsd file, with
     property names as the dictionary key and arrays as the values.
 

--- a/orix/io/plugins/emsoft_h5ebsd.py
+++ b/orix/io/plugins/emsoft_h5ebsd.py
@@ -22,14 +22,15 @@ import h5py
 import numpy as np
 
 from orix.quaternion.rotation import Rotation
-from orix.crystal_map import CrystalMap
 
 # Plugin description
 format_name = "emsoft_h5ebsd"
 file_extensions = ["h5", "hdf5", "h5ebsd"]
+format_type = "CrystalMap"
+writes = False
 
 
-def file_reader(filename: str, refined: bool = False, **kwargs) -> CrystalMap:
+def file_reader(filename, refined=False, **kwargs):
     """Return a CrystalMap object from EMsoft's dictionary indexing dot
     product files.
 
@@ -44,7 +45,7 @@ def file_reader(filename: str, refined: bool = False, **kwargs) -> CrystalMap:
 
     Returns
     -------
-    CrystalMap
+    dict
     """
     mode = kwargs.pop("mode", "r")
     f = h5py.File(filename, mode=mode, **kwargs)
@@ -61,25 +62,24 @@ def file_reader(filename: str, refined: bool = False, **kwargs) -> CrystalMap:
     step_y = header_group["Step Y"][:][0]
     map_size = ny * nx
 
-    # Get map coordinates ("Y Position" data set is not correct in EMsoft as of 2020-04,
-    # see: https://github.com/EMsoft-org/EMsoft/blob/7762e1961508fe3e71d4702620764ceb98a78b9e/Source/EMsoftHDFLib/EMh5ebsd.f90#L1093)
-    x = data_group["X Position"][:]
-    # y = data_group["Y Position"][:]
-    y = np.sort(np.tile(np.arange(ny) * step_y, nx))
-
-    # Get number of top matches kept per data point
-    n_top_matches = f["NMLparameters/EBSDIndexingNameListType/nnk"][:][0]
-
-    # Get phase IDs
-    phase_id = data_group["Phase"][:]
-
-    # Get phase name and crystal symmetry
-    phase_name = re.search(
-        r"([A-z0-9]+)", phase_group["MaterialName"][:][0].decode()
-    ).group(1)
-    symmetry = re.search(
-        r"\[([A-z0-9]+)\]", phase_group["Point Group"][:][0].decode()
-    ).group(1)
+    # Some of the data needed to create a CrystalMap object
+    data_dict = {
+        # Get map coordinates ("Y Position" data set is not correct in EMsoft as of
+        # 2020-04, see:
+        # https://github.com/EMsoft-org/EMsoft/blob/7762e1961508fe3e71d4702620764ceb98a78b9e/Source/EMsoftHDFLib/EMh5ebsd.f90#L1093)
+        "x": data_group["X Position"][:],
+        # y = data_group["Y Position"][:]
+        "y": np.sort(np.tile(np.arange(ny) * step_y, nx)),
+        # Get phase IDs
+        "phase_id": data_group["Phase"][:],
+        # Get phase name and crystal symmetry
+        "phase_name": re.search(
+            r"([A-z0-9]+)", phase_group["MaterialName"][:][0].decode()
+        ).group(1),
+        "symmetry": re.search(
+            r"\[([A-z0-9]+)\]", phase_group["Point Group"][:][0].decode()
+        ).group(1)
+    }
 
     # Get rotations
     if refined:
@@ -89,24 +89,19 @@ def file_reader(filename: str, refined: bool = False, **kwargs) -> CrystalMap:
         dictionary_size = data_group["FZcnt"][:][0]
         dictionary_euler = data_group["DictionaryEulerAngles"][:][:dictionary_size]
         euler = dictionary_euler[top_match_idx, :]
-    rotations = Rotation.from_euler(euler)
+    data_dict["rotations"] = Rotation.from_euler(euler)
 
-    properties = _get_properties(
+    # Get number of top matches kept per data point
+    n_top_matches = f["NMLparameters/EBSDIndexingNameListType/nnk"][:][0]
+
+    data_dict["prop"] = _get_properties(
         data_group=data_group, n_top_matches=n_top_matches, map_size=map_size,
     )
 
-    return CrystalMap(
-        rotations=rotations,
-        phase_id=phase_id,
-        x=x,
-        y=y,
-        phase_name=phase_name,
-        symmetry=symmetry,
-        prop=properties,
-    )
+    return data_dict
 
 
-def _get_properties(data_group: h5py.Group, n_top_matches: int, map_size: int) -> dict:
+def _get_properties(data_group, n_top_matches, map_size):
     """Return a dictionary of properties within an EMsoft h5ebsd file, with
     property names as the dictionary key and arrays as the values.
 

--- a/orix/io/plugins/emsoft_h5ebsd.py
+++ b/orix/io/plugins/emsoft_h5ebsd.py
@@ -26,6 +26,7 @@ from orix.quaternion.rotation import Rotation
 # Plugin description
 format_name = "emsoft_h5ebsd"
 file_extensions = ["h5", "hdf5", "h5ebsd"]
+module = "orix.crystal_map"
 format_type = "CrystalMap"
 writes = False
 

--- a/orix/io/plugins/orix_hdf5.py
+++ b/orix/io/plugins/orix_hdf5.py
@@ -36,9 +36,8 @@ footprint = ["crystal_map"]  # Unique HDF5 footprint
 
 
 def file_reader(filename, **kwargs):
-    """Return a dictionary with items to initialize a
-    :class:`~orix.crystal_map.crystal_map.CrystalMap` object from orix'
-    HDF5 format.
+    """Return a :class:`~orix.crystal_map.crystal_map.CrystalMap` object
+    from a file in orix' HDF5 file format.
 
     Parameters
     ----------
@@ -49,8 +48,7 @@ def file_reader(filename, **kwargs):
 
     Returns
     -------
-    dict
-        Dictionary with items to initialize a CrystalMap.
+    CrystalMap
     """
     mode = kwargs.pop("mode", "r")
     with File(filename, mode=mode, **kwargs) as f:

--- a/orix/io/plugins/orix_hdf5.py
+++ b/orix/io/plugins/orix_hdf5.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2019 The pyXem developers
+# Copyright 2018-2020 The pyXem developers
 #
 # This file is part of orix.
 #

--- a/orix/io/plugins/orix_hdf5.py
+++ b/orix/io/plugins/orix_hdf5.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2019 The pyXem developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+from warnings import warn
+
+from h5py import File
+import numpy as np
+
+
+# Plugin description
+format_name = "orix_hdf5"
+file_extensions = ["h5", "hdf5"]
+format_type = "CrystalMap"
+writes = True
+
+
+def file_writer(filename, object2write, **kwargs):
+    """Write a :class:`~orix.crystal_map.CrystalMap` object to an HDF5
+    file.
+
+    Parameters
+    ----------
+    filename : str
+        Name of file to write to.
+    object2write : CrystalMap
+        Object to write to file.
+    kwargs
+        Keyword arguments passed to :meth:`h5py:Group.require_dataset`.
+    """
+    # Set manufacturer and version to use in the file
+    from orix import __version__
+    man_ver_dict = {"manufacturer": "orix", "version": __version__}
+
+    # Open file in correct mode
+    try:
+        f = File(filename, mode="w")
+    except OSError:
+        raise OSError(f"Cannot write to the already open file '{filename}'.")
+
+    # Add manufacturer and version to top group
+    dict2hdf5group(man_ver_dict, f["/"], **kwargs)
+
+    # Create scan group
+    scan_group = f.create_group("scan1/crystal_map")
+
+    # Data group with arrays with values per point
+    data_group = scan_group.create_group("data")
+
+    # Header group with all other information
+    header_group = scan_group.create_group("header")
+    header = _get_phase_list_dict(object2write.phases)
+
+
+def dict2hdf5group(dictionary, group, **kwargs):
+    """Write a dictionary to datasets in a new group in an opened HDF5
+    file.
+
+    Parameters
+    ----------
+    dictionary : dict
+        Dataset names as keys with datasets as values.
+    group : h5py:Group
+        HDF5 group to write dictionary to.
+    kwargs
+        Keyword arguments passed to :meth:`h5py:Group.require_dataset`.
+    """
+    for key, val in dictionary.items():
+        ddtype = type(val)
+        dshape = (1,)
+        if isinstance(val, dict):
+            dict2hdf5group(val, group.create_group(key), **kwargs)
+            continue  # Jump to next item in dictionary
+        elif isinstance(val, str):
+            ddtype = "S" + str(len(val) + 1)
+            val = val.encode()
+        elif ddtype == np.dtype("O"):
+            try:
+                if isinstance(val, np.ndarray):
+                    ddtype = val.dtype
+                else:
+                    ddtype = val[0].dtype
+                dshape = np.shape(val)
+            except TypeError:
+                warn(
+                    UserWarning,
+                    "The hdf5 writer could not write the following information "
+                    f"to the file '{key} : {val}'."
+                )
+                break
+        group.create_dataset(key, shape=dshape, dtype=ddtype, **kwargs)
+        group[key][()] = val
+
+
+def _get_phase_list_dict(phases, dictionary=None):
+    """Get a dictionary of phases to write to an HDF5 group.
+
+    Parameters
+    ----------
+    phases : PhaseList
+        Phases to write to file.
+    dictionary : dict
+        Dictionary to update with phase information. If None (default),
+        a new dictionary is created.
+
+    Returns
+    -------
+    dictionary : dict
+        Dictionary of phase information to write to the HDF5 group.
+    """
+    if dictionary is None:
+        dictionary = {}
+
+    dictionary["phases"] = {}
+    for i, p in phases:
+        phase_dict = dictionary["phases"][i]
+        phase_dict["name"] = p.name
+        if hasattr(p.symmetry, "name"):
+            symmetry = p.symmetry.name
+        else:
+            symmetry = "None"
+        phase_dict["symmetry"] = symmetry
+        phase_dict["color"] = p.color
+
+    return dictionary

--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -199,7 +199,7 @@ class CrystalMapPlot(Axes):
             for _, p in crystal_map.phases_in_data:
                 patches.append(mpatches.Patch(color=p.color_rgb, label=p.name))
         else:  # Create masked array of correct shape
-            if isinstance(value, Scalar) or isinstance(value, Vector3d):
+            if isinstance(value, (Scalar, Vector3d)):
                 value = value.data
             data = crystal_map.get_map_data(value)
             data = data[self._data_slices]

--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -127,11 +127,11 @@ class CrystalMapPlot(Axes):
         >>> import matplotlib.pyplot as plt
         >>> import numpy as np
         >>> from orix import plot
-        >>> from orix.io import load_ang
+        >>> from orix.io import load
 
         Import a crystal map
 
-        >>> cm = load_ang("/some/directory/data.ang")
+        >>> cm = load("/some/directory/data.ang")
 
         Plot a phase map
 

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -131,6 +131,18 @@ def temp_ang_file():
         gc.collect()  # Garbage collection so that file can be used by multiple tests
 
 
+@pytest.fixture(params=["h5"])
+def temp_file_path(request):
+    """Temporary file in a temporary directory for use when tests need
+    to write, and sometimes read again, a signal to, and from, a file.
+    """
+    ext = request.param
+    with TemporaryDirectory() as tmp:
+        file_path = os.path.join(tmp, "data_temp." + ext)
+        yield file_path
+        gc.collect()
+
+
 @pytest.fixture(
     params=[
         # Tuple with default values for five parameters: map_shape, step_sizes,
@@ -165,7 +177,6 @@ def angfile_tsl(tmpdir, request):
     rotations : np.ndarray
         A sample, smaller than the map size, of example rotations as
         rows of Euler angle triplets.
-
     """
     f = tmpdir.join("angfile_tsl.ang")
 
@@ -238,7 +249,6 @@ def angfile_astar(tmpdir, request):
     rotations : np.ndarray
         A sample, smaller than the map size, of example rotations as
         rows of Euler angle triplets.
-
     """
     f = tmpdir.join("angfile_astar.ang")
 
@@ -303,7 +313,6 @@ def angfile_emsoft(tmpdir, request):
     rotations : np.ndarray
         A sample, smaller than the map size, of example rotations as
         rows of Euler angle triplets.
-
     """
     f = tmpdir.join("angfile_emsoft.ang")
 
@@ -363,7 +372,6 @@ def temp_emsoft_h5ebsd_file(tmpdir, request):
         Number of top matching orientations per data point kept.
     refined : bool
         Whether refined Euler angles and dot products are read.
-
     """
     f = File(tmpdir.join("emsoft_h5ebsd_file.h5"), mode="w")
 

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -147,7 +147,7 @@ class TestCrystalMapInit:
         [
             ((1, 4, 3), (0, 1.5, 1.5), 1, [0, 1, 2]),
             ((1, 4, 3), (0, 1.5, 1.5), 1, [0, 1, 2, 3]),
-            ((1, 4, 3), (0, 1.5, 1.5), 1, [0, 1]),
+            ((1, 4, 3), (0, 1.5, 1.5), 1, [2, 42]),
         ],
         indirect=["crystal_map_input"],
     )
@@ -162,6 +162,9 @@ class TestCrystalMapInit:
         if n_different < 0:
             symmetries += [None] * abs(n_different)
         assert [cm.phases.symmetries[i] == symmetries[i] for i in range(n_phase_ids)]
+
+        unique_phase_ids = list(np.unique(crystal_map_input["phase_id"]).astype(int))
+        assert cm.phases.ids == unique_phase_ids
 
     def test_init_with_single_symmetry(self, crystal_map_input):
         symmetry = O

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -60,14 +60,26 @@ class TestCrystalMapInit:
         ),
         [
             (
-                ((1, 5, 5), (0, 1.5, 1.5), 3),
+                ((1, 5, 5), (0, 1.5, 1.5), 3, [0]),
                 (5, 5),
                 25,
                 {"z": 0, "y": 1.5, "x": 1.5},
                 3,
             ),
-            (((1, 1, 10), (0, 0.1, 0.1), 1), (10,), 10, {"z": 0, "y": 0, "x": 0.1}, 1),
-            (((1, 10, 1), (0, 1e-3, 0), 2), (10,), 10, {"z": 0, "y": 1e-3, "x": 0}, 2,),
+            (
+                ((1, 1, 10), (0, 0.1, 0.1), 1, [0]),
+                (10,),
+                10,
+                {"z": 0, "y": 0, "x": 0.1},
+                1,
+            ),
+            (
+                ((1, 10, 1), (0, 1e-3, 0), 2, [0]),
+                (10,),
+                10,
+                {"z": 0, "y": 1e-3, "x": 0},
+                2,
+            ),
         ],
         indirect=["crystal_map_input"],
     )
@@ -109,59 +121,77 @@ class TestCrystalMapInit:
         assert np.allclose(cm.prop.id, cm.id)
         assert np.allclose(cm.prop.is_in_data, cm.is_in_data)
 
-    @pytest.mark.parametrize("unique_phase_ids", [[0, 1], [1, -1]])
-    def test_init_with_phase_id(self, crystal_map_input, unique_phase_ids):
-        x = crystal_map_input["x"]
-
-        # Create phase ID array, ensuring all are present
-        phase_id = np.random.choice(unique_phase_ids, x.size)
-        for i, unique_id in enumerate(unique_phase_ids):
-            phase_id[i] = unique_id
-
-        cm = CrystalMap(phase_id=phase_id, **crystal_map_input)
+    @pytest.mark.parametrize(
+        "crystal_map_input",
+        [
+            ((1, 4, 3), (0, 1.5, 1.5), 1, [0, 1]),
+            ((1, 4, 3), (0, 1.5, 1.5), 1, [1, -1]),
+        ],
+        indirect=["crystal_map_input"],
+    )
+    def test_init_with_phase_id(self, crystal_map_input):
+        phase_id = crystal_map_input["phase_id"]
+        cm = CrystalMap(**crystal_map_input)
 
         assert np.allclose(cm.phase_id, phase_id)
         # Test all_indexed
-        if -1 in unique_phase_ids:
+        if -1 in np.unique(phase_id):
             assert not cm.all_indexed
-            assert -1 in cm.phases.phase_ids
+            assert -1 in cm.phases.ids
         else:
             assert cm.all_indexed
-            assert -1 not in cm.phases.phase_ids
+            assert -1 not in cm.phases.ids
 
-    def test_init_with_symmetry_list(self, crystal_map_input):
-        symmetries = [C2, C3]
-        cm = CrystalMap(symmetry=symmetries, **crystal_map_input)
-        assert cm.phases.symmetries == symmetries
+    @pytest.mark.parametrize(
+        "crystal_map_input",
+        [
+            ((1, 4, 3), (0, 1.5, 1.5), 1, [0, 1, 2]),
+            ((1, 4, 3), (0, 1.5, 1.5), 1, [0, 1, 2, 3]),
+            ((1, 4, 3), (0, 1.5, 1.5), 1, [0, 1]),
+        ],
+        indirect=["crystal_map_input"],
+    )
+    def test_init_with_phase_list(self, crystal_map_input):
+        symmetries = [C2, C3, C4]
+        phase_list = PhaseList(symmetries=symmetries)
+        cm = CrystalMap(phase_list=phase_list, **crystal_map_input)
+
+        n_symmetries = len(symmetries)
+        n_phase_ids = len(cm.phases.ids)
+        n_different = n_symmetries - n_phase_ids
+        if n_different < 0:
+            symmetries += [None] * abs(n_different)
+        assert [cm.phases.symmetries[i] == symmetries[i] for i in range(n_phase_ids)]
 
     def test_init_with_single_symmetry(self, crystal_map_input):
         symmetry = O
-        cm = CrystalMap(symmetry=symmetry, **crystal_map_input)
-        assert cm.phases.symmetries[0] == symmetry
+        phase_list = PhaseList(symmetries=symmetry)
+        cm = CrystalMap(phase_list=phase_list, **crystal_map_input)
+        assert np.allclose(cm.phases.symmetries[0].data, symmetry.data)
 
 
 class TestCrystalMapGetItem:
     @pytest.mark.parametrize(
         "crystal_map_input, slice_tuple, expected_shape",
         [
-            (((5, 5, 5), (1, 1, 1), 1), slice(None, None, None), (5, 5, 5)),
+            (((5, 5, 5), (1, 1, 1), 1, [0]), slice(None, None, None), (5, 5, 5)),
             (
-                ((5, 5, 5), (1, 1, 1), 1),
+                ((5, 5, 5), (1, 1, 1), 1, [0]),
                 (slice(1, 2, None), slice(None, None, None)),
                 (1, 5, 5),
             ),
             (
-                ((2, 5, 5), (1, 1, 1), 1),
+                ((2, 5, 5), (1, 1, 1), 1, [0]),
                 (slice(0, 2, None), slice(None, None, None), slice(1, 4, None)),
                 (2, 5, 3),
             ),
             (
-                ((3, 10, 10), (1, 0.5, 0.1), 2),
+                ((3, 10, 10), (1, 0.5, 0.1), 2, [0]),
                 (1, slice(5, 10, None), slice(None, None, None)),
                 (1, 5, 10),
             ),
             (
-                ((3, 10, 10), (1, 0.5, 0.1), 2),
+                ((3, 10, 10), (1, 0.5, 0.1), 2, [0]),
                 (slice(None, 10, None), slice(2, 4, None), slice(None, 3, None)),
                 (3, 2, 3),
             ),
@@ -178,8 +208,8 @@ class TestCrystalMapGetItem:
         x = crystal_map_input["x"]
 
         # Create phase ID array, ensuring all are present
-        phase_ids = np.random.choice(phase_list.phase_ids, x.size)
-        for i, unique_id in enumerate(phase_list.phase_ids):
+        phase_ids = np.random.choice(phase_list.ids, x.size)
+        for i, unique_id in enumerate(phase_list.ids):
             phase_ids[i] = unique_id
 
         # Get number of points with each phase ID
@@ -187,6 +217,7 @@ class TestCrystalMapGetItem:
         for phase_i, phase in phase_list:
             n_points_per_phase[phase.name] = len(np.where(phase_ids == phase_i)[0])
 
+        crystal_map_input.pop("phase_id")
         cm = CrystalMap(phase_id=phase_ids, **crystal_map_input)
         cm.phases = phase_list
 
@@ -213,7 +244,7 @@ class TestCrystalMapGetItem:
 
     @pytest.mark.parametrize(
         "crystal_map_input",
-        [((1, 4, 3), (1, 1, 1), 1)],
+        [((1, 4, 3), (1, 1, 1), 1, [0])],
         indirect=["crystal_map_input"],
     )
     def test_get_by_condition(self, crystal_map_input):
@@ -232,11 +263,11 @@ class TestCrystalMapGetItem:
     def test_get_by_multiple_conditions(self, crystal_map, phase_list):
         cm = crystal_map
 
-        assert phase_list.phase_ids == [0, 1, 2]  # Test code assumption
+        assert phase_list.ids == [0, 1, 2]  # Test code assumption
 
         cm.phases = phase_list
         cm.prop["dp"] = np.arange(cm.size)
-        a_phase_id = phase_list.phase_ids[0]
+        a_phase_id = phase_list.ids[0]
         cm[cm.dp > 3].phase_id = a_phase_id
 
         condition1 = cm.dp > 3
@@ -248,11 +279,11 @@ class TestCrystalMapGetItem:
     @pytest.mark.parametrize(
         "crystal_map_input, integer_slices, expected_id, raises",
         [
-            (((3, 4, 4), (1, 1, 1), 1), (0, 0, 2), 2, False),
-            (((3, 4, 4), (1, 1, 1), 3), (0, 2, 0), 8, False),
-            (((3, 4, 4), (1, 1, 1), 3), (2, 0, 0), 32, False),
-            (((1, 4, 1), (0, 1, 0), 2), 1, 1, False),
-            (((3, 4, 4), (1, 1, 1), 3), (1000, 0, 0), None, True),
+            (((3, 4, 4), (1, 1, 1), 1, [0]), (0, 0, 2), 2, False),
+            (((3, 4, 4), (1, 1, 1), 3, [0]), (0, 2, 0), 8, False),
+            (((3, 4, 4), (1, 1, 1), 3, [0]), (2, 0, 0), 32, False),
+            (((1, 4, 1), (0, 1, 0), 2, [0]), 1, 1, False),
+            (((3, 4, 4), (1, 1, 1), 3, [0]), (1000, 0, 0), None, True),
         ],
         indirect=["crystal_map_input"],
     )
@@ -304,7 +335,7 @@ class TestCrystalMapSetAttributes:
         cm = crystal_map
 
         condition = cm.x > 1.5
-        phase_ids = cm.phases.phase_ids  # Get before adding a new phase
+        phase_ids = cm.phases.ids  # Get before adding a new phase
 
         if index_error:
             with pytest.raises(IndexError, match="list index out of range"):
@@ -321,7 +352,7 @@ class TestCrystalMapSetAttributes:
 
         new_phase_ids = phase_ids + [set_phase_id]
         new_phase_ids.sort()
-        assert cm.phases.phase_ids == new_phase_ids
+        assert cm.phases.ids == new_phase_ids
 
     def test_phases_in_data(self, crystal_map, phase_list):
         cm = crystal_map
@@ -330,7 +361,7 @@ class TestCrystalMapSetAttributes:
         assert cm.phases_in_data.names != cm.phases.names
 
         ids_not_in_data = np.setdiff1d(
-            np.array(cm.phases.phase_ids), np.array(cm.phases_in_data.phase_ids)
+            np.array(cm.phases.ids), np.array(cm.phases_in_data.ids)
         )
         condition1 = cm.x > 1.5
         condition2 = cm.y > 1.5
@@ -345,10 +376,11 @@ class TestCrystalMapOrientations:
         x = crystal_map_input["x"]
 
         # Create phase ID array, ensuring all are present
-        phase_ids = np.random.choice(phase_list.phase_ids, x.size)
-        for i, unique_id in enumerate(phase_list.phase_ids):
+        phase_ids = np.random.choice(phase_list.ids, x.size)
+        for i, unique_id in enumerate(phase_list.ids):
             phase_ids[i] = unique_id
 
+        crystal_map_input.pop("phase_id")
         cm = CrystalMap(phase_id=phase_ids, **crystal_map_input)
 
         # Set phases and make sure all are in data
@@ -357,7 +389,7 @@ class TestCrystalMapOrientations:
 
         # Ensure all points have a valid orientation
         orientations_size = 0
-        for phase_id in phase_list.phase_ids:
+        for phase_id in phase_list.ids:
             o = cm[cm.phase_id == phase_id].orientations
             assert isinstance(o, Orientation)
             orientations_size += o.size
@@ -404,7 +436,7 @@ class TestCrystalMapOrientations:
 
     @pytest.mark.parametrize(
         "crystal_map_input, rotations_per_point",
-        [(((1, 5, 5), (0, 1.5, 1.5), 3), 3)],
+        [(((1, 5, 5), (0, 1.5, 1.5), 3, [0]), 3)],
         indirect=["crystal_map_input"],
     )
     def test_multiple_orientations_per_point(
@@ -412,7 +444,7 @@ class TestCrystalMapOrientations:
     ):
         cm = CrystalMap(**crystal_map_input)
 
-        assert cm.phases.phase_ids == [0]  # Test code assumption
+        assert cm.phases.ids == [0]  # Test code assumption
         cm.phases[0].symmetry = "m-3m"
 
         assert cm.rotations_per_point == rotations_per_point
@@ -462,17 +494,17 @@ class TestCrystalMapGetMapData:
         "crystal_map_input, to_get, expected_array",
         [
             (
-                ((1, 4, 4), (0, 0.5, 1), 2),
+                ((1, 4, 4), (0, 0.5, 1), 2, [0]),
                 "x",
                 np.array([0, 1, 2, 3] * 4).reshape((4, 4)),
             ),
             (
-                ((1, 4, 4), (0, 0.5, 1), 2),
+                ((1, 4, 4), (0, 0.5, 1), 2, [0]),
                 "y",
                 np.array([[i * 0.5] * 4 for i in range(4)]),  # [0, 0, 0, 0, 0.5, ...]
             ),
             (
-                ((2, 4, 4), (0.28, 0.5, 1), 2),
+                ((2, 4, 4), (0.28, 0.5, 1), 2, [0]),
                 "z",
                 np.stack((np.zeros((4, 4)), np.ones((4, 4)) * 0.28), axis=0),
             ),
@@ -511,7 +543,7 @@ class TestCrystalMapGetMapData:
 
     @pytest.mark.parametrize(
         "crystal_map_input",
-        [((1, 3, 2), (0, 1, 1), 3), ((3, 1, 2), (1, 1, 1), 1)],
+        [((1, 3, 2), (0, 1, 1), 3, [0]), ((3, 1, 2), (1, 1, 1), 1, [0])],
         indirect=["crystal_map_input"],
     )
     def test_get_orientations_array(self, crystal_map_input, phase_list):
@@ -567,7 +599,7 @@ class TestCrystalMapGetMapData:
 
     @pytest.mark.parametrize(
         "crystal_map_input",
-        [((1, 2, 2), (0, 1, 1), 2), ((3, 2, 2), (1, 1, 1), 1),],
+        [((1, 2, 2), (0, 1, 1), 2, [0]), ((3, 2, 2), (1, 1, 1), 1, [0])],
         indirect=["crystal_map_input"],
     )
     def test_get_rotations_array(self, crystal_map_input):
@@ -576,8 +608,11 @@ class TestCrystalMapGetMapData:
         # Get with string
         r = cm.get_map_data("rotations")
 
-        new_shape = cm.rotations_shape + (3,)
-        expected_array = cm.rotations.to_euler().reshape(*new_shape)
+        new_shape = cm.shape + (3,)
+        if cm.rotations_per_point > 1:
+            expected_array = cm.rotations[:, 0].to_euler().reshape(*new_shape)
+        else:
+            expected_array = cm.rotations.to_euler().reshape(*new_shape)
         assert np.allclose(r, expected_array, atol=1e-3)
 
         # Get with array (RGB)
@@ -587,7 +622,7 @@ class TestCrystalMapGetMapData:
 
     @pytest.mark.parametrize(
         "crystal_map_input",
-        [((3, 9, 3), (1, 1.5, 1.5), 2), ((2, 10, 5), (1, 0.1, 0.1), 3),],
+        [((3, 9, 3), (1, 1.5, 1.5), 2, [0]), ((2, 10, 5), (1, 0.1, 0.1), 3, [0])],
         indirect=["crystal_map_input"],
     )
     def test_get_phase_id_array_from_3d_data(self, crystal_map_input):
@@ -597,9 +632,9 @@ class TestCrystalMapGetMapData:
     @pytest.mark.parametrize(
         "crystal_map_input, to_get",
         [
-            (((1, 4, 3), (1, 1, 1), 1), "z"),
-            (((4, 1, 3), (1, 1, 1), 1), "y"),
-            (((4, 3, 1), (1, 1, 1), 1), "x"),
+            (((1, 4, 3), (1, 1, 1), 1, [0]), "z"),
+            (((4, 1, 3), (1, 1, 1), 1, [0]), "y"),
+            (((4, 3, 1), (1, 1, 1), 1, [0]), "x"),
         ],
         indirect=["crystal_map_input"],
     )
@@ -616,11 +651,11 @@ class TestCrystalMapRepresentation:
         cm.scan_unit = "nm"
 
         # Test code assumptions
-        assert phase_list.phase_ids == [0, 1, 2]
+        assert phase_list.ids == [0, 1, 2]
         assert cm.shape == (4, 3)
 
-        cm[0, 1].phase_id = phase_list.phase_ids[1]
-        cm[1, 1].phase_id = phase_list.phase_ids[2]
+        cm[0, 1].phase_id = phase_list.ids[1]
+        cm[1, 1].phase_id = phase_list.ids[2]
 
         cm.prop["iq"] = np.arange(cm.size)
 
@@ -639,54 +674,53 @@ class TestCrystalMapRepresentation:
 
 
 class TestCrystalMapCopying:
-    def test_shallowcopy_crystal_map(self, crystal_map_input):
-        map_size = crystal_map_input["x"].size
-        phase_ids = np.arange(map_size)
+    def test_shallowcopy_crystal_map(self, crystal_map):
+        cm2 = crystal_map[:]  # Everything except `is_in_data` is shallow copied
+        cm3 = crystal_map  # These are the same objects (of course)
 
-        cm = CrystalMap(phase_id=phase_ids, **crystal_map_input)
+        assert np.may_share_memory(cm2._phase_id, crystal_map._phase_id)
+        assert np.may_share_memory(cm2._rotations.data, crystal_map._rotations.data)
 
-        cm2 = cm[:]  # Everything except `is_in_data` is shallow copied
-        cm3 = cm  # These are the same objects (of course)
-
-        assert np.may_share_memory(cm2._phase_id, cm._phase_id)
-        assert np.may_share_memory(cm2._rotations.data, cm._rotations.data)
-
-        cm[3, 0].phase_id = -2
-        assert np.allclose(cm2.phase_id, cm.phase_id)
-        assert np.allclose(cm3.phase_id, cm.phase_id)
+        crystal_map[3, 0].phase_id = -2
+        assert np.allclose(cm2.phase_id, crystal_map.phase_id)
+        assert np.allclose(cm3.phase_id, crystal_map.phase_id)
 
         # The user is strictly speaking only supposed to change this via __getitem__()
-        cm.is_in_data[2] = False
-        assert cm2.size != cm.size
-        assert cm3.size == cm.size
-        assert np.allclose(cm2.is_in_data, cm.is_in_data) is False
-        assert np.may_share_memory(cm3.is_in_data, cm.is_in_data)
+        crystal_map.is_in_data[2] = False
+        assert cm2.size != crystal_map.size
+        assert cm3.size == crystal_map.size
+        assert np.allclose(cm2.is_in_data, crystal_map.is_in_data) is False
+        assert np.may_share_memory(cm3.is_in_data, crystal_map.is_in_data)
 
-    def test_deepcopy_crystal_map(self, crystal_map_input):
-        map_size = crystal_map_input["x"].size
-        phase_ids = np.arange(map_size)
+    def test_deepcopy_crystal_map(self, crystal_map):
+        cm2 = crystal_map.deepcopy()
 
-        cm = CrystalMap(phase_id=phase_ids, **crystal_map_input)
-
-        cm2 = cm.deepcopy()
-
-        cm[3, 0].phase_id = -2
-        assert np.allclose(cm2.phase_id, cm.phase_id) is False
-        assert np.may_share_memory(cm2._phase_id, cm._phase_id) is False
+        crystal_map[3, 0].phase_id = -2
+        assert np.allclose(cm2.phase_id, crystal_map.phase_id) is False
+        assert np.may_share_memory(cm2._phase_id, crystal_map._phase_id) is False
 
 
 class TestCrystalMapShape:
     @pytest.mark.parametrize(
         "crystal_map_input, expected_slices",
         [
-            (((1, 10, 30), (0, 0.1, 0.1), 2), (slice(0, 10, None), slice(0, 30, None))),
             (
-                ((2, 13, 27), (0.3, 0.7, 0.9), 3),
+                ((1, 10, 30), (0, 0.1, 0.1), 2, [0]),
+                (slice(0, 10, None), slice(0, 30, None)),
+            ),
+            (
+                ((2, 13, 27), (0.3, 0.7, 0.9), 3, [0]),
                 (slice(0, 2, None), slice(0, 13, None), slice(0, 27, None)),
             ),
-            (((1, 4, 3), (0, 1.5, 1.5), 1), (slice(0, 4, None), slice(0, 3, None))),
+            (
+                ((1, 4, 3), (0, 1.5, 1.5), 1, [0]),
+                (slice(0, 4, None), slice(0, 3, None)),
+            ),
             # Testing rounding 15 / 2 = 7.5 and 45 / 2 = 22.5
-            (((1, 15, 45), (0, 2, 2), 1), (slice(0, 15, None), slice(0, 45, None))),
+            (
+                ((1, 15, 45), (0, 2, 2), 1, [0]),
+                (slice(0, 15, None), slice(0, 45, None)),
+            ),
         ],
         indirect=["crystal_map_input"],
     )
@@ -699,7 +733,7 @@ class TestCrystalMapShape:
         [
             # Slice 3D data with an index in all axes
             (
-                ((2, 3, 4), (1, 1, 1), 1),
+                ((2, 3, 4), (1, 1, 1), 1, [0]),
                 (1, 2, 3),
                 1,
                 (1, 1, 1),
@@ -707,7 +741,7 @@ class TestCrystalMapShape:
             ),
             # Slice 3D data with indices in only two axes
             (
-                ((2, 3, 4), (0.1, 0.1, 0.1), 1),
+                ((2, 3, 4), (0.1, 0.1, 0.1), 1, [0]),
                 (1, 2),
                 4,
                 (1, 1, 4),
@@ -716,7 +750,7 @@ class TestCrystalMapShape:
             # Slice 3D data with indices in only two axes (same as above, to make sure
             # slice determination is unaffected by step size)
             (
-                ((2, 3, 4), (1, 1, 1), 1),
+                ((2, 3, 4), (1, 1, 1), 1, [0]),
                 (1, 2),
                 4,
                 (1, 1, 4),
@@ -724,7 +758,7 @@ class TestCrystalMapShape:
             ),
             # Slice 3D data with an index in only one axis
             (
-                ((2, 3, 4), (0.1, 0.1, 0.1), 1),
+                ((2, 3, 4), (0.1, 0.1, 0.1), 1, [0]),
                 (1,),
                 12,
                 (1, 3, 4),
@@ -748,10 +782,10 @@ class TestCrystalMapShape:
     @pytest.mark.parametrize(
         "crystal_map_input, expected_shape",
         [
-            (((1, 10, 30), (0, 0.1, 0.1), 2), (10, 30)),
-            (((2, 13, 27), (0.3, 0.7, 0.9), 3), (2, 13, 27)),
-            (((1, 4, 3), (0, 1.5, 1.5), 1), (4, 3)),
-            (((1, 15, 45), (0, 2, 2), 2), (15, 45)),
+            (((1, 10, 30), (0, 0.1, 0.1), 2, [0]), (10, 30)),
+            (((2, 13, 27), (0.3, 0.7, 0.9), 3, [0]), (2, 13, 27)),
+            (((1, 4, 3), (0, 1.5, 1.5), 1, [0]), (4, 3)),
+            (((1, 15, 45), (0, 2, 2), 2, [0]), (15, 45)),
         ],
         indirect=["crystal_map_input"],
     )
@@ -762,10 +796,10 @@ class TestCrystalMapShape:
     @pytest.mark.parametrize(
         "crystal_map_input, expected_shape",
         [
-            (((1, 10, 30), (0, 0.1, 0.1), 2), (10, 30, 2)),
-            (((2, 13, 27), (0.3, 0.7, 0.9), 3), (2, 13, 27, 3)),
-            (((1, 4, 3), (0, 1.5, 1.5), 5), (4, 3, 5)),
-            (((1, 15, 45), (0, 2, 2), 2), (15, 45, 2)),
+            (((1, 10, 30), (0, 0.1, 0.1), 2, [0]), (10, 30, 2)),
+            (((2, 13, 27), (0.3, 0.7, 0.9), 3, [0]), (2, 13, 27, 3)),
+            (((1, 4, 3), (0, 1.5, 1.5), 5, [0]), (4, 3, 5)),
+            (((1, 15, 45), (0, 2, 2), 2, [0]), (15, 45, 2)),
         ],
         indirect=["crystal_map_input"],
     )
@@ -776,11 +810,11 @@ class TestCrystalMapShape:
     @pytest.mark.parametrize(
         "crystal_map_input, expected_coordinate_axes",
         [
-            (((1, 10, 30), (0, 0.1, 0.1), 1), {0: "y", 1: "x"}),
-            (((2, 13, 27), (0.3, 0.7, 0.9), 1), {0: "z", 1: "y", 2: "x"}),
-            (((1, 13, 27), (0, 1.5, 1.5), 1), {0: "y", 1: "x"}),
-            (((2, 13, 1), (1, 2, 1), 2), {0: "z", 1: "y"}),
-            (((2, 1, 13), (1, 0, 2), 1), {0: "z", 1: "x"}),
+            (((1, 10, 30), (0, 0.1, 0.1), 1, [0]), {0: "y", 1: "x"}),
+            (((2, 13, 27), (0.3, 0.7, 0.9), 1, [0]), {0: "z", 1: "y", 2: "x"}),
+            (((1, 13, 27), (0, 1.5, 1.5), 1, [0]), {0: "y", 1: "x"}),
+            (((2, 13, 1), (1, 2, 1), 2, [0]), {0: "z", 1: "y"}),
+            (((2, 1, 13), (1, 0, 2), 1, [0]), {0: "z", 1: "x"}),
         ],
         indirect=["crystal_map_input"],
     )

--- a/orix/tests/test_crystal_map_plot.py
+++ b/orix/tests/test_crystal_map_plot.py
@@ -22,7 +22,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 import pytest
 
-from orix import plot  # Needed for projection="plot_map"? Might be imported via below
 from orix.plot import CrystalMapPlot
 from orix.plot.crystal_map_plot import convert_unit
 from orix.crystal_map import CrystalMap
@@ -41,8 +40,8 @@ class TestCrystalMapPlot:
     @pytest.mark.parametrize(
         "crystal_map_input, expected_data_shape",
         [
-            (((1, 10, 20), (0, 1.5, 1.5), 1), (10, 20, 3)),
-            (((1, 4, 3), (0, 0.1, 0.1), 1), (4, 3, 3)),
+            (((1, 10, 20), (0, 1.5, 1.5), 1, [0]), (10, 20, 3)),
+            (((1, 4, 3), (0, 0.1, 0.1), 1, [0]), (4, 3, 3)),
         ],
         indirect=["crystal_map_input"],
     )
@@ -51,7 +50,7 @@ class TestCrystalMapPlot:
         cm = CrystalMap(**crystal_map_input)
 
         assert np.unique(cm.phase_id) == np.array([0])  # Test code assumption
-        assert phase_list.phase_ids == [0, 1, 2]
+        assert phase_list.ids == [0, 1, 2]
         cm.phases = phase_list
         cm[0, 0].phase_id = 0
         cm[1, 1].phase_id = 2
@@ -113,7 +112,7 @@ class TestCrystalMapPlot:
 
     @pytest.mark.parametrize(
         "crystal_map_input",
-        [((2, 9, 3), (1, 1.5, 1.5), 1), ((2, 10, 5), (1, 0.1, 0.1), 1)],
+        [((2, 9, 3), (1, 1.5, 1.5), 1, [0]), ((2, 10, 5), (1, 0.1, 0.1), 1, [0])],
         indirect=["crystal_map_input"],
     )
     @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
@@ -122,7 +121,7 @@ class TestCrystalMapPlot:
 
         # Test code assumptions
         assert np.unique(cm.phase_id) == np.array([0])
-        assert phase_list.phase_ids == [0, 1, 2]
+        assert phase_list.ids == [0, 1, 2]
         assert cm.ndim == 3
 
         cm.phases = phase_list
@@ -141,7 +140,7 @@ class TestCrystalMapPlot:
 
     @pytest.mark.parametrize(
         "crystal_map_input",
-        [((2, 9, 6), (1, 1.5, 1.5), 2), ((2, 10, 5), (1, 0.1, 0.1), 1)],
+        [((2, 9, 6), (1, 1.5, 1.5), 2, [0]), ((2, 10, 5), (1, 0.1, 0.1), 1, [0])],
         indirect=["crystal_map_input"],
     )
     @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
@@ -187,9 +186,9 @@ class TestCrystalMapPlotUtilities:
     @pytest.mark.parametrize(
         "crystal_map_input, idx_to_change, axes, depth, expected_plot_shape",
         [
-            (((2, 10, 20), (1, 1.5, 1.5), 1), (1, 5, 4), (1, 2), 1, (10, 20)),
-            (((4, 4, 3), (0.1, 0.1, 0.1), 1), (0, 0, 2), (0, 1), 2, (4, 4)),
-            (((10, 10, 10), (1, 1, 1), 2), (-1, 8, -1), (0, 2), 8, (10, 10)),
+            (((2, 10, 20), (1, 1.5, 1.5), 1, [0]), (1, 5, 4), (1, 2), 1, (10, 20)),
+            (((4, 4, 3), (0.1, 0.1, 0.1), 1, [0]), (0, 0, 2), (0, 1), 2, (4, 4)),
+            (((10, 10, 10), (1, 1, 1), 2, [0]), (-1, 8, -1), (0, 2), 8, (10, 10)),
         ],
         indirect=["crystal_map_input"],
     )
@@ -464,9 +463,9 @@ class TestScalebar:
     @pytest.mark.parametrize(
         "crystal_map_input, scalebar_properties, artist_attribute",
         [
-            (((1, 10, 30), (0, 1, 1), 1), {}, {}),  # Default
+            (((1, 10, 30), (0, 1, 1), 1, [0]), {}, {}),  # Default
             (
-                ((1, 10, 30), (0, 1, 1), 1),
+                ((1, 10, 30), (0, 1, 1), 1, [0]),
                 {
                     "loc": 4,
                     "frameon": False,
@@ -521,12 +520,12 @@ class TestScalebar:
             "expected_width_unit, expected_unit"
         ),
         [
-            (((10, 20, 1), (1, 1, 0), 1), "px", {0: "z", 1: "y"}, 2, 2, "px"),
-            (((1, 10, 30), (0, 1, 1), 1), "px", {0: "y", 1: "x"}, 2, 2, "px"),
-            (((1, 10, 40), (0, 1, 1), 1), "px", {0: "y", 1: "x"}, 5, 5, "px"),
-            (((20, 1, 10), (1, 1, 1), 1), "um", {0: "z", 1: "x"}, 1, 1, "um"),
+            (((10, 20, 1), (1, 1, 0), 1, [0]), "px", {0: "z", 1: "y"}, 2, 2, "px"),
+            (((1, 10, 30), (0, 1, 1), 1, [0]), "px", {0: "y", 1: "x"}, 2, 2, "px"),
+            (((1, 10, 40), (0, 1, 1), 1, [0]), "px", {0: "y", 1: "x"}, 5, 5, "px"),
+            (((20, 1, 10), (1, 1, 1), 1, [0]), "um", {0: "z", 1: "x"}, 1, 1, "um"),
             (
-                ((1, 100, 117), (0, 1.5, 1.5), 1),
+                ((1, 100, 117), (0, 1.5, 1.5), 1, [0]),
                 "nm",
                 {0: "y", 1: "x"},
                 13.33,
@@ -573,8 +572,8 @@ class TestScalebar:
     @pytest.mark.parametrize(
         "crystal_map_input, warns",
         [
-            (((1, 10, 20), (0, 1.5, 1.5), 1), False),
-            (((1, 4, 3), (0, 0.1, 0.1), 1), True),
+            (((1, 10, 20), (0, 1.5, 1.5), 1, [0]), False),
+            (((1, 4, 3), (0, 0.1, 0.1), 1, [0]), True),
         ],
         indirect=["crystal_map_input"],
     )

--- a/orix/tests/test_io.py
+++ b/orix/tests/test_io.py
@@ -45,7 +45,7 @@ class TestGeneralIO:
     @pytest.mark.parametrize("temp_file_path", ["ctf"], indirect=["temp_file_path"])
     def test_load_unsupported_format(self, temp_file_path):
         np.savetxt(temp_file_path, X=np.random.rand(100, 8))
-        with pytest.raises(IOError, match=f"Could not read '{temp_file_path}'. If the"):
+        with pytest.raises(IOError, match=f"Could not read "):
             _ = load(temp_file_path)
 
 

--- a/orix/tests/test_io.py
+++ b/orix/tests/test_io.py
@@ -16,25 +16,92 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
+from contextlib import contextmanager
+from collections import OrderedDict
+from io import StringIO
+from numbers import Number
 import os
+import sys
 
 from diffpy.structure import Lattice, Structure
+from h5py import File
 import pytest
 import numpy as np
 
-from orix import io
-from orix.io import load
+from orix import __version__ as orix_version
+from orix.crystal_map import CrystalMap, Phase, PhaseList
+from orix.io import (
+    load,
+    save,
+    loadang,
+    loadctf,
+    _plugin_from_footprints,
+    _overwrite_or_not,
+)
 from orix.io.plugins.ang import (
     _get_header,
     _get_phases_from_header,
     _get_vendor_columns,
 )
+from orix.io.plugins.orix_hdf5 import (
+    hdf5group2dict,
+    dict2crystalmap,
+    dict2phaselist,
+    dict2phase,
+    dict2structure,
+    dict2lattice,
+    dict2atom,
+    dict2hdf5group,
+    crystalmap2dict,
+    phaselist2dict,
+    phase2dict,
+    structure2dict,
+    lattice2dict,
+    atom2dict,
+)
+from orix.io.plugins import ang, emsoft_h5ebsd, orix_hdf5
+from orix.quaternion.rotation import Rotation
 
 from orix.tests.conftest import (
     ANGFILE_TSL_HEADER,
     ANGFILE_ASTAR_HEADER,
     ANGFILE_EMSOFT_HEADER,
 )
+
+plugin_list = [ang, emsoft_h5ebsd, orix_hdf5]
+
+
+@contextmanager
+def replace_stdin(target):
+    orig = sys.stdin
+    sys.stdin = target
+    yield
+    sys.stdin = orig
+
+
+def assert_dictionaries_are_equal(input_dict, output_dict):
+    for key in output_dict.keys():
+        output_value = output_dict[key]
+        input_value = input_dict[key]
+        if isinstance(output_value, (dict, OrderedDict)):
+            assert_dictionaries_are_equal(input_value, output_value)
+        else:
+            if isinstance(output_value, (np.ndarray, Number)):
+                assert np.allclose(input_value, output_value)
+            elif isinstance(output_value, Rotation):
+                assert np.allclose(input_value.to_euler(), output_value.to_euler())
+            elif isinstance(output_value, Phase):
+                assert_dictionaries_are_equal(
+                    input_value.__dict__, output_value.__dict__
+                )
+            elif isinstance(output_value, PhaseList):
+                assert_dictionaries_are_equal(input_value._dict, output_value._dict)
+            elif isinstance(output_value, Structure):
+                assert np.allclose(output_value.xyz, input_value.xyz)
+                assert str(output_value.element) == str(input_value.element)
+                assert np.allclose(output_value.occupancy, input_value.occupancy)
+            else:
+                assert input_value == output_value
 
 
 class TestGeneralIO:
@@ -48,6 +115,66 @@ class TestGeneralIO:
         np.savetxt(temp_file_path, X=np.random.rand(100, 8))
         with pytest.raises(IOError, match=f"Could not read "):
             _ = load(temp_file_path)
+
+    @pytest.mark.parametrize(
+        "top_group, expected_plugin",
+        [("Scan 1", emsoft_h5ebsd), ("crystal_map", orix_hdf5), ("Scan 2", None)],
+    )
+    def test_plugin_from_footprints(self, temp_file_path, top_group, expected_plugin):
+        with File(temp_file_path, mode="w") as f:
+            f.create_group(top_group)
+            assert (
+                _plugin_from_footprints(
+                    temp_file_path, plugins=[emsoft_h5ebsd, orix_hdf5]
+                )
+                is expected_plugin
+            )
+
+    def test_overwrite_or_not(self, crystal_map, temp_file_path):
+        save(temp_file_path, crystal_map)
+        with pytest.warns(UserWarning, match="Not overwriting, since your terminal "):
+            _overwrite_or_not(temp_file_path)
+
+    @pytest.mark.parametrize(
+        "answer, expected", [("y", True), ("n", False), ("m", None)]
+    )
+    def test_overwrite_or_not_input(
+        self, crystal_map, temp_file_path, answer, expected
+    ):
+        save(temp_file_path, crystal_map)
+        if answer == "m":
+            with replace_stdin(StringIO(answer)):
+                with pytest.raises(EOFError):
+                    _overwrite_or_not(temp_file_path)
+        else:
+            with replace_stdin(StringIO(answer)):
+                assert _overwrite_or_not(temp_file_path) is expected
+
+    @pytest.mark.parametrize("temp_file_path", ["angs", "hdf4", "h6"])
+    def test_save_unsupported_raises(self, temp_file_path, crystal_map):
+        _, ext = os.path.splitext(temp_file_path)
+        with pytest.raises(IOError, match=f"'{ext}' does not correspond to any "):
+            save(temp_file_path, crystal_map)
+
+    def test_save_overwrite_raises(self, temp_file_path, crystal_map):
+        with pytest.raises(ValueError, match="`overwrite` parameter can only be "):
+            save(temp_file_path, crystal_map, overwrite=1)
+
+    @pytest.mark.parametrize(
+        "overwrite, expected_phase_name", [(True, "hepp"), (False, "")]
+    )
+    def test_save_overwrite(
+        self, temp_file_path, crystal_map, overwrite, expected_phase_name
+    ):
+        assert crystal_map.phases[0].name == ""
+        save(temp_file_path, crystal_map)
+        assert os.path.isfile(temp_file_path) is True
+
+        crystal_map.phases[0].name = "hepp"
+        save(temp_file_path, crystal_map, overwrite=overwrite)
+
+        crystal_map2 = load(temp_file_path)
+        assert crystal_map2.phases[0].name == expected_phase_name
 
 
 @pytest.mark.parametrize(
@@ -92,7 +219,7 @@ class TestGeneralIO:
     indirect=["angfile_astar"],
 )
 def test_loadang(angfile_astar, expected_data):
-    loaded_data = io.loadang(angfile_astar)
+    loaded_data = loadang(angfile_astar)
     assert np.allclose(loaded_data.data, expected_data)
 
 
@@ -102,11 +229,11 @@ def test_loadctf():
     fname = "temp.ctf"
     np.savetxt(fname, z)
 
-    _ = io.loadctf(fname)
+    _ = loadctf(fname)
     os.remove(fname)
 
 
-class TestAngReader:
+class TestAngPlugin:
     @pytest.mark.parametrize(
         "angfile_tsl, map_shape, step_sizes, phase_id, n_unknown_columns, example_rot",
         [
@@ -210,7 +337,7 @@ class TestAngReader:
 
         # Phases
         assert cm.phases.size == 2  # Including non-indexed
-        assert cm.phases.phase_ids == [-1, 0]
+        assert cm.phases.ids == [-1, 0]
         phase = cm.phases[0]
         assert phase.name == "Aluminum"
         assert phase.symmetry.name == "432"
@@ -297,7 +424,7 @@ class TestAngReader:
 
         # Phases
         assert cm.phases.size == 1
-        assert cm.phases.phase_ids == [1]
+        assert cm.phases.ids == [1]
         phase = cm.phases[1]
         assert phase.name == "Nickel"
         assert phase.symmetry.name == "432"
@@ -397,7 +524,7 @@ class TestAngReader:
         # Phases (change if file header is changed!)
         phases_in_data = cm["indexed"].phases_in_data
         assert phases_in_data.size == 2
-        assert phases_in_data.phase_ids == [1, 2]
+        assert phases_in_data.ids == [1, 2]
         assert phases_in_data.names == ["austenite", "ferrite"]
         assert [i.name for i in phases_in_data.symmetries] == ["432",] * 2
 
@@ -539,7 +666,7 @@ class TestAngReader:
         assert np.allclose(lattice_constants, expected_lattice_constants)
 
 
-class TestEMsoftReader:
+class TestEMsoftPlugin:
     @pytest.mark.parametrize(
         (
             "temp_emsoft_h5ebsd_file, map_shape, step_sizes, example_rot, "
@@ -633,3 +760,133 @@ class TestEMsoftReader:
             title="austenite",
             lattice=Lattice(a=3.595, b=3.595, c=3.595, alpha=90, beta=90, gamma=90),
         )
+
+
+class TestOrixHDF5Plugin:
+    def test_file_writer(self, crystal_map, temp_file_path):
+        save(filename=temp_file_path, object2write=crystal_map)
+
+        with File(temp_file_path, mode="r") as f:
+            assert f["manufacturer"][()][0].decode() == "orix"
+            assert f["version"][()][0].decode() == orix_version
+
+    def test_file_writer_raises(self, temp_file_path, crystal_map):
+        with pytest.raises(OSError, match="Cannot write to the already open file "):
+            with File(temp_file_path, mode="w") as _:
+                save(temp_file_path, crystal_map, overwrite=True)
+
+    def test_dict2hdf5group(self, temp_file_path):
+        with File(temp_file_path, mode="w") as f:
+            group = f.create_group(name="a_group")
+            with pytest.warns(UserWarning, match="The orix HDF5 writer could not"):
+                dict2hdf5group(
+                    dictionary={"a": [np.array(24.5)], "c": set()}, group=group
+                )
+
+    def test_crystalmap2dict(self, temp_file_path, crystal_map_input):
+        cm = CrystalMap(**crystal_map_input)
+        cm_dict = crystalmap2dict(cm)
+
+        this_dict = {"hello": "there"}
+        cm_dict2 = crystalmap2dict(cm, dictionary=this_dict)
+
+        cm_dict2.pop("hello")
+        assert_dictionaries_are_equal(cm_dict, cm_dict2)
+
+        assert np.allclose(cm_dict["data"]["x"], crystal_map_input["x"])
+        assert cm_dict["header"]["z_step"] == cm.dz
+
+    def test_phaselist2dict(self, phase_list):
+        pl_dict = phaselist2dict(phase_list)
+        this_dict = {"hello": "there"}
+        this_dict = phaselist2dict(phase_list, dictionary=this_dict)
+        this_dict.pop("hello")
+
+        assert_dictionaries_are_equal(pl_dict, this_dict)
+
+    def test_phase2dict(self, phase_list):
+        phase_dict = phase2dict(phase_list[0])
+        this_dict = {"hello": "there"}
+        this_dict = phase2dict(phase_list[0], dictionary=this_dict)
+        this_dict.pop("hello")
+
+        assert_dictionaries_are_equal(phase_dict, this_dict)
+
+    def test_structure2dict(self, phase_list):
+        structure = phase_list[0].structure
+        structure_dict = structure2dict(structure)
+        this_dict = {"hello": "there"}
+        this_dict = structure2dict(structure, this_dict)
+        this_dict.pop("hello")
+
+        lattice1 = structure_dict["lattice"]
+        lattice2 = this_dict["lattice"]
+        assert np.allclose(lattice1["abcABG"], lattice2["abcABG"])
+        assert np.allclose(lattice1["baserot"], lattice2["baserot"])
+        assert_dictionaries_are_equal(structure_dict["atoms"], this_dict["atoms"])
+
+    def test_hdf5group2dict_update_dict(self, temp_file_path, crystal_map):
+        save(temp_file_path, crystal_map)
+        with File(temp_file_path, mode="r") as f:
+            this_dict = {"hello": "there"}
+            this_dict = hdf5group2dict(f["crystal_map"], dictionary=this_dict)
+
+            assert this_dict["hello"] == "there"
+            assert this_dict["data"] == f["crystal_map/data"]
+            assert this_dict["header"] == f["crystal_map/header"]
+
+    def test_file_reader(self, crystal_map, temp_file_path):
+        save(filename=temp_file_path, object2write=crystal_map)
+        cm2 = load(filename=temp_file_path)
+        assert_dictionaries_are_equal(crystal_map.__dict__, cm2.__dict__)
+
+    def test_dict2crystalmap(self, crystal_map):
+        cm2 = dict2crystalmap(crystalmap2dict(crystal_map))
+        assert_dictionaries_are_equal(crystal_map.__dict__, cm2.__dict__)
+
+    def test_dict2phaselist(self, phase_list):
+        phase_list2 = dict2phaselist(phaselist2dict(phase_list))
+
+        assert phase_list.size == phase_list2.size
+        assert phase_list.ids == phase_list2.ids
+        assert phase_list.names == phase_list2.names
+        assert phase_list.colors == phase_list2.colors
+        assert [
+            s1.name == s2.name
+            for s1, s2 in zip(phase_list.symmetries, phase_list2.symmetries)
+        ]
+
+    def test_dict2phase(self, phase_list):
+        phase1 = phase_list[0]
+        phase2 = dict2phase(phase2dict(phase1))
+
+        assert phase1.name == phase2.name
+        assert phase1.color == phase2.color
+        assert phase1.symmetry.name == phase2.symmetry.name
+        assert phase1.structure.lattice.abcABG() == phase2.structure.lattice.abcABG()
+
+    def test_dict2structure(self, phase_list):
+        structure1 = phase_list[0].structure
+        structure2 = dict2structure(structure2dict(structure1))
+
+        lattice1 = structure1.lattice
+        lattice2 = structure2.lattice
+        assert lattice1.abcABG() == lattice2.abcABG()
+        assert np.allclose(lattice1.baserot, lattice2.baserot)
+
+        assert str(structure1.element) == str(structure2.element)
+        assert np.allclose(structure1.xyz, structure2.xyz)
+
+    def test_dict2lattice(self, phase_list):
+        lattice = phase_list[0].structure.lattice
+        lattice2 = dict2lattice(lattice2dict(lattice))
+
+        assert lattice.abcABG() == lattice2.abcABG()
+        assert np.allclose(lattice.baserot, lattice2.baserot)
+
+    def test_dict2atom(self, phase_list):
+        atom = phase_list[0].structure[0]
+        atom2 = dict2atom(atom2dict(atom))
+
+        assert str(atom.element) == str(atom2.element)
+        assert np.allclose(atom.xyz, atom2.xyz)


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

Closes #59.

Adds a master load function, `orix.io.load()`, which takes a filename and keyword arguments, determines the file format from the file extension and calls the correct reader. Readers have been moved to `orix.io.plugins` and their `load_x` function have been standardized to `file_reader`. This IO format is adopted from HyperSpy.

Todo:
- [x] Merge #66 into this branch *after* it is merged into master.
- [x] Reader/writer of `CrystalMap` objects to HDF5 file
̃- [ ] ~Reader/writer of `Phase` objects to HDF5 group (to be included within an HDF5 file)~ To/from dictionary instead of to/from HDF5 group
- [x] ~Reader/writer of `PhaseList` objects to HDF5 group (to be included within an HDF5 file)~ To/from dictionary instead of to/from HDF5 group
- [x] Master save function, to be used by the different classes via their own `.save()`.
- [x] Tests.

Want modular reader/writer so that classes' readers/writers can be used in other packages.