### PR TITLE
Housekeeping on grain exchange case and docstrings

### DIFF
--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -127,12 +127,11 @@ class Misorientation(Rotation):
         """tuple of Symmetry"""
         return self._symmetry
 
-    #@property
     def equivalent(self,grain_exchange=False):
         """Equivalent misorientations
 
         grain_exchange : bool
-            If true the rotation g and g^{-1} are considered the identical
+            If true the rotation g and g^{-1} are considered to be identical
 
         Returns
         -------

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -128,8 +128,11 @@ class Misorientation(Rotation):
         return self._symmetry
 
     @property
-    def equivalent(self):
+    def equivalent(self,grain_exchange=False):
         """Equivalent misorientations
+
+        grain_exchange : bool
+            If true the rotation g and g^{-1} are considered the identical
 
         Returns
         -------
@@ -137,10 +140,12 @@ class Misorientation(Rotation):
 
         """
         Gl, Gr = self._symmetry
-        if Gl._tuples == Gr._tuples:  # Grain exchange case
-            orientations = Orientation.stack([self, ~self]).flatten()
+
+        if grain_exchange and (Gl._tuples == Gr._tuples):
+             orientations = Orientation.stack([self, ~self]).flatten()
         else:
             orientations = Orientation(self)
+
         equivalent = Gr.outer(orientations.outer(Gl))
         return self.__class__(equivalent).flatten()
 

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -166,8 +166,8 @@ class Misorientation(Rotation):
         >>> m = Misorientation(data).set_symmetry(C4, C2)
         >>> m
         Misorientation (2,) 4, 2
-        [[-0.7071  0.     -0.7071  0.    ]
-         [ 0.      0.7071 -0.7071  0.    ]]
+        [[-0.7071  0.7071  0.      0.    ]
+        [ 0.      1.      0.      0.    ]]
 
         """
         symmetry_pairs = iproduct(Gl, Gr)
@@ -270,7 +270,7 @@ class Orientation(Misorientation):
         >>> o
         Orientation (2,) 4
         [[-0.7071  0.     -0.7071  0.    ]
-         [ 0.     -0.7071 -0.7071  0.    ]]
+        [ 0.      1.      0.      0.    ]]
 
         """
         return super(Orientation, self).set_symmetry(C1, symmetry)

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -127,7 +127,7 @@ class Misorientation(Rotation):
         """tuple of Symmetry"""
         return self._symmetry
 
-    def equivalent(self,grain_exchange=False):
+    def equivalent(self, grain_exchange=False):
         """Equivalent misorientations
 
         grain_exchange : bool
@@ -141,7 +141,7 @@ class Misorientation(Rotation):
         Gl, Gr = self._symmetry
 
         if grain_exchange and (Gl._tuples == Gr._tuples):
-             orientations = Orientation.stack([self, ~self]).flatten()
+            orientations = Orientation.stack([self, ~self]).flatten()
         else:
             orientations = Orientation(self)
 

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -127,7 +127,7 @@ class Misorientation(Rotation):
         """tuple of Symmetry"""
         return self._symmetry
 
-    @property
+    #@property
     def equivalent(self,grain_exchange=False):
         """Equivalent misorientations
 

--- a/orix/tests/test_orientation.py
+++ b/orix/tests/test_orientation.py
@@ -91,17 +91,17 @@ def test_getitem(orientation, symmetry):
 
 @pytest.mark.parametrize("Gl", [C4, C2])
 def test_equivalent(Gl):
-    """ Tests that the property Misorientation.equivalent runs without error
+    """ Tests that the property Misorientation.equivalent runs without error,
+    use grain_exchange=True as this falls back to grain_exchange=False when
+    Gl!=Gr:
 
-    Cases
-    -----
-    Gl == C4 ~ "grain exchange"
-    Gl == C2 ~ "no grain exchange"
+    Gl == C4 is grain exchange
+    Gl == C2 is no grain exchange
     """
     m = Misorientation([1, 1, 1, 1])  # any will do
     m_new = m.set_symmetry(Gl, C4, verbose=True)
     m_new.symmetry
-    _m = m_new.equivalent
+    _m = m_new.equivalent(grain_exchange=True)
 
 
 def test_repr():


### PR DESCRIPTION
Will close #57 and #58 

Purpose
-----------

Corrects the docstring error touched on in #57 
Sets up the grain exchange case for the `.equivalent` method.

Comments
--------------

To make this work, `equivalent` was changed from a `@property` to a method. This allows the user to specify grain exchange at runtime, but isn't the style in which most of `orix` is written. @hakonanes, does `CrystalMap` have a natural preference here? 