### PR TITLE
Fix off-by-1 when reading Euler angles from EMsoft dot product file

### DIFF
--- a/orix/io/plugins/emsoft_h5ebsd.py
+++ b/orix/io/plugins/emsoft_h5ebsd.py
@@ -87,7 +87,7 @@ def file_reader(filename, refined=False, **kwargs):
     if refined:
         euler = data_group["RefinedEulerAngles"][:]
     else:  # Get n top matches for each pixel
-        top_match_idx = data_group["TopMatchIndices"][:][:map_size]
+        top_match_idx = data_group["TopMatchIndices"][:][:map_size] - 1
         dictionary_size = data_group["FZcnt"][:][0]
         dictionary_euler = data_group["DictionaryEulerAngles"][:][:dictionary_size]
         euler = dictionary_euler[top_match_idx, :]


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

Fixes #72.

EMsoft's dot product file contains a dictionary of Euler angles used to simulate EBSD patterns, and a list of the IDs in this dictionary of the typically 50 top matching Euler angles for each experimental pattern. I haven't gotten an answer from the EMsoft people yet (they are quick at responding, I'm just being impatient...), but I'm pretty certain this list is 1-indexed. So this fix makes sure we read the correct top matching Euler angles.