### PR TITLE
Remove unnecessary check for whether scalebar has frame in plotting

### DIFF
--- a/orix/tests/test_crystal_map_plot.py
+++ b/orix/tests/test_crystal_map_plot.py
@@ -468,14 +468,12 @@ class TestScalebar:
                 ((1, 10, 30), (0, 1, 1), 1, [0]),
                 {
                     "loc": 4,
-                    "frameon": False,
                     "sep": 6,
                     "size_vertical": 0.2,
                     "alpha": 0.8,
                 },
                 {
                     "loc": "loc",
-                    "frameon": ["patch", "_visible"],
                     "sep": ["_box", "sep"],
                     "size_vertical": ["size_bar", "_children", 0, "_height"],
                     "alpha": ["patch", "_alpha"],


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

See #82.