### PR TITLE
[feature] gridding utils

### DIFF
--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -1,5 +1,5 @@
 __name__ = "orix"
-__version__ = "0.3.1dev"
+__version__ = "0.4.0dev"
 __author__ = "Ben Martineau, Phillip Crout, Håkon Wiik Ånes, Duncan Johnstone"
 __author_email__ = "pyxem.team@gmail.com"
 __description__ = (

--- a/orix/gridding/grid_generators.py
+++ b/orix/gridding/grid_generators.py
@@ -15,3 +15,5 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+""" This user facing code generates 'grids' in orientation spaces """

--- a/orix/gridding/grid_generators.py
+++ b/orix/gridding/grid_generators.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 The pyXem developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.

--- a/orix/gridding/grid_generators.py
+++ b/orix/gridding/grid_generators.py
@@ -17,3 +17,9 @@
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
 """ This user facing code generates 'grids' in orientation spaces """
+
+def get_grid_fundamental():
+    pass
+
+def get_grid_local():
+    pass

--- a/orix/gridding/grid_generators.py
+++ b/orix/gridding/grid_generators.py
@@ -18,8 +18,57 @@
 
 """ This user facing code generates 'grids' in orientation spaces """
 
-def get_grid_fundamental():
-    pass
+from orix.gridding.gridding_utils import (
+    create_equispaced_grid,
+    get_proper_point_group_string,
+)
 
-def get_grid_local():
-    pass
+
+def get_grid_fundamental(resolution, point_group=None, space_group=None):
+    """
+    Generates a grid of rotations that lie within a fundamental zone
+
+    Parameters
+    ----------
+    resolution:
+
+    point_group:
+
+    space_group:
+
+    Returns
+    -------
+
+    See Also
+    --------
+    orix.gridding.utils.create_equispaced_grid
+    """
+    if point_group is None:
+        point_group = get_proper_point_group_string(space_group)
+
+    q = create_equispaced_grid(resolution)
+    q = q < point_group
+
+    return q
+
+
+def get_grid_local(resolution, center, grid_width):
+    """
+    Generates a grid of rotations about a given rotation
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
+    See Also
+    --------
+    orix.gridding_utils.create_equispaced_grid
+    """
+    q = create_equispaced_grid(resolution)
+    q = ~center * q
+    q = q[q.angle < grid_width]
+    q = center * q
+
+    return q

--- a/orix/gridding/gridding_utils.py
+++ b/orix/gridding/gridding_utils.py
@@ -19,6 +19,14 @@
 """ This file contains functions (broadly internal ones) that support
 the grid generation within rotation space """
 
+def create_equispaced_grid():
+    """
+    Returns rotations that are evenly spaced according to the Harr measure of
+    SO3
+
+    """
+    pass
+
 def get_proper_point_group_string(space_group_number):
     """
     Maps a space-group-number to a point group

--- a/orix/gridding/gridding_utils.py
+++ b/orix/gridding/gridding_utils.py
@@ -27,7 +27,7 @@ from orix.quaternion.rotation import Rotation
 
 def create_equispaced_grid(resolution):
     """
-    Returns rotations that are evenly spaced according to the Harr measure of
+    Returns rotations that are evenly spaced according to the Harr measure on
     SO3
 
     Parameters

--- a/orix/gridding/gridding_utils.py
+++ b/orix/gridding/gridding_utils.py
@@ -15,3 +15,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+""" This file contains functions (broadly internal ones) that support
+the grid generation within rotation space """

--- a/orix/gridding/gridding_utils.py
+++ b/orix/gridding/gridding_utils.py
@@ -30,6 +30,11 @@ def create_equispaced_grid(resolution):
     Returns rotations that are evenly spaced according to the Harr measure of
     SO3
 
+    Parameters
+    ----------
+
+    Returns
+    -------
     """
     num_steps = int(np.ceil(360 / resolution))
 

--- a/orix/gridding/gridding_utils.py
+++ b/orix/gridding/gridding_utils.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 The pyXem developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.

--- a/orix/gridding/gridding_utils.py
+++ b/orix/gridding/gridding_utils.py
@@ -19,13 +19,31 @@
 """ This file contains functions (broadly internal ones) that support
 the grid generation within rotation space """
 
-def create_equispaced_grid():
+import numpy as np
+from itertools import product
+
+from orix.quaternion.rotation import Rotation
+
+
+def create_equispaced_grid(resolution):
     """
     Returns rotations that are evenly spaced according to the Harr measure of
     SO3
 
     """
-    pass
+    num_steps = int(np.ceil(360 / resolution))
+
+    alpha = np.linspace(0, np.pi, num=num_steps, endpoint=False)
+    beta = np.arcos(np.linspace(1, -1, num=num_steps, endpoint=False))
+    gamma = np.linspace(0, np.pi, num=num_steps, endpoint=False)
+    q = np.asarray(list(product(alpha, beta, gamma)))
+
+    # convert to quaternions
+    q = Rotation.from_euler(q, convention="bunge", direction="crystal2lab")
+    # remove duplicates
+    q = q.unique()
+    return q
+
 
 def get_proper_point_group_string(space_group_number):
     """

--- a/orix/gridding/gridding_utils.py
+++ b/orix/gridding/gridding_utils.py
@@ -18,3 +18,57 @@
 
 """ This file contains functions (broadly internal ones) that support
 the grid generation within rotation space """
+
+def get_proper_point_group_string(space_group_number):
+    """
+    Maps a space-group-number to a point group
+
+    Parameters
+    ----------
+    space_group_number : int
+
+    Returns
+    -------
+    point_group_str : str
+        The proper point group string in --- convention
+
+    Notes
+    -----
+    This function enumerates the list on https://en.wikipedia.org/wiki/List_of_space_groups
+    Point groups (32) are converted to proper point groups (11) using the Schoenflies
+    representations given in that table.
+    """
+
+    if space_group_number in [1, 2]:
+        return "1"  # triclinic
+    if 2 < space_group_number < 16:
+        return "2"  # monoclinic
+    if 15 < space_group_number < 75:
+        return "222"  # orthorhomic
+    if 74 < space_group_number < 143:  # tetragonal
+        if (74 < space_group_number < 89) or (99 < space_group_number < 110):
+            return "4"  # cyclic
+        else:
+            return "422"  # dihedral
+    if 142 < space_group_number < 168:  # trigonal
+        if 142 < space_group_number < 148 or 156 < space_group_number < 161:
+            return "3"  # cyclic
+        else:
+            return "32"  # dihedral
+    if 167 < space_group_number < 194:  # hexagonal
+        if 167 < space_group_number < 176 or space_group_number in [183, 184, 185, 186]:
+            return "6"  # cyclic
+        else:
+            return "622"  # dihedral
+    if 193 < space_group_number < 231:  # cubic
+        if 193 < space_group_number < 207 or space_group_number in [
+            215,
+            216,
+            217,
+            218,
+            219,
+            220,
+        ]:
+            return "432"  # oct
+        else:
+            return "23"  # tet


### PR DESCRIPTION
As detailed elsewhere #84 we're porting (some) of the gridding functionality from `diffsims` to `orix`. Because this change will allow a significant clean up of diffsims I'm PRing to `0.3.x`, as the new files won't touch any `0.3` code. I will also bump the matplotlib version in `setup.py`. Then a "quick" `0.3.1` release here will solve that problem.

Release Notes:
orix can now produce uniform grids of rotations around a fixed rotations, or within a stated fundamental zone.

Notes:
This will close #85 