### PR TITLE
Rename Phase.symmetry to .point_group, change cm/IO accordingly

### DIFF
--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -51,11 +51,11 @@ class CrystalMap:
     phase_id : numpy.ndarray
         Phase IDs of points in data.
     phases : orix.crystal_map.PhaseList
-        List of phases with their IDs, names, crystal symmetry objects and
-        colors (possibly more than are in the data).
+        List of phases with their IDs, names, point groups and colors
+        (possibly more than are in the data).
     phases_in_data : orix.crystal_map.PhaseList
-        List of phases in data with their IDs, names, crystal symmetry
-        objects and colors.
+        List of phases in data with their IDs, names, point groups and
+        colors.
     prop : orix.crystal_map.CrystalMapProperties
         Dictionary with properties, like quality metrics, in each data
         point.
@@ -122,7 +122,7 @@ class CrystalMap:
             map is assumed to be 2D or 1D, and it is set to None.
         phase_list : PhaseList, optional
             A list of phases in the data with their with names,
-            symmetries and structures. The order in which the phases
+            point groups and structures. The order in which the phases
             appear in the list is important, as it is this, and not the
             phases' IDs, that is used to link the phases to the input
             `phase_id` if the IDs aren't exactly the same as in
@@ -164,7 +164,7 @@ class CrystalMap:
         ...     x=x,
         ...     y=y,
         ...     phase_name=["austenite", "ferrite"],  # Overwrites Structure.title
-        ...     symmetry=["432", "432"],
+        ...     point_group=["432", "432"],
         ...     structure=structures,
         ...     prop=properties,
         ... )
@@ -219,7 +219,7 @@ class CrystalMap:
                 # default initial values
                 phase_list = PhaseList(
                     names=phase_list.names,
-                    symmetries=phase_list.symmetries,
+                    point_groups=phase_list.point_groups,
                     colors=phase_list.colors,
                     structures=phase_list.structures,
                     ids=unique_phase_ids,
@@ -375,7 +375,7 @@ class CrystalMap:
                 rotations = self.rotations[:, 0]
             else:
                 rotations = self.rotations
-            return Orientation(rotations).set_symmetry(phases[:].symmetry)
+            return Orientation(rotations).set_symmetry(phases[:].point_group)
         else:
             raise ValueError(
                 f"Data has the phases {phases.names}, however, you are executing a "
@@ -460,9 +460,9 @@ class CrystalMap:
         A CrystalMap object can be indexed in multiple ways...
 
         >>> cm
-        Phase   Orientations       Name  Symmetry       Color
-            1   5657 (48.4%)  austenite       432    tab:blue
-            2   6043 (51.6%)    ferrite       432  tab:orange
+        Phase   Orientations       Name  Point group       Color
+            1   5657 (48.4%)  austenite          432    tab:blue
+            2   6043 (51.6%)    ferrite          432  tab:orange
         Properties: iq, dp
         Scan unit: um
         >>> cm.shape
@@ -472,18 +472,18 @@ class CrystalMap:
 
         >>> cm2 = cm[20:40, 50:60]
         >>> cm2
-        Phase   Orientations       Name  Symmetry       Color
-            1    148 (74.0%)  austenite       432    tab:blue
-            2     52 (26.0%)    ferrite       432  tab:orange
+        Phase  Orientations       Name  Point group       Color
+            1   148 (74.0%)  austenite          432    tab:blue
+            2    52 (26.0%)    ferrite          432  tab:orange
         Properties: iq, dp
         Scan unit: um
         >>> cm2.shape
         (20, 10)
         >>> cm2 = cm[20:40, 3]
         >>> cm2
-        Phase   Orientations       Name  Symmetry       Color
-            1     16 (80.0%)  austenite       432    tab:blue
-            2      4 (20.0%)    ferrite       432  tab:orange
+        Phase  Orientations       Name  Point group       Color
+            1    16 (80.0%)  austenite          432    tab:blue
+            2     4 (20.0%)    ferrite          432  tab:orange
         Properties: iq, dp
         Scan unit: um
         >>> cm2.shape
@@ -493,8 +493,8 @@ class CrystalMap:
 
         >>> cm2 = cm[10, 10]
         >>> cm2
-        Phase   Orientations     Name  Symmetry       Color
-            2     1 (100.0%)  ferrite       432  tab:orange
+        Phase  Orientations     Name  Point group       Color
+            2    1 (100.0%)  ferrite          432  tab:orange
         Properties: iq, dp
         Scan unit: um
         >>> cm.shape
@@ -503,25 +503,25 @@ class CrystalMap:
         ... by phase name(s)
 
         >>> cm2 = cm["austenite"]
-        Phase   Orientations       Name  Symmetry     Color
-            1  5657 (100.0%)  austenite       432  tab:blue
+        Phase   Orientations       Name  Point group     Color
+            1  5657 (100.0%)  austenite          432  tab:blue
         Properties: iq, dp
         Scan unit: um
         >>> cm2.shape
         (100, 117)
         >>> cm["austenite", "ferrite"]
-        Phase   Orientations       Name  Symmetry       Color
-            1   5657 (48.4%)  austenite       432    tab:blue
-            2   6043 (51.6%)    ferrite       432  tab:orange
+        Phase  Orientations       Name  Point group       Color
+            1  5657 (48.4%)  austenite          432    tab:blue
+            2  6043 (51.6%)    ferrite          432  tab:orange
         Properties: iq, dp
         Scan unit: um
 
         ... by "indexed" and "not_indexed"
 
         >>> cm["indexed"]
-        Phase   Orientations       Name  Symmetry       Color
-            1   5657 (48.4%)  austenite       432    tab:blue
-            2   6043 (51.6%)    ferrite       432  tab:orange
+        Phase  Orientations       Name  Point group       Color
+            1  5657 (48.4%)  austenite          432    tab:blue
+            2  6043 (51.6%)    ferrite          432  tab:orange
         Properties: iq, dp
         Scan unit: um
         >>> cm["not_indexed"]
@@ -530,14 +530,14 @@ class CrystalMap:
         ... or by boolean arrays ((chained) conditional(s))
 
         >>> cm[cm.dp > 0.81]
-        Phase   Orientations       Name  Symmetry       Color
-            1   4092 (44.8%)  austenite       432    tab:blue
-            2   5035 (55.2%)    ferrite       432  tab:orange
+        Phase  Orientations       Name  Point group       Color
+            1  4092 (44.8%)  austenite          432    tab:blue
+            2  5035 (55.2%)    ferrite          432  tab:orange
         Properties: iq, dp
         Scan unit: um
         >>> cm[(cm.iq > np.mean(cm.iq)) & (cm.phase_id == 1)]
-        Phase   Orientations       Name  Symmetry     Color
-            1  1890 (100.0%)  austenite       432  tab:blue
+        Phase   Orientations       Name  Point group     Color
+            1  1890 (100.0%)  austenite          432  tab:blue
         Properties: iq, dp
         Scan unit: um
         """
@@ -610,26 +610,28 @@ class CrystalMap:
 
         # Ensure attributes set to None are treated OK
         names = ["None" if not name else name for name in phases.names]
-        symmetry_names = ["None" if not sym else sym.name for sym in phases.symmetries]
+        point_group_names = [
+            "None" if not sym else sym.name for sym in phases.point_groups
+        ]
 
         # Determine column widths
         unique_phases = np.unique(phase_ids)
         p_sizes = [np.where(phase_ids == i)[0].size for i in unique_phases]
         id_len = 5
-        ori_len = max(max([len(str(p_size)) for p_size in p_sizes]) + 9, 13)
-        name_len = max(max([len(n) for n in names]), 5)
-        sym_len = max(max([len(sn) for sn in symmetry_names]), 8)
-        col_len = max(max([len(i) for i in phases.colors]), 6)
+        ori_len = max(max([len(str(p_size)) for p_size in p_sizes]) + 8, 12)
+        name_len = max(max([len(n) for n in names]), 4)
+        pg_len = max(max([len(sn) for sn in point_group_names]), 11)
+        col_len = max(max([len(i) for i in phases.colors]), 5)
 
         # Column alignment
-        align = ">"  # left ">" or right "<"
+        align = ">"  # right ">" or left "<"
 
         # Header (note the two-space spacing)
         representation = (
             "{:{align}{width}}  ".format("Phase", width=id_len, align=align)
             + "{:{align}{width}}  ".format("Orientations", width=ori_len, align=align)
             + "{:{align}{width}}  ".format("Name", width=name_len, align=align)
-            + "{:{align}{width}}  ".format("Symmetry", width=sym_len, align=align)
+            + "{:{align}{width}}  ".format("Point group", width=pg_len, align=align)
             + "{:{align}{width}}\n".format("Color", width=col_len, align=align)
         )
 
@@ -642,7 +644,7 @@ class CrystalMap:
                 f"{phase_id:{align}{id_len}}  "
                 + f"{ori_str:{align}{ori_len}}  "
                 + f"{names[i]:{align}{name_len}}  "
-                + f"{symmetry_names[i]:{align}{sym_len}}  "
+                + f"{point_group_names[i]:{align}{pg_len}}  "
                 + f"{phases.colors[i]:{align}{col_len}}\n"
             )
 

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -64,13 +64,7 @@ class Phase:
         Return a deep copy using :py:func:`~copy.deepcopy` function.
     """
 
-    def __init__(
-        self,
-        name=None,
-        structure=None,
-        point_group=None,
-        color=None
-    ):
+    def __init__(self, name=None, structure=None, point_group=None, color=None):
         """
         Parameters
         ----------

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -41,8 +41,7 @@ POINT_GROUP_ALIASES = {
 
 
 class Phase:
-    """Name, crystal symmetry, and color of a phase in a crystallographic
-    map.
+    """Name, point group, and color of a phase in a crystallographic map.
 
     Attributes
     ----------
@@ -54,8 +53,10 @@ class Phase:
         Phase name.
     structure : diffpy.structure.Structure
         Unit cell with atoms and lattice.
-    symmetry : orix.quaternion.symmetry.Symmetry
-        Crystal symmetries of the phase.
+    point_group : orix.quaternion.symmetry.Symmetry
+        Point group describing the symmetry operations of the phase's
+        crystal structure, according to the International Tables of
+        Crystallography.
 
     Methods
     -------
@@ -63,7 +64,13 @@ class Phase:
         Return a deep copy using :py:func:`~copy.deepcopy` function.
     """
 
-    def __init__(self, name=None, structure=None, symmetry=None, color=None):
+    def __init__(
+        self,
+        name=None,
+        structure=None,
+        point_group=None,
+        color=None
+    ):
         """
         Parameters
         ----------
@@ -73,9 +80,10 @@ class Phase:
             Unit cell with atoms and a lattice. If None is passed
             (default), a default :class:`diffpy.structure.Structure`
             object is created.
-        symmetry : str or orix.quaternion.symmetry.Symmetry, optional
-            Point group of phase's crystal symmetry. If None is passed
-            (default), it set to None.
+        point_group : str or orix.quaternion.symmetry.Symmetry, optional
+            Point group describing the symmetry operations of the phase's
+            crystal structure, according to the International Tables of
+            Crystallography. If None is passed (default), it set to None.
         color : str, optional
             Phase color. If None is passed (default), it is set to
             'tab:blue' (first among the default Matplotlib colors).
@@ -86,14 +94,14 @@ class Phase:
         >>> from orix.crystal_map import Phase
         >>> p = Phase(
         ...     name="al",
-        ...     symmetry="m-3m",
+        ...     point_group="m-3m",
         ...     structure=Structure(
         ...         atoms=[Atom("al", [0, 0, 0])],
         ...         lattice=Lattice(0.405, 0.405, 0.405, 90, 90, 90)
         ...     )
         ... )
         >>> p
-        <name: al. symmetry: m-3m. color: tab:blue>
+        <name: al. point group: m-3m. color: tab:blue>
         >>> p.structure
         [al   0.000000 0.000000 0.000000 1.0000]
         >>> p.structure.lattice
@@ -102,7 +110,7 @@ class Phase:
         self.structure = structure if structure is not None else Structure()
         if name is not None:
             self.name = name
-        self.symmetry = symmetry
+        self.point_group = point_group
         self.color = color if color is not None else "tab:blue"
 
     @property
@@ -152,13 +160,13 @@ class Phase:
         return mcolors.to_rgb(self.color)
 
     @property
-    def symmetry(self):
-        """Crystal symmetry of phase."""
-        return self._symmetry
+    def point_group(self):
+        """Point group of phase."""
+        return self._point_group
 
-    @symmetry.setter
-    def symmetry(self, value):
-        """Set crystal symmetry of phase."""
+    @point_group.setter
+    def point_group(self, value):
+        """Set point group of phase."""
         if isinstance(value, int):
             value = str(value)
         if isinstance(value, str):
@@ -166,9 +174,9 @@ class Phase:
                 if value == alias:
                     value = correct
                     break
-            for symmetry in _groups:
-                if value.replace("-", "") == symmetry.name.replace("-", ""):
-                    value = symmetry
+            for point_group in _groups:
+                if value.replace("-", "") == point_group.name.replace("-", ""):
+                    value = point_group
                     break
         if not isinstance(value, Symmetry) and value is not None:
             raise ValueError(
@@ -176,15 +184,16 @@ class Phase:
                 " group as a string, or None."
             )
         else:
-            self._symmetry = value
+            self._point_group = value
 
     def __repr__(self):
-        if self.symmetry:
-            symmetry_name = self.symmetry.name
+        if self.point_group:
+            point_group_name = self.point_group.name
         else:
-            symmetry_name = self.symmetry  # Which should be None
+            point_group_name = self.point_group  # Which should be None
         return (
-            f"<name: {self.name}. symmetry: {symmetry_name}. color: " f"{self.color}>"
+            f"<name: {self.name}. point group: {point_group_name}. color: "
+            f"{self.color}>"
         )
 
     def deepcopy(self):
@@ -210,8 +219,8 @@ class PhaseList:
         Number of phases in list.
     structures : list of diffpy.structure.Structure
         List of unit cells with atoms and the lattice of phase.
-    symmetries : list of orix.quaternion.symmetry.Symmetry
-        List of phase crystal symmetries.
+    point_groups : list of orix.quaternion.symmetry.Symmetry
+        List of phase point groups.
 
     Methods
     -------
@@ -229,7 +238,7 @@ class PhaseList:
         self,
         phases=None,
         names=None,
-        symmetries=None,
+        point_groups=None,
         colors=None,
         ids=None,
         structures=None,
@@ -243,14 +252,15 @@ class PhaseList:
             arguments are ignored if this is passed.
         names : str or list of str, optional
             Phase names. Overwrites the names in the `structure` objects.
-        symmetries : str, int, orix.quaternion.symmetry.Symmetry or list\
-                of str, int or orix.quaternion.symmetry.Symmetry, optional
-            Point group symmetries.
+        point_groups : str, int, orix.quaternion.symmetry.Symmetry or\
+                list of str, int or orix.quaternion.symmetry.Symmetry,\
+                optional
+            Point groups.
         colors : str or list of str, optional
             Phase colors.
         ids : int, list of int or numpy.ndarray of int, optional
             Phase IDs.
-        structures : diffpy.structure.Structure or list of
+        structures : diffpy.structure.Structure or list of\
                 diffpy.structure.Structure, optional
             Unit cells with atoms and a lattice of each phase. If None
             is passed (default), a default
@@ -263,7 +273,7 @@ class PhaseList:
         >>> from orix.crystal_map import Phase, PhaseList
         >>> pl = PhaseList(
         ...     names=["al", "cu"],
-        ...     symmetries=["m-3m"] * 2,
+        ...     point_groups=["m-3m"] * 2,
         ...     structures=[
         ...         Structure(
         ...             atoms=[Atom("al", [0] * 3)],
@@ -276,9 +286,9 @@ class PhaseList:
         ...     ]
         ... )
         >>> pl
-        Id  Name  Symmetry       Color
-         0    al      m-3m    tab:blue
-         1    cu      m-3m  tab:orange
+        Id  Name  Point groups       Color
+         0    al          m-3m    tab:blue
+         1    cu          m-3m  tab:orange
         >>> pl["al"].structure
         [al   0.000000 0.000000 0.000000 1.0000]
         """
@@ -306,8 +316,8 @@ class PhaseList:
             # iterables of length 1
             if isinstance(names, str):
                 names = list((names,))
-            if isinstance(symmetries, (str, Symmetry, int)):
-                symmetries = list((symmetries,))
+            if isinstance(point_groups, (str, Symmetry, int)):
+                point_groups = list((point_groups,))
             if isinstance(colors, (str, tuple)):
                 colors = list((colors,))
             if isinstance(ids, int):
@@ -320,7 +330,7 @@ class PhaseList:
             max_entries = max(
                 [
                     len(i) if i is not None else 0
-                    for i in [names, symmetries, ids, structures]
+                    for i in [names, point_groups, ids, structures]
                 ]
             )
 
@@ -341,11 +351,11 @@ class PhaseList:
                 except (IndexError, TypeError):
                     name = None
 
-                # Get symmetry or None
+                # Get point group or None
                 try:
-                    symmetry = symmetries[i]
+                    point_group = point_groups[i]
                 except (IndexError, TypeError):
-                    symmetry = None
+                    point_group = None
 
                 # Get a color (always)
                 try:
@@ -372,7 +382,7 @@ class PhaseList:
                     structure = None
 
                 d[phase_id] = Phase(
-                    name=name, symmetry=symmetry, color=color, structure=structure
+                    name=name, point_group=point_group, color=color, structure=structure
                 )
 
                 # To ensure color aliases are added to `used_colors`
@@ -387,9 +397,9 @@ class PhaseList:
         return [phase.name for _, phase in self]
 
     @property
-    def symmetries(self):
-        """List of crystal symmetries of phases in the list."""
-        return [phase.symmetry for _, phase in self]
+    def point_groups(self):
+        """List of point groups of phases in the list."""
+        return [phase.point_group for _, phase in self]
 
     @property
     def colors(self):
@@ -424,39 +434,39 @@ class PhaseList:
         --------
         A PhaseList object can be indexed in multiple ways.
 
-        >>> pl = PhaseList(names=['a', 'b'], symmetries=['1', '3'])
+        >>> pl = PhaseList(names=['a', 'b'], point_groups=['1', '3'])
         >>> pl
-        Id  Name  Symmetry  Color
-        0   a     1         tab:blue
-        1   b     3         tab:orange
+        Id  Name  Point group       Color
+         0     a            1    tab:blue
+         1     b            3  tab:orange
 
         Return a Phase object if only one phase matches the key
 
         >>> pl[0]  # Index with a single phase id
-        <name: a. symmetry: 1. color: tab:blue>
+        <name: a. point group: 1. color: tab:blue>
         >>> pl['b']  # Index with a phase name
-        <name: b. symmetry: 3. color: tab:orange>
+        <name: b. point group: 3. color: tab:orange>
         >>> pl[:1]
-        <name: b. symmetry: 3. color: tab:orange>
+        <name: b. point group: 3. color: tab:orange>
 
         Return a PhaseList object
 
         >>> pl[0:]  # Index with slices
-        Id  Name  Symmetry  Color
-        0   a     1         tab:blue
-        1   b     3         tab:orange
+        Id  Name  Point group       Color
+         0    a             1    tab:blue
+         1    b             3  tab:orange
         >>> pl['a', 'b']  # Index with a tuple of phase names
-        Id  Name  Symmetry  Color
-        0   a     1         tab:blue
-        1   b     3         tab:orange
+        Id  Name  Point group       Color
+         0    a             1    tab:blue
+         1    b             3  tab:orange
         >>> pl[0, 1]  # Index with a tuple of phase phase_ids
-        Id  Name  Symmetry  Color
-        0   a     1         tab:blue
-        1   b     3         tab:orange
+        Id  Name  Point group       Color
+         0     a            1    tab:blue
+         1     b            3  tab:orange
         >>> pl[[0, 1]]  # Index with a list of phase_ids
-        Id  Name  Symmetry  Color
-        0   a     1         tab:blue
-        1   b     3         tab:orange
+        Id  Name  Point group       Color
+         0     a            1    tab:blue
+         1     b            3  tab:orange
         """
         # Make key iterable if it isn't already
         if not isinstance(key, (tuple, slice, list, np.ndarray)):
@@ -502,7 +512,9 @@ class PhaseList:
             return PhaseList(d)
 
     def __setitem__(self, key, value):
-        """Add a phase to the list with a name, symmetry and structure."""
+        """Add a phase to the list with a name, point group and
+        structure.
+        """
         if key not in self.names:
             # Make sure the new phase gets a new color
             color_new = None
@@ -517,7 +529,9 @@ class PhaseList:
             else:  # `self.phase_ids` is an empty list
                 new_phase_id = 0
 
-            self._dict[new_phase_id] = Phase(name=key, symmetry=value, color=color_new)
+            self._dict[new_phase_id] = Phase(
+                name=key, point_group=value, color=color_new
+            )
         else:
             raise ValueError(f"{key} is already in the phase list {self.names}.")
 
@@ -556,16 +570,16 @@ class PhaseList:
 
         # Ensure attributes set to None are treated OK
         names = ["None" if not i else i for i in self.names]
-        symmetry_names = ["None" if not i else i.name for i in self.symmetries]
+        point_group_names = ["None" if not i else i.name for i in self.point_groups]
 
         # Determine column widths (allowing PhaseList to be empty)
         id_len = 2
         name_len = 4
         if names:
             name_len = max(max([len(i) for i in names]), name_len)
-        sym_len = 8
-        if symmetry_names:
-            sym_len = max(max([len(i) for i in symmetry_names]), sym_len)
+        pg_len = 11
+        if point_group_names:
+            pg_len = max(max([len(i) for i in point_group_names]), pg_len)
         col_len = 5
         if self.colors:
             col_len = max(max([len(i) for i in self.colors]), col_len)
@@ -577,7 +591,7 @@ class PhaseList:
         representation = (
             "{:{align}{width}}  ".format("Id", width=id_len, align=align)
             + "{:{align}{width}}  ".format("Name", width=name_len, align=align)
-            + "{:{align}{width}}  ".format("Symmetry", width=sym_len, align=align)
+            + "{:{align}{width}}  ".format("Point group", width=pg_len, align=align)
             + "{:{align}{width}}".format("Color", width=col_len, align=align)
         )
 
@@ -586,7 +600,7 @@ class PhaseList:
             representation += (
                 f"\n{phase_id:{align}{id_len}}  "
                 + f"{names[i]:{align}{name_len}}  "
-                + f"{symmetry_names[i]:{align}{sym_len}}  "
+                + f"{point_group_names[i]:{align}{pg_len}}  "
                 + f"{self.colors[i]:{align}{col_len}}"
             )
 
@@ -599,10 +613,10 @@ class PhaseList:
     def add_not_indexed(self):
         """Add a dummy phase to assign to not indexed data points.
 
-        The phase, named "not_indexed", has a "symmetry" equal to None,
+        The phase, named "not_indexed", has a `point_group` equal to None,
         and a white color when plotted.
         """
-        self._dict[-1] = Phase(name="not_indexed", symmetry=None, color="white")
+        self._dict[-1] = Phase(name="not_indexed", point_group=None, color="white")
         self.sort_by_id()
 
     def sort_by_id(self):

--- a/orix/io/plugins/ang.py
+++ b/orix/io/plugins/ang.py
@@ -97,7 +97,7 @@ def file_reader(filename):
     unique_phase_ids = np.unique(data_dict["phase_id"]).astype(int)
     data_dict["phase_list"] = PhaseList(
         names=phase_names,
-        symmetries=symmetries,
+        point_groups=symmetries,
         structures=structures,
         ids=unique_phase_ids,
     )
@@ -260,25 +260,25 @@ def _get_phases_from_header(header):
     -------
     phase_names : list of str
         List of names of detected phases.
-    phase_symmetries : list of str
-        List of symmetries of detected phase.
+    phase_point_groups : list of str
+        List of point groups of detected phase.
     lattice_constants : list of list of floats
         List of list of lattice parameters of detected phases.
 
     Notes
     -----
     Regular expressions are used to collect phase name, formula and
-    symmetry. This function have been tested with files from the following
-    vendor's formats: EDAX TSL OIM Data Collection v7, ASTAR Index, and
-    EMsoft v4/v5.
+    point group. This function have been tested with files from the
+    following vendor's formats: EDAX TSL OIM Data Collection v7, ASTAR
+    Index, and EMsoft v4/v5.
     """
     regexps = {
         "name": "# MaterialName([ \t]+)([A-z0-9 ]+)",
         "formula": "# Formula([ \t]+)([A-z0-9 ]+)",
-        "symmetry": "# Symmetry([ \t]+)([A-z0-9 ]+)",
+        "point_group": "# Symmetry([ \t]+)([A-z0-9 ]+)",
         "lattice_constants": r"# LatticeConstants([ \t+])(.*)",
     }
-    phases = {"name": [], "formula": [], "symmetry": [], "lattice_constants": []}
+    phases = {"name": [], "formula": [], "point_group": [], "lattice_constants": []}
     for line in header:
         for key, exp in regexps.items():
             match = re.search(exp, line)
@@ -296,4 +296,4 @@ def _get_phases_from_header(header):
     if len(names) == 0 or any([i != "" for i in names]):
         names = phases["name"]
 
-    return names, phases["symmetry"], phases["lattice_constants"]
+    return names, phases["point_group"], phases["lattice_constants"]

--- a/orix/io/plugins/emsoft_h5ebsd.py
+++ b/orix/io/plugins/emsoft_h5ebsd.py
@@ -66,7 +66,7 @@ def file_reader(filename, refined=False, **kwargs):
     map_size = ny * nx
 
     # Some of the data needed to create a CrystalMap object
-    phase_name, symmetry, structure = _get_phase(phase_group)
+    phase_name, point_group, structure = _get_phase(phase_group)
     data_dict = {
         # Get map coordinates ("Y Position" data set is not correct in EMsoft as of
         # 2020-04, see:
@@ -76,9 +76,9 @@ def file_reader(filename, refined=False, **kwargs):
         "y": np.sort(np.tile(np.arange(ny) * step_y, nx)),
         # Get phase IDs
         "phase_id": data_group["Phase"][:],
-        # Get phase name, crystal symmetry and structure (lattice)
+        # Get phase name, point group and structure (lattice)
         "phase_list": PhaseList(
-            Phase(name=phase_name, symmetry=symmetry, structure=structure)
+            Phase(name=phase_name, point_group=point_group, structure=structure)
         ),
         "scan_unit": "um",
     }
@@ -165,13 +165,13 @@ def _get_phase(data_group):
     -------
     name : str
         Phase name.
-    symmetry : str
-        Phase symmetry.
+    point_group : str
+        Phase point group.
     structure : diffpy.structure.Structure
         Phase structure.
     """
     name = re.search(r"([A-z0-9]+)", data_group["MaterialName"][:][0].decode()).group(1)
-    symmetry = re.search(
+    point_group = re.search(
         r"\[([A-z0-9]+)\]", data_group["Point Group"][:][0].decode()
     ).group(1)
     lattice = Lattice(
@@ -181,4 +181,4 @@ def _get_phase(data_group):
         )
     )
     structure = Structure(title=name, lattice=lattice)
-    return name, symmetry, structure
+    return name, point_group, structure

--- a/orix/io/plugins/orix_hdf5.py
+++ b/orix/io/plugins/orix_hdf5.py
@@ -164,6 +164,8 @@ def dict2phase(dictionary):
     ----------
     dictionary : dict
         Dictionary with phase information.
+    version : list, optional
+        orix version. If None (default), the current version is assumed.
 
     Returns
     -------
@@ -172,7 +174,11 @@ def dict2phase(dictionary):
     dictionary = copy.deepcopy(dictionary)
     structure = dict2structure(dictionary["structure"])
     structure.title = dictionary["name"]
-    point_group = dictionary["point_group"]
+    # TODO: Remove this check in v0.6.0
+    try:
+        point_group = dictionary["point_group"]
+    except KeyError:  # v0.3.0
+        point_group = dictionary["symmetry"]
     if point_group == "None":
         point_group = None
     return Phase(

--- a/orix/io/plugins/orix_hdf5.py
+++ b/orix/io/plugins/orix_hdf5.py
@@ -172,13 +172,13 @@ def dict2phase(dictionary):
     dictionary = copy.deepcopy(dictionary)
     structure = dict2structure(dictionary["structure"])
     structure.title = dictionary["name"]
-    symmetry = dictionary["symmetry"]
-    if symmetry == "None":
-        symmetry = None
+    point_group = dictionary["point_group"]
+    if point_group == "None":
+        point_group = None
     return Phase(
         name=dictionary["name"],
         color=dictionary["color"],
-        symmetry=symmetry,
+        point_group=point_group,
         structure=structure,
     )
 
@@ -412,11 +412,11 @@ def phase2dict(phase, dictionary=None):
         dictionary = {}
 
     dictionary["name"] = phase.name
-    if hasattr(phase.symmetry, "name"):
-        symmetry = phase.symmetry.name
+    if hasattr(phase.point_group, "name"):
+        point_group = phase.point_group.name
     else:
-        symmetry = "None"
-    dictionary["symmetry"] = symmetry
+        point_group = "None"
+    dictionary["point_group"] = point_group
     dictionary["color"] = phase.color
     dictionary["structure"] = structure2dict(phase.structure)
 

--- a/orix/io/plugins/orix_hdf5.py
+++ b/orix/io/plugins/orix_hdf5.py
@@ -164,8 +164,6 @@ def dict2phase(dictionary):
     ----------
     dictionary : dict
         Dictionary with phase information.
-    version : list, optional
-        orix version. If None (default), the current version is assumed.
 
     Returns
     -------

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -484,11 +484,14 @@ def temp_emsoft_h5ebsd_file(tmpdir, request):
     ]
 )
 def phase_list(request):
-    names, symmetry_names, colors, lattices, atoms = request.param
+    names, point_group_names, colors, lattices, atoms = request.param
     # Apparently diffpy.structure don't allow iteration over a list of lattices
     structures = [Structure(lattice=lattices[i], atoms=a) for i, a in enumerate(atoms)]
     return PhaseList(
-        names=names, symmetries=symmetry_names, colors=colors, structures=structures
+        names=names,
+        point_groups=point_group_names,
+        colors=colors,
+        structures=structures
     )
 
 

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -491,7 +491,7 @@ def phase_list(request):
         names=names,
         point_groups=point_group_names,
         colors=colors,
-        structures=structures
+        structures=structures,
     )
 
 

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -161,7 +161,9 @@ class TestCrystalMapInit:
         n_different = n_point_groups - n_phase_ids
         if n_different < 0:
             point_groups += [None] * abs(n_different)
-        assert [cm.phases.point_groups[i] == point_groups[i] for i in range(n_phase_ids)]
+        assert [
+            cm.phases.point_groups[i] == point_groups[i] for i in range(n_phase_ids)
+        ]
 
         unique_phase_ids = list(np.unique(crystal_map_input["phase_id"]).astype(int))
         assert cm.phases.ids == unique_phase_ids

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -152,25 +152,25 @@ class TestCrystalMapInit:
         indirect=["crystal_map_input"],
     )
     def test_init_with_phase_list(self, crystal_map_input):
-        symmetries = [C2, C3, C4]
-        phase_list = PhaseList(symmetries=symmetries)
+        point_groups = [C2, C3, C4]
+        phase_list = PhaseList(point_groups=point_groups)
         cm = CrystalMap(phase_list=phase_list, **crystal_map_input)
 
-        n_symmetries = len(symmetries)
+        n_point_groups = len(point_groups)
         n_phase_ids = len(cm.phases.ids)
-        n_different = n_symmetries - n_phase_ids
+        n_different = n_point_groups - n_phase_ids
         if n_different < 0:
-            symmetries += [None] * abs(n_different)
-        assert [cm.phases.symmetries[i] == symmetries[i] for i in range(n_phase_ids)]
+            point_groups += [None] * abs(n_different)
+        assert [cm.phases.point_groups[i] == point_groups[i] for i in range(n_phase_ids)]
 
         unique_phase_ids = list(np.unique(crystal_map_input["phase_id"]).astype(int))
         assert cm.phases.ids == unique_phase_ids
 
-    def test_init_with_single_symmetry(self, crystal_map_input):
-        symmetry = O
-        phase_list = PhaseList(symmetries=symmetry)
+    def test_init_with_single_point_group(self, crystal_map_input):
+        point_group = O
+        phase_list = PhaseList(point_groups=point_group)
         cm = CrystalMap(phase_list=phase_list, **crystal_map_input)
-        assert np.allclose(cm.phases.symmetries[0].data, symmetry.data)
+        assert np.allclose(cm.phases.point_groups[0].data, point_group.data)
 
 
 class TestCrystalMapGetItem:
@@ -400,7 +400,7 @@ class TestCrystalMapOrientations:
         assert orientations_size == cm.size
 
     @pytest.mark.parametrize(
-        "symmetry, rotation, expected_orientation",
+        "point_group, rotation, expected_orientation",
         [
             (C2, [(0.6088, 0, 0, 0.7934)], [(-0.7934, 0, 0, 0.6088)]),
             (C3, [(0.6088, 0, 0, 0.7934)], [(-0.9914, 0, 0, 0.1305)]),
@@ -408,22 +408,22 @@ class TestCrystalMapOrientations:
             (O, [(0.6088, 0, 0, 0.7934)], [(-0.9914, 0, 0, -0.1305)]),
         ],
     )
-    def test_orientations_symmetry(self, symmetry, rotation, expected_orientation):
+    def test_orientations_symmetry(self, point_group, rotation, expected_orientation):
         r = Rotation(rotation)
         cm = CrystalMap(rotations=r, phase_id=np.array([0]))
-        cm.phases = PhaseList(Phase("a", symmetry=symmetry))
+        cm.phases = PhaseList(Phase("a", point_group=point_group))
 
         o = cm.orientations
 
         assert np.allclose(
-            o.data, Orientation(r).set_symmetry(symmetry).data, atol=1e-3
+            o.data, Orientation(r).set_symmetry(point_group).data, atol=1e-3
         )
         assert np.allclose(o.data, expected_orientation, atol=1e-3)
 
     def test_orientations_none_symmetry_raises(self, crystal_map_input):
         cm = CrystalMap(**crystal_map_input)
 
-        assert cm.phases.symmetries == [None]
+        assert cm.phases.point_groups == [None]
 
         with pytest.raises(TypeError, match="'NoneType' object is not iterable"):
             _ = cm.orientations
@@ -448,7 +448,7 @@ class TestCrystalMapOrientations:
         cm = CrystalMap(**crystal_map_input)
 
         assert cm.phases.ids == [0]  # Test code assumption
-        cm.phases[0].symmetry = "m-3m"
+        cm.phases[0].point_group = "m-3m"
 
         assert cm.rotations_per_point == rotations_per_point
         assert cm.orientations.size == cm.size
@@ -594,7 +594,7 @@ class TestCrystalMapGetMapData:
             phase_mask_in_data = cm.phase_id == i
             array[phase_mask] = (
                 Orientation(rotations[phase_mask_in_data])
-                .set_symmetry(phase.symmetry)
+                .set_symmetry(phase.point_group)
                 .to_euler()
             )
 
@@ -667,10 +667,10 @@ class TestCrystalMapRepresentation:
         print(cm.__repr__())
 
         assert cm.__repr__() == (
-            "Phase   Orientations   Name  Symmetry   Color\n"
-            "    0     10 (83.3%)      a      m-3m       r\n"
-            "    1       1 (8.3%)      b       432       g\n"
-            "    2       1 (8.3%)      c         3       b\n"
+            "Phase  Orientations  Name  Point group  Color\n"
+            "    0    10 (83.3%)     a         m-3m      r\n"
+            "    1      1 (8.3%)     b          432      g\n"
+            "    2      1 (8.3%)     c            3      b\n"
             "Properties: iq\n"
             "Scan unit: nm"
         )

--- a/orix/tests/test_crystal_map_plot.py
+++ b/orix/tests/test_crystal_map_plot.py
@@ -267,7 +267,7 @@ class TestCrystalMapPlotUtilities:
     ):
         cm = crystal_map
         cm[0, 0].phase_id = 1
-        cm.phases = PhaseList(names=phase_names, symmetries=[3, 3], colors=phase_colors)
+        cm.phases = PhaseList(names=phase_names, point_groups=[3, 3], colors=phase_colors)
 
         fig = plt.figure()
         ax = fig.add_subplot(projection=PLOT_MAP)

--- a/orix/tests/test_crystal_map_plot.py
+++ b/orix/tests/test_crystal_map_plot.py
@@ -267,7 +267,9 @@ class TestCrystalMapPlotUtilities:
     ):
         cm = crystal_map
         cm[0, 0].phase_id = 1
-        cm.phases = PhaseList(names=phase_names, point_groups=[3, 3], colors=phase_colors)
+        cm.phases = PhaseList(
+            names=phase_names, point_groups=[3, 3], colors=phase_colors
+        )
 
         fig = plt.figure()
         ax = fig.add_subplot(projection=PLOT_MAP)
@@ -466,12 +468,7 @@ class TestScalebar:
             (((1, 10, 30), (0, 1, 1), 1, [0]), {}, {}),  # Default
             (
                 ((1, 10, 30), (0, 1, 1), 1, [0]),
-                {
-                    "loc": 4,
-                    "sep": 6,
-                    "size_vertical": 0.2,
-                    "alpha": 0.8,
-                },
+                {"loc": 4, "sep": 6, "size_vertical": 0.2, "alpha": 0.8,},
                 {
                     "loc": "loc",
                     "sep": ["_box", "sep"],

--- a/orix/tests/test_io.py
+++ b/orix/tests/test_io.py
@@ -245,7 +245,7 @@ class TestAngPlugin:
                     np.zeros(5 * 3, dtype=int),  # phase_id
                     5,  # n_unknown_columns
                     np.array(
-                        [[1.59942, 2.37748, 4.53419], [1.59331, 2.37417, 4.53628],]
+                        [[1.59942, 2.37748, 4.53419], [1.59331, 2.37417, 4.53628]]
                     ),  # rotations as rows of Euler angle triplets
                 ),
                 (5, 3),
@@ -253,7 +253,7 @@ class TestAngPlugin:
                 np.zeros(5 * 3, dtype=int),
                 5,
                 np.array(
-                    [[1.59942, 2.37748, -1.74690], [1.59331, 2.37417, -1.74899],]
+                    [[1.59942, 2.37748, -1.74690], [1.59331, 2.37417, -1.74899]]
                 ),  # rotations as rows of Euler angle triplets
             ),
             (
@@ -263,7 +263,7 @@ class TestAngPlugin:
                     np.zeros(8 * 4, dtype=int),  # phase_id
                     5,  # n_unknown_columns
                     np.array(
-                        [[5.81107, 2.34188, 4.47345], [6.16205, 0.79936, 1.31702],]
+                        [[5.81107, 2.34188, 4.47345], [6.16205, 0.79936, 1.31702]]
                     ),  # rotations as rows of Euler angle triplets
                 ),
                 (8, 4),
@@ -271,7 +271,7 @@ class TestAngPlugin:
                 np.zeros(8 * 4, dtype=int),
                 5,
                 np.array(
-                    [[-0.12113, 2.34188, 1.31702], [-0.47211, 0.79936, -1.80973],]
+                    [[-0.12113, 2.34188, 1.31702], [-0.47211, 0.79936, -1.80973]]
                 ),  # rotations as rows of Euler angle triplets
             ),
         ],
@@ -363,7 +363,7 @@ class TestAngPlugin:
                 (4.5, 4.5),
                 np.ones(9 * 3, dtype=int),
                 np.array(
-                    [[1.895079, 0.739496, 1.413542], [1.897871, 0.742638, 1.413717],]
+                    [[1.895079, 0.739496, 1.413542], [1.897871, 0.742638, 1.413717]]
                 ),
             ),
             (
@@ -382,7 +382,7 @@ class TestAngPlugin:
                 (10, 10),
                 np.ones(11 * 13, dtype=int),
                 np.array(
-                    [[1.621760, 2.368935, -1.723861], [1.604481, 2.367539, -1.741315],]
+                    [[1.621760, 2.368935, -1.723861], [1.604481, 2.367539, -1.741315]]
                 ),
             ),
         ],
@@ -460,7 +460,7 @@ class TestAngPlugin:
                     )
                 ),
                 np.array(
-                    [[1.895079, 0.739496, 1.413542], [1.897871, 0.742638, 1.413717],]
+                    [[1.895079, 0.739496, 1.413542], [1.897871, 0.742638, 1.413717]]
                 ),
             ),
             (
@@ -474,7 +474,7 @@ class TestAngPlugin:
                         )
                     ),  # phase_id
                     np.array(
-                        [[1.62176, 2.36894, -1.72386], [1.60448, 2.36754, -1.72386],]
+                        [[1.62176, 2.36894, -1.72386], [1.60448, 2.36754, -1.72386]]
                     ),
                 ),
                 (3, 6),
@@ -485,7 +485,7 @@ class TestAngPlugin:
                         np.ones(int(np.floor((3 * 6) / 2))) * 2,
                     )
                 ),
-                np.array([[1.62176, 2.36894, -1.72386], [1.60448, 2.36754, -1.72386],]),
+                np.array([[1.62176, 2.36894, -1.72386], [1.60448, 2.36754, -1.72386]]),
             ),
         ],
         indirect=["angfile_emsoft"],
@@ -526,7 +526,7 @@ class TestAngPlugin:
         assert phases_in_data.size == 2
         assert phases_in_data.ids == [1, 2]
         assert phases_in_data.names == ["austenite", "ferrite"]
-        assert [i.name for i in phases_in_data.point_groups] == ["432", ] * 2
+        assert [i.name for i in phases_in_data.point_groups] == ["432"] * 2
 
     def test_get_header(self, temp_ang_file):
         temp_ang_file.write(ANGFILE_ASTAR_HEADER)

--- a/orix/tests/test_io.py
+++ b/orix/tests/test_io.py
@@ -340,7 +340,7 @@ class TestAngPlugin:
         assert cm.phases.ids == [-1, 0]
         phase = cm.phases[0]
         assert phase.name == "Aluminum"
-        assert phase.symmetry.name == "432"
+        assert phase.point_group.name == "432"
 
     @pytest.mark.parametrize(
         "angfile_astar, map_shape, step_sizes, phase_id, example_rot",
@@ -427,7 +427,7 @@ class TestAngPlugin:
         assert cm.phases.ids == [1]
         phase = cm.phases[1]
         assert phase.name == "Nickel"
-        assert phase.symmetry.name == "432"
+        assert phase.point_group.name == "432"
 
     @pytest.mark.parametrize(
         "angfile_emsoft, map_shape, step_sizes, phase_id, example_rot",
@@ -526,7 +526,7 @@ class TestAngPlugin:
         assert phases_in_data.size == 2
         assert phases_in_data.ids == [1, 2]
         assert phases_in_data.names == ["austenite", "ferrite"]
-        assert [i.name for i in phases_in_data.symmetries] == ["432",] * 2
+        assert [i.name for i in phases_in_data.point_groups] == ["432", ] * 2
 
     def test_get_header(self, temp_ang_file):
         temp_ang_file.write(ANGFILE_ASTAR_HEADER)
@@ -606,7 +606,7 @@ class TestAngPlugin:
             assert column_names == expected_columns
 
     @pytest.mark.parametrize(
-        "header_phase_part, expected_names, expected_symmetries, "
+        "header_phase_part, expected_names, expected_point_groups, "
         "expected_lattice_constants",
         [
             (
@@ -636,7 +636,7 @@ class TestAngPlugin:
         self,
         header_phase_part,
         expected_names,
-        expected_symmetries,
+        expected_point_groups,
         expected_lattice_constants,
     ):
         # Create header from parts
@@ -659,10 +659,10 @@ class TestAngPlugin:
             "#",
             "# GRID: SqrGrid#",
         ]
-        names, symmetries, lattice_constants = _get_phases_from_header(header)
+        names, point_groups, lattice_constants = _get_phases_from_header(header)
 
         assert names == expected_names
-        assert symmetries == expected_symmetries
+        assert point_groups == expected_point_groups
         assert np.allclose(lattice_constants, expected_lattice_constants)
 
 
@@ -874,7 +874,7 @@ class TestOrixHDF5Plugin:
         assert phase_list.colors == phase_list2.colors
         assert [
             s1.name == s2.name
-            for s1, s2 in zip(phase_list.symmetries, phase_list2.symmetries)
+            for s1, s2 in zip(phase_list.point_groups, phase_list2.point_groups)
         ]
 
     def test_dict2phase(self, phase_list):
@@ -883,7 +883,7 @@ class TestOrixHDF5Plugin:
 
         assert phase1.name == phase2.name
         assert phase1.color == phase2.color
-        assert phase1.symmetry.name == phase2.symmetry.name
+        assert phase1.point_group.name == phase2.point_group.name
         assert phase1.structure.lattice.abcABG() == phase2.structure.lattice.abcABG()
 
     def test_dict2structure(self, phase_list):

--- a/orix/tests/test_phase_list.py
+++ b/orix/tests/test_phase_list.py
@@ -416,8 +416,8 @@ class TestPhaseList:
 
             assert phase_list.names == expected_names
             assert [
-                       s.name for s in phase_list.point_groups
-                   ] == expected_point_group_names
+                s.name for s in phase_list.point_groups
+            ] == expected_point_group_names
 
     def test_set_phase_in_empty_phaselist(self):
         pl = PhaseList()


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

Renames `Phase.symmetry` to `Phase.point_group`, in anticipation of adding `Phase.space_group`, from `diffpy.structure.spacegroupmod.SpaceGroup`, as discussed in #87. Accompanying changes are made to the `PhaseList` and `CrystalMap` classes, as well as all IO plugins.

The `CrystalMap`, `Phase` and `PhaseList` representations now look like this:

```python
>>> cm
Phase  Orientations       Name  Point group       Color
    1  5657 (48.4%)  austenite          432    tab:blue
    2  6043 (51.6%)    ferrite          432  tab:orange
Properties: iq, dp
Scan unit: um
>>> cm.phases
Id       Name  Point group       Color
 1  austenite          432    tab:blue
 2    ferrite          432  tab:orange
>>> cm.phases["austenite"]
<name: austenite. point group: 432. color: tab:blue>
>>> cm.phases["austenite"].point_group
Symmetry (24,) 432
[[ 1.      0.      0.      0.    ]
[...]  # Many rotations
 [ 0.5    -0.5     0.5     0.5   ]]
```

Initializing `CrystalMap`, `Phase` and `PhaseList` is now done by passing a `point_group` argument instead of `symmetry`.

Issues resulting from this PR:
* Might the naming of `point_group` compared to `symmetry` be confusing for the user? I actually think it might be a better naming and help the user's understanding.  
* The orix HDF5 plugin now writes the phase point group to an HDF5 dataset with name `point_group` and not `symmetry`, with similar changes when reading. So, if this PR is merged into master, reading a phase HDF5 group  from a file written with the current writer won't work... unless we check for this in the reader. Doing this is easy. However, it raises the question of how many such small changes we should accomodate.