### PR TITLE
Force black upon commit and add "extras_require" to setup.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+      - id: black
+        language_version: python3.8

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,16 @@
+from itertools import chain
 from setuptools import setup, find_packages
 from orix import __name__, __version__, __author__, __author_email__, __description__
 
+# Projects with optional features for building the documentation and running
+# tests. From setuptools:
+# https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
+extra_feature_requirements = {
+    "tests": ["pytest >= 5.4", "pytest-cov >= 2.8.1", "coverage >= 5.0"]
+}
+extra_feature_requirements["dev"] = ["black >= 19.3b0", "pre-commit >= 1.16",] + list(
+    chain(*list(extra_feature_requirements.values()))
+)
 
 setup(
     name=__name__,
@@ -24,6 +34,7 @@ setup(
         "Topic :: Scientific/Engineering :: Physics",
     ],
     packages=find_packages(exclude=["orix/tests"]),
+    extras_require=extra_feature_requirements,
     # fmt: off
     install_requires=[
         "diffpy.structure >= 3",


### PR DESCRIPTION
Developer changes:
* Adds a pre-commit (https://pre-commit.com/) config file. If the developer installs pre-commit and runs `pre-commit install`, `black` is run automatically before they are allowed to commit. Pre-commit is used by e.g. napari (https://github.com/napari/napari/blob/master/.pre-commit-config.yaml).
* Adds `extras_require` dictionary to `setup.py`. Running `pip install -e .[tests]` installs dependencies *and* `pytest >= 5.4`, `pytest-cov >= 2.8.1` and `coverage >= 5.0` (min. version as in kikuchipy (https://github.com/kikuchipy/kikuchipy). Running `pip install -e .[dev]` installs dependencies, the "tests" packages above, *and* `black >= 19.3b0` and `pre-commit >= 1.16`.