### PR TITLE
Remove language_version in pre-commit config file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,3 @@ repos:
     rev: stable
     hooks:
       - id: black
-        language_version: python3.8


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

Trying to commit changes with Python<3.8 when `language_version: python3.8` in pre-commit config file fails. Since we support 3.6-8, this is removed.

Sorry, discovered this now.