### PR TITLE
Add Rotation.to/from_matrix() methods to convert between quaternions and orientation matrices

### DIFF
--- a/orix/tests/test_rotation.py
+++ b/orix/tests/test_rotation.py
@@ -1,3 +1,4 @@
+# from diffpy.structure.spacegroups import
 from math import cos, sin, tan, pi
 import numpy as np
 import pytest
@@ -455,11 +456,32 @@ def test_random_vonmises(shape, reference):
     assert isinstance(r, Rotation)
 
 
-def test_to_matrix():
-    r = Rotation([[1, 0, 0, 0], [0, 1, 0, 0]])
-    assert np.allclose(r.to_matrix(), [np.eye(3), np.diag([1, -1, -1])])
+class TestFromToMatrix:
+    def test_to_matrix(self):
+        r = Rotation([[1, 0, 0, 0], [3, 0, 0, 0], [0, 1, 0, 0], [0, 2, 0, 0]]).reshape(
+            2, 2
+        )
+        om = np.array(
+            [np.eye(3), np.eye(3), np.diag([1, -1, -1]), np.diag([1, -1, -1])]
+        )
+        assert np.allclose(r.to_matrix(), om.reshape((2, 2, 3, 3)))
 
+    def test_from_matrix(self):
+        r = Rotation([[1, 0, 0, 0], [3, 0, 0, 0], [0, 1, 0, 0], [0, 2, 0, 0]])
+        om = np.array(
+            [np.eye(3), np.eye(3), np.diag([1, -1, -1]), np.diag([1, -1, -1])]
+        )
+        assert np.allclose(Rotation.from_matrix(om).data, r.data)
+        assert np.allclose(
+            Rotation.from_matrix(om.reshape((2, 2, 3, 3))).data, r.reshape(2, 2).data
+        )
 
-def test_from_matrix():
-    om = np.array([np.eye(3), np.diag([1, -1, -1])])
-    assert np.allclose(Rotation.from_matrix(om).to_matrix(), om)
+    def test_from_to_matrix(self):
+        om = np.array(
+            [np.eye(3), np.eye(3), np.diag([1, -1, -1]), np.diag([1, -1, -1])]
+        )
+        assert np.allclose(Rotation.from_matrix(om).to_matrix(), om)
+
+    def test_from_to_matrix2(self, e):
+        r = Rotation.from_euler(e.reshape((5, 2, 3)))
+        assert np.allclose(Rotation.from_matrix(r.to_matrix()).data, r.data)

--- a/orix/tests/test_rotation.py
+++ b/orix/tests/test_rotation.py
@@ -1,4 +1,3 @@
-# from diffpy.structure.spacegroups import
 from math import cos, sin, tan, pi
 import numpy as np
 import pytest

--- a/orix/tests/test_rotation.py
+++ b/orix/tests/test_rotation.py
@@ -453,3 +453,13 @@ def test_random_vonmises(shape, reference):
     r = Rotation.random_vonmises(shape, 1.0, reference)
     assert r.shape == shape
     assert isinstance(r, Rotation)
+
+
+def test_to_matrix():
+    r = Rotation([[1, 0, 0, 0], [0, 1, 0, 0]])
+    assert np.allclose(r.to_matrix(), [np.eye(3), np.diag([1, -1, -1])])
+
+
+def test_from_matrix():
+    om = np.array([np.eye(3), np.diag([1, -1, -1])])
+    assert np.allclose(Rotation.from_matrix(om).to_matrix(), om)


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

Release notes: Add Rotation.to/from_matrix() methods to convert between quaternions and orientation matrices.

To do:
- [x] More robust tests
- [x] Think of any edge cases or different input shapes (help wanted)