### PR TITLE
Modify spacegroup2pointgroup conversion to include improper point groups

### DIFF
--- a/orix/quaternion/symmetry.py
+++ b/orix/quaternion/symmetry.py
@@ -477,6 +477,16 @@ def _get_point_group(space_group_number, proper=False):
     -------
     point_group : orix.quaternion.symmetry.Symmetry
         One of the 11 proper or 32 point groups.
+
+    Examples
+    --------
+    >>> from orix.quaternion.symmetry import _get_point_group
+    >>> pgOh = _get_point_group(225)
+    >>> pgOh.name
+    'm-3m'
+    >>> pgO = _get_point_group(225, proper=True)
+    >>> pgO.name
+    '432'
     """
     spg = GetSpaceGroup(space_group_number)
     pgn = spg.point_group_name

--- a/orix/quaternion/symmetry.py
+++ b/orix/quaternion/symmetry.py
@@ -37,6 +37,7 @@ improper rotations. A mirror symmetry is equivalent to a 2-fold rotation
 combined with inversion.
 
 """
+from diffpy.structure.spacegroups import GetSpaceGroup
 import numpy as np
 
 from orix.quaternion.rotation import Rotation
@@ -416,3 +417,70 @@ def get_distinguished_points(s1, s2=C1):
     """
     distinguished_points = s1.outer(s2).antipodal.unique(antipodal=False)
     return distinguished_points[distinguished_points.angle > 0]
+
+
+spacegroup2pointgroup_dict = {
+    "PG1": {"proper": C1, "improper": C1},
+    "PG1bar": {"proper": C1, "improper": Ci},
+    "PG2": {"proper": C2, "improper": C2},
+    "PGm": {"proper": C2, "improper": Cs},
+    "PG2/m": {"proper": C2, "improper": C2h},
+    "PG222": {"proper": D2, "improper": D2},
+    "PGmm2": {"proper": C2, "improper": C2v},
+    "PGmmm": {"proper": D2, "improper": D2h},
+    "PG4": {"proper": C4, "improper": C4},
+    "PG4bar": {"proper": C4, "improper": S4},
+    "PG4/m": {"proper": C4, "improper": C4h},
+    "PG422": {"proper": D4, "improper": D4},
+    "PG4mm": {"proper": C4, "improper": C4v},
+    "PG4bar2m": {"proper": D4, "improper": D2d},
+    "PG4barm2": {"proper": D4, "improper": D2d},
+    "PG4/mmm": {"proper": D4, "improper": D4h},
+    "PG3": {"proper": C3, "improper": C3},
+    "PG3bar": {"proper": C3, "improper": S6},  # Improper also known as C3i
+    "PG312": {"proper": D3, "improper": D3},
+    "PG321": {"proper": D3, "improper": D3},
+    "PG3m1": {"proper": C3, "improper": C3v},
+    "PG31m": {"proper": C3, "improper": C3v},
+    "PG3m": {"proper": C3, "improper": C3v},
+    "PG3bar1m": {"proper": D3, "improper": D3d},
+    "PG3barm1": {"proper": D3, "improper": D3d},
+    "PG3barm": {"proper": D3, "improper": D3d},
+    "PG6": {"proper": C6, "improper": C6},
+    "PG6bar": {"proper": C6, "improper": C3h},
+    "PG6/m": {"proper": C6, "improper": C6h},
+    "PG622": {"proper": D6, "improper": D6},
+    "PG6mm": {"proper": C6, "improper": C6v},
+    "PG6barm2": {"proper": D6, "improper": D3h},
+    "PG6bar2m": {"proper": D6, "improper": D3h},
+    "PG6/mmm": {"proper": D6, "improper": D6h},
+    "PG23": {"proper": T, "improper": T},
+    "PGm3bar": {"proper": T, "improper": Th},
+    "PG432": {"proper": O, "improper": O},
+    "PG4bar3m": {"proper": T, "improper": Td},
+    "PGm3barm": {"proper": O, "improper": Oh},
+}
+
+
+def _get_point_group(space_group_number, proper=False):
+    """Maps a space group number to its (proper) point group.
+
+    Parameters
+    ----------
+    space_group_number : int
+        Between 1 and 231.
+    proper : bool, optional
+        Whether to return the point group with proper rotations only
+        (True), or just the point group (False). Default is False.
+
+    Returns
+    -------
+    point_group : orix.quaternion.symmetry.Symmetry
+        One of the 11 proper or 32 point groups.
+    """
+    spg = GetSpaceGroup(space_group_number)
+    pgn = spg.point_group_name
+    if proper:
+        return spacegroup2pointgroup_dict[pgn]["proper"]
+    else:
+        return spacegroup2pointgroup_dict[pgn]["improper"]

--- a/orix/sampling/sample_generators.py
+++ b/orix/sampling/sample_generators.py
@@ -20,11 +20,9 @@
 
 import numpy as np
 
-from orix.sampling.sampling_utils import (
-    uniform_SO3_sample,
-    _get_proper_point_group,
-)
+from orix.sampling.sampling_utils import uniform_SO3_sample
 from orix.quaternion.orientation_region import OrientationRegion
+from orix.quaternion.symmetry import _get_point_group
 
 
 def get_sample_fundamental(resolution=2, point_group=None, space_group=None):
@@ -52,10 +50,10 @@ def get_sample_fundamental(resolution=2, point_group=None, space_group=None):
     Examples
     --------
     >>> from orix.quaternion.symmetry import C2,C4
-    >>> grid = get_grid_fundamental(1, point_group=C2)
+    >>> grid = get_sample_fundamental(1, point_group=C2)
     """
     if point_group is None:
-        point_group = _get_proper_point_group(space_group)
+        point_group = _get_point_group(space_group, proper=True)
 
     q = uniform_SO3_sample(resolution)
     fundamental_region = OrientationRegion.from_symmetry(point_group)

--- a/orix/sampling/sampling_utils.py
+++ b/orix/sampling/sampling_utils.py
@@ -22,52 +22,7 @@ the grid generation within rotation space """
 import numpy as np
 from itertools import product
 
-from diffpy.structure.spacegroups import GetSpaceGroup
-
 from orix.quaternion.rotation import Rotation
-from orix.quaternion.symmetry import C1, C2, C3, C4, C6, D2, D3, D4, D6, O, T
-
-conversion_dict = {
-    "PG1": C1,
-    "PG1bar": C1,
-    "PG2": C2,
-    "PGm": C2,
-    "PG2/m": C2,
-    "PG222": D2,
-    "PGmm2": C2,
-    "PGmmm": D2,
-    "PG4": C4,
-    "PG4bar": C4,
-    "PG4/m": C4,
-    "PG422": D4,
-    "PG4mm": C4,
-    "PG4bar2m": D4,
-    "PG4barm2": D4,
-    "PG4/mmm": D4,
-    "PG3": C3,
-    "PG3bar": C3,
-    "PG312": D3,
-    "PG321": D3,
-    "PG3m1": C3,
-    "PG31m": C3,
-    "PG3m": C3,
-    "PG3bar1m": D3,
-    "PG3barm1": D3,
-    "PG3barm": D3,
-    "PG6": C6,
-    "PG6bar": C6,
-    "PG6/m": C6,
-    "PG622": D6,
-    "PG6mm": C6,
-    "PG6barm2": D6,
-    "PG6bar2m": D6,
-    "PG6/mmm": D6,
-    "PG23": T,
-    "PGm3bar": T,
-    "PG432": O,
-    "PG4bar3m": T,
-    "PGm3barm": O,
-}
 
 
 def uniform_SO3_sample(resolution):
@@ -100,23 +55,3 @@ def uniform_SO3_sample(resolution):
     # remove duplicates
     q = q.unique()
     return q
-
-
-def _get_proper_point_group(space_group_number):
-    """
-    Maps a space group number to its proper point group
-
-    Parameters
-    ----------
-    space_group_number : int
-        Between 1 and 231
-
-    Returns
-    -------
-    point_group : orix.quaternion.symmetry.Symmetry
-        One of the 11 proper point groups
-    """
-    spg = GetSpaceGroup(space_group_number)
-    pgn = spg.point_group_name
-
-    return conversion_dict[pgn]

--- a/orix/tests/test_sampling.py
+++ b/orix/tests/test_sampling.py
@@ -21,19 +21,9 @@ import pytest
 import numpy as np
 
 from orix.quaternion.rotation import Rotation
-from orix.quaternion.symmetry import C1, C2, C3, C4, C6, D2, D3, D4, D6, O, T
-from orix.sampling.sampling_utils import (
-    uniform_SO3_sample,
-    _get_proper_point_group,
-)
+from orix.quaternion.symmetry import C2, C6, D6, _get_point_group
+from orix.sampling.sampling_utils import uniform_SO3_sample
 from orix.sampling.sample_generators import get_sample_fundamental, get_sample_local
-
-
-def test_get_proper_point_group():
-    """ Makes sure all the ints from 1 to 230 give answers"""
-    for _space_group in np.arange(1, 231):
-        point_group = _get_proper_point_group(_space_group)
-        assert point_group in [C1, C2, C3, C4, C6, D2, D3, D4, D6, O, T]
 
 
 @pytest.fixture(scope="session")
@@ -87,7 +77,7 @@ def test_get_sample_fundamental_zone_order(C6_sample):
 def test_get_sample_fundamental_space_group(C6_sample):
     """ Going via the space_group route """
     # assert that space group #3 is has pg C2
-    assert C2 == _get_proper_point_group(3)
+    assert C2 == _get_point_group(3, proper=True)
     C2_sample = get_sample_fundamental(4, space_group=3)
     ratio = C2_sample.size / C6_sample.size
     assert np.isclose(ratio, 3, rtol=0.025)

--- a/orix/tests/test_symmetry.py
+++ b/orix/tests/test_symmetry.py
@@ -1,7 +1,8 @@
+from diffpy.structure.spacegroups import GetSpaceGroup
 import pytest
 
 from orix.quaternion.symmetry import *
-from orix.vector import Vector3d
+from orix.quaternion.symmetry import _get_point_group, spacegroup2pointgroup_dict
 
 
 @pytest.fixture(params=[(1, 2, 3)])
@@ -309,3 +310,15 @@ def test_fundamental_sector(symmetry, expected):
 def test_no_symm_fundemental_sector():
     nosym = Symmetry.from_generators(Rotation([1, 0, 0, 0]))
     nosym.fundamental_sector()
+
+
+def test_get_point_group():
+    """Makes sure all the ints from 1 to 230 give answers."""
+    for sg_number in np.arange(1, 231):
+        proper_pg = _get_point_group(sg_number, proper=True)
+        assert proper_pg in [C1, C2, C3, C4, C6, D2, D3, D4, D6, O, T]
+
+        sg = GetSpaceGroup(sg_number)
+        pg = _get_point_group(sg_number, proper=False)
+        assert proper_pg == spacegroup2pointgroup_dict[sg.point_group_name]["proper"]
+        assert pg == spacegroup2pointgroup_dict[sg.point_group_name]["improper"]


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

* Changed location and name of function `orix.sampling.sampling_utils._get_proper_point_group()` to `orix.quaternion.symmetry._get_point_group()`
* Added a `proper: bool = False` parameter to `_get_point_group()`, returning either the proper or "improper" point group from the old `conversion_dict`. Since the name is now `_get_point_group()`, default is to return the improper point group.
* Added "improper" point groups to the `conversion_dict` space group to point group conversion dictionary. Also moved the dictionary to `orix.quaternion.symmetry`.
* Moved and updated tests accordingly

This PR, or a version of it, is necessary when deriving the point group from the space group in the `Phase` class. The idea is that when you define a `Phase` specifying a space group, you don't necessarily want the proper point group, just the point group.

Feel free to change the setup of the dictionary (proper/improper) or propose a change if you think it's ugly and can be done better.

I'm sure the docstring wording can be improved also.

Example usage:
```python
>>> from orix.quaternion.symmetry import _get_point_group
>>> from diffpy.structure.spacegroups import GetSpaceGroup
>>> sg225 = GetSpaceGroup(225)
>>> sg225.short_name
'Fm-3m'
>>> sg225.point_group_name
'PGm3barm'
>>> _get_point_group(225).name
'm-3m'
>>> _get_point_group(225, proper=False).name
'm-3m'
>>> _get_point_group(225, proper=True).name
'432'
```