### PR TITLE
Add diffpy.structure space group to Phase class

### DIFF
--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -459,9 +459,9 @@ class CrystalMap:
         A CrystalMap object can be indexed in multiple ways...
 
         >>> cm
-        Phase   Orientations       Name  Space/point group       Color
-            1   5657 (48.4%)  austenite         Fm-3m/m-3m    tab:blue
-            2   6043 (51.6%)    ferrite         Im-3m/m-3m  tab:orange
+        Phase  Orientations       Name  Space group  Point group  Proper point group       Color
+            1  5657 (48.4%)  austenite         None          432                 432    tab:blue
+            2  6043 (51.6%)    ferrite         None          432                 432  tab:orange
         Properties: iq, dp
         Scan unit: um
         >>> cm.shape
@@ -471,18 +471,18 @@ class CrystalMap:
 
         >>> cm2 = cm[20:40, 50:60]
         >>> cm2
-        Phase  Orientations       Name  Space/point group       Color
-            1   148 (74.0%)  austenite         Fm-3m/m-3m    tab:blue
-            2    52 (26.0%)    ferrite         Im-3m/m-3m  tab:orange
+        Phase  Orientations       Name  Space group  Point group  Proper point group       Color
+            1   148 (74.0%)  austenite         None          432                 432    tab:blue
+            2    52 (26.0%)    ferrite         None          432                 432  tab:orange
         Properties: iq, dp
         Scan unit: um
         >>> cm2.shape
         (20, 10)
         >>> cm2 = cm[20:40, 3]
         >>> cm2
-        Phase  Orientations       Name  Space/point group       Color
-            1    16 (80.0%)  austenite         Fm-3m/m-3m    tab:blue
-            2     4 (20.0%)    ferrite         Im-3m/m-3m  tab:orange
+        Phase  Orientations       Name  Space group  Point group  Proper point group       Color
+            1    16 (80.0%)  austenite         None          432                 432    tab:blue
+            2     4 (20.0%)    ferrite         None          432                 432  tab:orange
         Properties: iq, dp
         Scan unit: um
         >>> cm2.shape
@@ -492,8 +492,8 @@ class CrystalMap:
 
         >>> cm2 = cm[10, 10]
         >>> cm2
-        Phase  Orientations     Name  Space/point group       Color
-            2    1 (100.0%)  ferrite         Im-3m/m-3m  tab:orange
+        Phase  Orientations     Name  Space group  Point group  Proper point group       Color
+            2    1 (100.0%)  ferrite         None          432                 432  tab:orange
         Properties: iq, dp
         Scan unit: um
         >>> cm.shape
@@ -502,26 +502,26 @@ class CrystalMap:
         ... by phase name(s)
 
         >>> cm2 = cm["austenite"]
-        Phase   Orientations       Name  Space/point group     Color
-            1  5657 (100.0%)  austenite         Fm-3m/m-3m  tab:blue
+        Phase  Orientations       Name  Space group  Point group  Proper point group     Color
+            1  5657 (100.0%)  austenite         None          432                 432  tab:blue
         Properties: iq, dp
         Scan unit: um
         >>> cm2.shape
         (100, 117)
         >>> cm["austenite", "ferrite"]
-        Phase  Orientations       Name  Space/point group       Color
-            1  5657 (48.4%)  austenite         Fm-3m/m-3m    tab:blue
-            2  6043 (51.6%)    ferrite         Im-3m/m-3m  tab:orange
-        Properties: dp, iq
+        Phase  Orientations       Name  Space group  Point group  Proper point group       Color
+            1  5657 (48.4%)  austenite         None          432                 432    tab:blue
+            2  6043 (51.6%)    ferrite         None          432                 432  tab:orange
+        Properties: iq, dp
         Scan unit: um
 
         ... by "indexed" and "not_indexed"
 
         >>> cm["indexed"]
-        Phase  Orientations       Name  Space/point group       Color
-            1  5657 (48.4%)  austenite         Fm-3m/m-3m    tab:blue
-            2  6043 (51.6%)    ferrite         Im-3m/m-3m  tab:orange
-        Properties: dp, iq
+        Phase  Orientations       Name  Space group  Point group  Proper point group       Color
+            1  5657 (48.4%)  austenite         None          432                 432    tab:blue
+            2  6043 (51.6%)    ferrite         None          432                 432  tab:orange
+        Properties: iq, dp
         Scan unit: um
         >>> cm["not_indexed"]
         No data.
@@ -529,14 +529,14 @@ class CrystalMap:
         ... or by boolean arrays ((chained) conditional(s))
 
         >>> cm[cm.dp > 0.81]
-        Phase  Orientations       Name  Space/point group       Color
-            1  4092 (44.8%)  austenite         Fm-3m/m-3m    tab:blue
-            2  5035 (55.2%)    ferrite         Im-3m/m-3m  tab:orange
+        Phase  Orientations       Name  Space group  Point group  Proper point group       Color
+            1  4092 (44.8%)  austenite         None          432                 432    tab:blue
+            2  5035 (55.2%)    ferrite         None          432                 432  tab:orange
         Properties: iq, dp
         Scan unit: um
         >>> cm[(cm.iq > np.mean(cm.iq)) & (cm.phase_id == 1)]
-        Phase   Orientations       Name  Space/point group     Color
-            1  1890 (100.0%)  austenite         Fm-3m/m-3m  tab:blue
+        Phase  Orientations       Name  Space group  Point group  Proper point group     Color
+            1  1890 (100.0%)  austenite         None          432                 432  tab:blue
         Properties: iq, dp
         Scan unit: um
         """
@@ -609,10 +609,11 @@ class CrystalMap:
 
         # Ensure attributes set to None are treated OK
         names = ["None" if not name else name for name in phases.names]
-        space_group_names = [
-            "None" if not i else i.short_name for i in phases.space_groups
+        sg_names = ["None" if not i else i.short_name for i in phases.space_groups]
+        pg_names = ["None" if not i else i.name for i in phases.point_groups]
+        ppg_names = [
+            "None" if not i else i.proper_subgroup.name for i in phases.point_groups
         ]
-        point_group_names = ["None" if not i else i.name for i in phases.point_groups]
 
         # Determine column widths
         unique_phases = np.unique(phase_ids)
@@ -620,9 +621,9 @@ class CrystalMap:
         id_len = 5
         ori_len = max(max([len(str(p_size)) for p_size in p_sizes]) + 8, 12)
         name_len = max(max([len(n) for n in names]), 4)
-        pg_len_max = max([len(i) for i in point_group_names])
-        sg_len_max = max([len(i) for i in space_group_names])
-        sg_pg_len = max(pg_len_max + sg_len_max + 1, 17)
+        sg_len = max(max([len(i) for i in sg_names]), 11)
+        pg_len = max(max([len(i) for i in pg_names]), 11)
+        ppg_len = max(max([len(i) for i in ppg_names]), 18)
         col_len = max(max([len(i) for i in phases.colors]), 5)
 
         # Column alignment
@@ -633,8 +634,10 @@ class CrystalMap:
             "{:{align}{width}}  ".format("Phase", width=id_len, align=align)
             + "{:{align}{width}}  ".format("Orientations", width=ori_len, align=align)
             + "{:{align}{width}}  ".format("Name", width=name_len, align=align)
+            + "{:{align}{width}}  ".format("Space group", width=sg_len, align=align)
+            + "{:{align}{width}}  ".format("Point group", width=pg_len, align=align)
             + "{:{align}{width}}  ".format(
-                "Space/point group", width=sg_pg_len, align=align
+                "Proper point group", width=ppg_len, align=align
             )
             + "{:{align}{width}}\n".format("Color", width=col_len, align=align)
         )
@@ -644,12 +647,13 @@ class CrystalMap:
             p_size = np.where(phase_ids == phase_id)[0].size
             p_fraction = 100 * p_size / self.size
             ori_str = f"{p_size} ({p_fraction:.1f}%)"
-            sg_pg = f"{space_group_names[i]}/{point_group_names[i]}"
             representation += (
                 f"{phase_id:{align}{id_len}}  "
                 + f"{ori_str:{align}{ori_len}}  "
                 + f"{names[i]:{align}{name_len}}  "
-                + f"{sg_pg:{align}{sg_pg_len}}  "
+                + f"{sg_names[i]:{align}{sg_len}}  "
+                + f"{pg_names[i]:{align}{pg_len}}  "
+                + f"{ppg_names[i]:{align}{ppg_len}}  "
                 + f"{phases.colors[i]:{align}{col_len}}\n"
             )
 

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -157,14 +157,13 @@ class CrystalMap:
         ...         lattice=Lattice(0.287, 0.287, 0.287, 90, 90, 90)
         ...     )
         ... ]
+        >>> pl = PhaseList(space_groups=[225, 229], structures=structures)
         >>> cm = CrystalMap(
         ...     rotations=rotations,
         ...     phase_id=phase_id,
         ...     x=x,
         ...     y=y,
-        ...     phase_name=["austenite", "ferrite"],  # Overwrites Structure.title
-        ...     point_group=["432", "432"],
-        ...     structure=structures,
+        ...     phase_list=pl,
         ...     prop=properties,
         ... )
         """
@@ -460,9 +459,9 @@ class CrystalMap:
         A CrystalMap object can be indexed in multiple ways...
 
         >>> cm
-        Phase   Orientations       Name  Point group       Color
-            1   5657 (48.4%)  austenite          432    tab:blue
-            2   6043 (51.6%)    ferrite          432  tab:orange
+        Phase   Orientations       Name  Space/point group       Color
+            1   5657 (48.4%)  austenite         Fm-3m/m-3m    tab:blue
+            2   6043 (51.6%)    ferrite         Im-3m/m-3m  tab:orange
         Properties: iq, dp
         Scan unit: um
         >>> cm.shape
@@ -472,18 +471,18 @@ class CrystalMap:
 
         >>> cm2 = cm[20:40, 50:60]
         >>> cm2
-        Phase  Orientations       Name  Point group       Color
-            1   148 (74.0%)  austenite          432    tab:blue
-            2    52 (26.0%)    ferrite          432  tab:orange
+        Phase  Orientations       Name  Space/point group       Color
+            1   148 (74.0%)  austenite         Fm-3m/m-3m    tab:blue
+            2    52 (26.0%)    ferrite         Im-3m/m-3m  tab:orange
         Properties: iq, dp
         Scan unit: um
         >>> cm2.shape
         (20, 10)
         >>> cm2 = cm[20:40, 3]
         >>> cm2
-        Phase  Orientations       Name  Point group       Color
-            1    16 (80.0%)  austenite          432    tab:blue
-            2     4 (20.0%)    ferrite          432  tab:orange
+        Phase  Orientations       Name  Space/point group       Color
+            1    16 (80.0%)  austenite         Fm-3m/m-3m    tab:blue
+            2     4 (20.0%)    ferrite         Im-3m/m-3m  tab:orange
         Properties: iq, dp
         Scan unit: um
         >>> cm2.shape
@@ -493,8 +492,8 @@ class CrystalMap:
 
         >>> cm2 = cm[10, 10]
         >>> cm2
-        Phase  Orientations     Name  Point group       Color
-            2    1 (100.0%)  ferrite          432  tab:orange
+        Phase  Orientations     Name  Space/point group       Color
+            2    1 (100.0%)  ferrite         Im-3m/m-3m  tab:orange
         Properties: iq, dp
         Scan unit: um
         >>> cm.shape
@@ -503,26 +502,26 @@ class CrystalMap:
         ... by phase name(s)
 
         >>> cm2 = cm["austenite"]
-        Phase   Orientations       Name  Point group     Color
-            1  5657 (100.0%)  austenite          432  tab:blue
+        Phase   Orientations       Name  Space/point group     Color
+            1  5657 (100.0%)  austenite         Fm-3m/m-3m  tab:blue
         Properties: iq, dp
         Scan unit: um
         >>> cm2.shape
         (100, 117)
         >>> cm["austenite", "ferrite"]
-        Phase  Orientations       Name  Point group       Color
-            1  5657 (48.4%)  austenite          432    tab:blue
-            2  6043 (51.6%)    ferrite          432  tab:orange
-        Properties: iq, dp
+        Phase  Orientations       Name  Space/point group       Color
+            1  5657 (48.4%)  austenite         Fm-3m/m-3m    tab:blue
+            2  6043 (51.6%)    ferrite         Im-3m/m-3m  tab:orange
+        Properties: dp, iq
         Scan unit: um
 
         ... by "indexed" and "not_indexed"
 
         >>> cm["indexed"]
-        Phase  Orientations       Name  Point group       Color
-            1  5657 (48.4%)  austenite          432    tab:blue
-            2  6043 (51.6%)    ferrite          432  tab:orange
-        Properties: iq, dp
+        Phase  Orientations       Name  Space/point group       Color
+            1  5657 (48.4%)  austenite         Fm-3m/m-3m    tab:blue
+            2  6043 (51.6%)    ferrite         Im-3m/m-3m  tab:orange
+        Properties: dp, iq
         Scan unit: um
         >>> cm["not_indexed"]
         No data.
@@ -530,14 +529,14 @@ class CrystalMap:
         ... or by boolean arrays ((chained) conditional(s))
 
         >>> cm[cm.dp > 0.81]
-        Phase  Orientations       Name  Point group       Color
-            1  4092 (44.8%)  austenite          432    tab:blue
-            2  5035 (55.2%)    ferrite          432  tab:orange
+        Phase  Orientations       Name  Space/point group       Color
+            1  4092 (44.8%)  austenite         Fm-3m/m-3m    tab:blue
+            2  5035 (55.2%)    ferrite         Im-3m/m-3m  tab:orange
         Properties: iq, dp
         Scan unit: um
         >>> cm[(cm.iq > np.mean(cm.iq)) & (cm.phase_id == 1)]
-        Phase   Orientations       Name  Point group     Color
-            1  1890 (100.0%)  austenite          432  tab:blue
+        Phase   Orientations       Name  Space/point group     Color
+            1  1890 (100.0%)  austenite         Fm-3m/m-3m  tab:blue
         Properties: iq, dp
         Scan unit: um
         """
@@ -699,8 +698,8 @@ class CrystalMap:
 
         # Declare array of correct shape, accounting for RGB
         # TODO: Better account for `item.shape`, e.g. quaternions
-        #  (item.shape[-1] == 4)
-        # TODO: ... in a more general way than here (not more if/else)!
+        #  (item.shape[-1] == 4) in a more general way than here (not more
+        #  if/else)!
         array = np.zeros(np.prod(map_shape))
         if isinstance(item, np.ndarray):
             if item.shape[-1] == 3:  # Assume RGB

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -54,11 +54,11 @@ class Phase:
     name : str
         Phase name.
     point_group : orix.quaternion.symmetry.Symmetry
-        Point group describing the symmetry elements of the phase's
+        Point group describing the symmetry operations of the phase's
         crystal structure, according to the International Tables of
         Crystallography.
     space_group : diffpy.structure.spacegroups.SpaceGroup
-        Space group describing the symmetry elements resulting from
+        Space group describing the symmetry operations resulting from
         associating the point group with a Bravais lattice, according to
         the International Tables of Crystallography.
     structure : diffpy.structure.Structure
@@ -80,7 +80,7 @@ class Phase:
             Phase name. Overwrites the name in the `structure` object.
         space_group : int or diffpy.structure.spacegroups.SpaceGroup,\
                 optional
-            Space group describing the symmetry elements resulting from
+            Space group describing the symmetry operations resulting from
             associating the point group with a Bravais lattice, according
             to the International Tables of Crystallography. If None is
             passed (default), it is set to None.

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -26,8 +26,7 @@ from diffpy.structure.spacegroups import GetSpaceGroup, SpaceGroup
 import matplotlib.colors as mcolors
 import numpy as np
 
-from orix.quaternion.symmetry import _groups, Symmetry
-from orix.sampling.sampling_utils import _get_proper_point_group
+from orix.quaternion.symmetry import _groups, _get_point_group, Symmetry
 
 # All named Matplotlib colors (tableau and xkcd already lower case hex)
 ALL_COLORS = mcolors.TABLEAU_COLORS
@@ -193,7 +192,7 @@ class Phase:
     def point_group(self):
         """Point group of phase."""
         if self.space_group is not None:
-            return _get_proper_point_group(self.space_group.number)
+            return _get_point_group(self.space_group.number)
         else:
             return self._point_group
 
@@ -225,7 +224,7 @@ class Phase:
                         f"'{self.space_group.short_name}' is derived from current point"
                         f" group '{old_point_group_name}'."
                     )
-                self.space_group = None
+                    self.space_group = None
             self._point_group = value
 
     def __repr__(self):

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -106,14 +106,14 @@ class Phase:
         >>> from orix.crystal_map import Phase
         >>> p = Phase(
         ...     name="al",
-        ...     point_group="m-3m",
+        ...     space_group=225,
         ...     structure=Structure(
         ...         atoms=[Atom("al", [0, 0, 0])],
         ...         lattice=Lattice(0.405, 0.405, 0.405, 90, 90, 90)
         ...     )
         ... )
         >>> p
-        <name: al. point group: m-3m. color: tab:blue>
+        <name: al. space/point group: Fm-3m/m-3m. color: tab:blue>
         >>> p.structure
         [al   0.000000 0.000000 0.000000 1.0000]
         >>> p.structure.lattice
@@ -325,7 +325,7 @@ class PhaseList:
         >>> from orix.crystal_map import Phase, PhaseList
         >>> pl = PhaseList(
         ...     names=["al", "cu"],
-        ...     point_groups=["m-3m"] * 2,
+        ...     space_groups=[225] * 2,
         ...     structures=[
         ...         Structure(
         ...             atoms=[Atom("al", [0] * 3)],
@@ -338,9 +338,9 @@ class PhaseList:
         ...     ]
         ... )
         >>> pl
-        Id  Name  Point groups       Color
-         0    al          m-3m    tab:blue
-         1    cu          m-3m  tab:orange
+        Id  Name  Space/point groups       Color
+         0    al          Fm-3m/m-3m    tab:blue
+         1    cu          Fm-3m/m-3m  tab:orange
         >>> pl["al"].structure
         [al   0.000000 0.000000 0.000000 1.0000]
         """
@@ -503,39 +503,39 @@ class PhaseList:
         --------
         A PhaseList object can be indexed in multiple ways.
 
-        >>> pl = PhaseList(names=['a', 'b'], point_groups=['1', '3'])
+        >>> pl = PhaseList(names=['a', 'b'], space_groups=[200, 220])
         >>> pl
-        Id  Name  Point group       Color
-         0     a            1    tab:blue
-         1     b            3  tab:orange
+        Id  Name  Space/point group       Color
+         0     a           Pm-3/m-3    tab:blue
+         1     b         I-43d/-43m  tab:orange
 
         Return a Phase object if only one phase matches the key
 
         >>> pl[0]  # Index with a single phase id
-        <name: a. point group: 1. color: tab:blue>
+        <name: a. space/point group: Pm-3/m-3. color: tab:blue>
         >>> pl['b']  # Index with a phase name
-        <name: b. point group: 3. color: tab:orange>
+        <name: b. space/point group: I-43d/-43m. color: tab:orange>
         >>> pl[:1]
-        <name: b. point group: 3. color: tab:orange>
+        <name: b. space/point group: I-43d/-43m. color: tab:orange>
 
         Return a PhaseList object
 
         >>> pl[0:]  # Index with slices
-        Id  Name  Point group       Color
-         0    a             1    tab:blue
-         1    b             3  tab:orange
+        Id  Name  Space/point group       Color
+         0    a            Pm-3/m-3    tab:blue
+         1    b          I-43d/-43m  tab:orange
         >>> pl['a', 'b']  # Index with a tuple of phase names
-        Id  Name  Point group       Color
-         0    a             1    tab:blue
-         1    b             3  tab:orange
+        Id  Name  Space/point group       Color
+         0    a            Pm-3/m-3    tab:blue
+         1    b          I-43d/-43m  tab:orange
         >>> pl[0, 1]  # Index with a tuple of phase phase_ids
-        Id  Name  Point group       Color
-         0     a            1    tab:blue
-         1     b            3  tab:orange
+        Id  Name  Space/point group       Color
+         0    a            Pm-3/m-3    tab:blue
+         1    b          I-43d/-43m  tab:orange
         >>> pl[[0, 1]]  # Index with a list of phase_ids
-        Id  Name  Point group       Color
-         0     a            1    tab:blue
-         1     b            3  tab:orange
+        Id  Name  Space/point group       Color
+         0    a            Pm-3/m-3    tab:blue
+         1    b          I-43d/-43m  tab:orange
         """
         # Make key iterable if it isn't already
         if not isinstance(key, (tuple, slice, list, np.ndarray)):

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -669,10 +669,14 @@ class TestCrystalMapRepresentation:
         print(cm.__repr__())
 
         assert cm.__repr__() == (
-            "Phase  Orientations  Name  Space/point group  Color\n"
-            "    0    10 (83.3%)     a          None/m-3m      r\n"
-            "    1      1 (8.3%)     b           None/432      g\n"
-            "    2      1 (8.3%)     c             None/3      b\n"
+            "Phase  Orientations  Name  Space group  Point group  Proper point group  "
+            "Color\n"
+            "    0    10 (83.3%)     a         None         m-3m                 432  "
+            "    r\n"
+            "    1      1 (8.3%)     b         None          432                 432  "
+            "    g\n"
+            "    2      1 (8.3%)     c         None            3                   3  "
+            "    b\n"
             "Properties: iq\n"
             "Scan unit: nm"
         )

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -669,10 +669,10 @@ class TestCrystalMapRepresentation:
         print(cm.__repr__())
 
         assert cm.__repr__() == (
-            "Phase  Orientations  Name  Point group  Color\n"
-            "    0    10 (83.3%)     a         m-3m      r\n"
-            "    1      1 (8.3%)     b          432      g\n"
-            "    2      1 (8.3%)     c            3      b\n"
+            "Phase  Orientations  Name  Space/point group  Color\n"
+            "    0    10 (83.3%)     a          None/m-3m      r\n"
+            "    1      1 (8.3%)     b           None/432      g\n"
+            "    2      1 (8.3%)     c             None/3      b\n"
             "Properties: iq\n"
             "Scan unit: nm"
         )


### PR DESCRIPTION
Closes #99 and #87 (see discussion therein).

Changes in this PR:
* Add `Phase.space_group` property, which stores a `diffpy.structure.spacegroups.SpaceGroup` object or `None`.
* If `Phase.space_group` is not `None`, derive `Phase.point_group` from `space_group`, otherwise return whatever is stored in `Phase._point_group`
* `Phase.space_group` can be set by passing a `SpaceGroup` or an integer 1-230
* `Phase` initialization is possible by either passing:
1. space group (point group is derived)
2. space group and point group (they have to "match" or a warning is raised [not error] and the space group is set to `None`)
3. point group (space group is set to `None`)
4. neither (both set to `None`)
* Add `space_groups` parameter to `PhaseList.__init__()`
* Add `PhaseList.space_groups` property
* `Phase`, `PhaseList`, and `CrystalMap` string representation now show
```python
>>> cm
Phase  Orientations       Name  Space group  Point group  Proper point group       Color
    1  5657 (48.4%)  austenite         None          432                 432    tab:blue
    2  6043 (51.6%)    ferrite         None          432                 432  tab:orange
Properties: iq, dp
Scan unit: um
>>> cm.phases
Id       Name  Space group  Point group  Proper point group       Color
 1  austenite         None          432                 432    tab:blue
 2    ferrite         None          432                 432  tab:orange
>>> cm.phases[1]
<name: austenite. space group: None. point group: 432. proper point group: 432. color: tab:blue>
```
* Update relevant docstrings

Todo in this PR:
- [x] #102 should be merged into this before proceding
- [x] Think of the best way to warn the user when trying to set space group and point group that doesn't "match"
- [x] Update docstring examples
- [x] Update tests

Other PRs:
- [ ] Improve adding a `Phase` to the `PhaseList`, via e.g. `PhaseList.append(Phase)`
- [ ] Write/read space group number to/from the crystal map orix HDF5 file, specifically the `phase2dict()` and `dict2phase()` functions