### PR TITLE
Write/read space group number to/from orix HDF5, update tests

### DIFF
--- a/orix/io/plugins/orix_hdf5.py
+++ b/orix/io/plugins/orix_hdf5.py
@@ -172,7 +172,16 @@ def dict2phase(dictionary):
     dictionary = copy.deepcopy(dictionary)
     structure = dict2structure(dictionary["structure"])
     structure.title = dictionary["name"]
-    # TODO: Remove this check in v0.6.0
+    # TODO: Remove this check in v0.6.0, since space_group was introduced in v0.4.0
+    try:
+        space_group = dictionary["space_group"]  # Either "None" or int
+    except KeyError:  # v0.3.0
+        space_group = "None"
+    if space_group == "None":
+        space_group = None
+    else:
+        space_group = int(space_group)
+    # TODO: Remove this check in v0.6.0, since name change was introduced in v0.4.0
     try:
         point_group = dictionary["point_group"]
     except KeyError:  # v0.3.0
@@ -181,9 +190,10 @@ def dict2phase(dictionary):
         point_group = None
     return Phase(
         name=dictionary["name"],
-        color=dictionary["color"],
+        space_group=space_group,
         point_group=point_group,
         structure=structure,
+        color=dictionary["color"],
     )
 
 
@@ -416,10 +426,15 @@ def phase2dict(phase, dictionary=None):
         dictionary = {}
 
     dictionary["name"] = phase.name
+    if hasattr(phase.space_group, "number"):
+        space_group = phase.space_group.number
+    else:
+        space_group = "None"
     if hasattr(phase.point_group, "name"):
         point_group = phase.point_group.name
     else:
         point_group = "None"
+    dictionary["space_group"] = space_group
     dictionary["point_group"] = point_group
     dictionary["color"] = phase.color
     dictionary["structure"] = structure2dict(phase.structure)

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -476,6 +476,7 @@ def temp_emsoft_h5ebsd_file(tmpdir, request):
     params=[
         (
             ["a", "b", "c"],
+            [229, 207, 143],
             ["m-3m", "432", "3"],
             ["r", "g", "b"],
             [Lattice()] * 3,
@@ -484,11 +485,12 @@ def temp_emsoft_h5ebsd_file(tmpdir, request):
     ]
 )
 def phase_list(request):
-    names, point_group_names, colors, lattices, atoms = request.param
+    names, space_groups, point_group_names, colors, lattices, atoms = request.param
     # Apparently diffpy.structure don't allow iteration over a list of lattices
     structures = [Structure(lattice=lattices[i], atoms=a) for i, a in enumerate(atoms)]
     return PhaseList(
         names=names,
+        space_groups=space_groups,
         point_groups=point_group_names,
         colors=colors,
         structures=structures,

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -664,18 +664,16 @@ class TestCrystalMapRepresentation:
 
         cm.prop["iq"] = np.arange(cm.size)
 
-        assert cm[cm.phase_id == -1].__repr__() == "No data."
+        assert repr(cm[cm.phase_id == -1]) == "No data."
 
-        print(cm.__repr__())
-
-        assert cm.__repr__() == (
+        assert repr(cm) == (
             "Phase  Orientations  Name  Space group  Point group  Proper point group  "
             "Color\n"
-            "    0    10 (83.3%)     a         None         m-3m                 432  "
+            "    0    10 (83.3%)     a        Im-3m         m-3m                 432  "
             "    r\n"
-            "    1      1 (8.3%)     b         None          432                 432  "
+            "    1      1 (8.3%)     b         P432          432                 432  "
             "    g\n"
-            "    2      1 (8.3%)     c         None            3                   3  "
+            "    2      1 (8.3%)     c           P3            3                   3  "
             "    b\n"
             "Properties: iq\n"
             "Scan unit: nm"

--- a/orix/tests/test_phase_list.py
+++ b/orix/tests/test_phase_list.py
@@ -421,13 +421,13 @@ class TestPhaseList:
 
     @pytest.mark.parametrize(
         (
-            "key_getter, desired_name, desired_point_group, desired_proper_point_group,"
-            "desired_color"
+            "key_getter, desired_name, desired_space_group, desired_point_group, "
+            "desired_proper_point_group, desired_color"
         ),
         [
-            (0, "a", "m-3m", "432", "r"),
-            ("b", "b", "432", "432", "g"),
-            (slice(2, None, None), "c", "3", "3", "b"),  # equivalent to pl[2:]
+            (0, "a", "Im-3m", "m-3m", "432", "r"),
+            ("b", "b", "P432", "432", "432", "g"),
+            (slice(2, None, None), "c", "P3", "3", "3", "b"),  # equivalent to pl[2:]
         ],
     )
     def test_get_phase_from_phaselist(
@@ -435,14 +435,15 @@ class TestPhaseList:
         phase_list,
         key_getter,
         desired_name,
+        desired_space_group,
         desired_point_group,
         desired_proper_point_group,
         desired_color,
     ):
         p = phase_list[key_getter]
 
-        assert p.__repr__() == (
-            f"<name: {desired_name}. space group: None. point group: "
+        assert repr(p) == (
+            f"<name: {desired_name}. space group: {desired_space_group}. point group: "
             f"{desired_point_group}. proper point group: {desired_proper_point_group}. "
             f"color: {desired_color}>"
         )


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

* Write a phase's space group number to the crystal map orix HDF5 file
* Read a phase's space group number from the crystal map orix HDF5 file
* Update tests

I've checked locally that a file written with `orix` v0.3 is readable after this change.