### PR TITLE
Make get_point_group function part of the public API

### DIFF
--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -26,7 +26,7 @@ from diffpy.structure.spacegroups import GetSpaceGroup, SpaceGroup
 import matplotlib.colors as mcolors
 import numpy as np
 
-from orix.quaternion.symmetry import _groups, _get_point_group, Symmetry
+from orix.quaternion.symmetry import _groups, get_point_group, Symmetry
 
 # All named Matplotlib colors (tableau and xkcd already lower case hex)
 ALL_COLORS = mcolors.TABLEAU_COLORS
@@ -193,7 +193,7 @@ class Phase:
     def point_group(self):
         """Point group of phase."""
         if self.space_group is not None:
-            return _get_point_group(self.space_group.number)
+            return get_point_group(self.space_group.number)
         else:
             return self._point_group
 

--- a/orix/quaternion/symmetry.py
+++ b/orix/quaternion/symmetry.py
@@ -462,7 +462,7 @@ spacegroup2pointgroup_dict = {
 }
 
 
-def _get_point_group(space_group_number, proper=False):
+def get_point_group(space_group_number, proper=False):
     """Maps a space group number to its (proper) point group.
 
     Parameters
@@ -480,11 +480,11 @@ def _get_point_group(space_group_number, proper=False):
 
     Examples
     --------
-    >>> from orix.quaternion.symmetry import _get_point_group
-    >>> pgOh = _get_point_group(225)
+    >>> from orix.quaternion.symmetry import get_point_group
+    >>> pgOh = get_point_group(225)
     >>> pgOh.name
     'm-3m'
-    >>> pgO = _get_point_group(225, proper=True)
+    >>> pgO = get_point_group(225, proper=True)
     >>> pgO.name
     '432'
     """

--- a/orix/sampling/sample_generators.py
+++ b/orix/sampling/sample_generators.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from orix.sampling.sampling_utils import uniform_SO3_sample
 from orix.quaternion.orientation_region import OrientationRegion
-from orix.quaternion.symmetry import _get_point_group
+from orix.quaternion.symmetry import get_point_group
 
 
 def get_sample_fundamental(resolution=2, point_group=None, space_group=None):
@@ -53,7 +53,7 @@ def get_sample_fundamental(resolution=2, point_group=None, space_group=None):
     >>> grid = get_sample_fundamental(1, point_group=C2)
     """
     if point_group is None:
-        point_group = _get_point_group(space_group, proper=True)
+        point_group = get_point_group(space_group, proper=True)
 
     q = uniform_SO3_sample(resolution)
     fundamental_region = OrientationRegion.from_symmetry(point_group)

--- a/orix/tests/test_sampling.py
+++ b/orix/tests/test_sampling.py
@@ -21,7 +21,7 @@ import pytest
 import numpy as np
 
 from orix.quaternion.rotation import Rotation
-from orix.quaternion.symmetry import C2, C6, D6, _get_point_group
+from orix.quaternion.symmetry import C2, C6, D6, get_point_group
 from orix.sampling.sampling_utils import uniform_SO3_sample
 from orix.sampling.sample_generators import get_sample_fundamental, get_sample_local
 
@@ -77,7 +77,7 @@ def test_get_sample_fundamental_zone_order(C6_sample):
 def test_get_sample_fundamental_space_group(C6_sample):
     """ Going via the space_group route """
     # assert that space group #3 is has pg C2
-    assert C2 == _get_point_group(3, proper=True)
+    assert C2 == get_point_group(3, proper=True)
     C2_sample = get_sample_fundamental(4, space_group=3)
     ratio = C2_sample.size / C6_sample.size
     assert np.isclose(ratio, 3, rtol=0.025)

--- a/orix/tests/test_symmetry.py
+++ b/orix/tests/test_symmetry.py
@@ -2,7 +2,7 @@ from diffpy.structure.spacegroups import GetSpaceGroup
 import pytest
 
 from orix.quaternion.symmetry import *
-from orix.quaternion.symmetry import _get_point_group, spacegroup2pointgroup_dict
+from orix.quaternion.symmetry import get_point_group, spacegroup2pointgroup_dict
 
 
 @pytest.fixture(params=[(1, 2, 3)])
@@ -315,10 +315,10 @@ def test_no_symm_fundemental_sector():
 def test_get_point_group():
     """Makes sure all the ints from 1 to 230 give answers."""
     for sg_number in np.arange(1, 231):
-        proper_pg = _get_point_group(sg_number, proper=True)
+        proper_pg = get_point_group(sg_number, proper=True)
         assert proper_pg in [C1, C2, C3, C4, C6, D2, D3, D4, D6, O, T]
 
         sg = GetSpaceGroup(sg_number)
-        pg = _get_point_group(sg_number, proper=False)
+        pg = get_point_group(sg_number, proper=False)
         assert proper_pg == spacegroup2pointgroup_dict[sg.point_group_name]["proper"]
         assert pg == spacegroup2pointgroup_dict[sg.point_group_name]["improper"]


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

* Remove underscore in `orix.quaternion.symmetry._get_point_group`, to signify the function is part of the public API.
* No other changes than the name change.