### PR TITLE
Replace PhaseList.__setitem__() with PhaseList.add() method

### DIFF
--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -586,30 +586,6 @@ class PhaseList:
         else:
             return PhaseList(d)
 
-    def __setitem__(self, key, value):
-        """Add a phase to the list with a name, point group and
-        structure.
-        """
-        if key not in self.names:
-            # Make sure the new phase gets a new color
-            color_new = None
-            for color_name in ALL_COLORS.keys():
-                if color_name not in self.colors:
-                    color_new = color_name
-                    break
-
-            # Create new ID
-            if self.ids:
-                new_phase_id = max(self.ids) + 1
-            else:  # `self.phase_ids` is an empty list
-                new_phase_id = 0
-
-            self._dict[new_phase_id] = Phase(
-                name=key, point_group=value, color=color_new
-            )
-        else:
-            raise ValueError(f"{key} is already in the phase list {self.names}.")
-
     def __delitem__(self, key):
         """Delete a phase from the phase list.
 
@@ -716,3 +692,56 @@ class PhaseList:
             if name == phase.name:
                 return phase_id
         raise KeyError(f"'{name}' is not among the phase names {self.names}.")
+
+    def add(self, value):
+        """Add phases to the end of a phase list, incrementing the phase
+        IDs.
+
+        Parameters
+        ----------
+        value : Phase, list of Phase or another PhaseList
+            Phase(s) to add. If a PhaseList is added, the phase IDs in the
+            old list are lost.
+
+        Examples
+        --------
+        >>> from orix.crystal_map import Phase, PhaseList
+        >>> pl = PhaseList(names=["a", "b"], space_groups=[10, 20])
+        >>> pl.add(Phase("c", space_group=30))
+        >>> pl.add([Phase("d", space_group=40), Phase("e")])
+        >>> pl.add(PhaseList(names=["f", "g"], space_groups=[60, 70]))
+        >>> pl
+        Id  Name  Space group  Point group  Proper point group       Color
+         0     a         P2/m          2/m                 112    tab:blue
+         1     b        C2221          222                 222  tab:orange
+         2     c         Pnc2          mm2                 211   tab:green
+         3     d         Ama2          mm2                 211     tab:red
+         4     e         None         None                None  tab:purple
+         5     f         Pbcn          mmm                 222   tab:brown
+         6     g         Fddd          mmm                 222    tab:pink
+        """
+        if isinstance(value, Phase):
+            value = [value]
+        if isinstance(value, PhaseList):
+            value = [i for _, i in value]
+        for phase in value:
+            if phase.name in self.names:
+                raise ValueError(
+                    f"'{phase.name}' is already in the phase list {self.names}"
+                )
+
+            # Ensure a new color
+            if phase.color in self.colors:
+                for color_name in ALL_COLORS.keys():
+                    if color_name not in self.colors:
+                        phase.color = color_name
+                        break
+
+            # Increment the highest phase ID
+            if self.ids:
+                new_phase_id = max(self.ids) + 1
+            else:  # `self.phase_ids` is an empty list
+                new_phase_id = 0
+
+            # Finally, add the phase to the list
+            self._dict[new_phase_id] = phase

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -346,14 +346,14 @@ class TestCrystalMapSetAttributes:
             with pytest.raises(IndexError, match="list index out of range"):
                 # `set_phase_id` ID is not in `self.phases.phase_ids`
                 cm[condition].phase_id = set_phase_id
-                _ = cm.__repr__()
+                _ = repr(cm)
 
-            # Add unknown ID to phase list to fix `self.__repr__()`
-            cm.phases["a"] = 432  # Add phase with ID 1
+            # Add unknown ID to phase list to fix `repr(self)`
+            cm.phases.add(Phase("a", point_group=432))  # Add phase with ID 1
         else:
             cm[condition].phase_id = set_phase_id
 
-        _ = cm.__repr__()
+        _ = repr(cm)
 
         new_phase_ids = phase_ids + [set_phase_id]
         new_phase_ids.sort()


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

Closes #109.

* Add `PhaseList.add()` method to add a `Phase`, list of `Phase` or another `PhaseList` to a `PhaseList`
* This method replaces the `PhaseList.__setitem__()`, which is removed
* Update relevant tests

Example use:
```python
>>> from orix.crystal_map import Phase, PhaseList
>>> pl = PhaseList(names=["a", "b"], space_groups=[10, 20])
>>> pl.add(Phase("c", space_group=30))
>>> pl.add([Phase("d", space_group=40), Phase("e")])
>>> pl.add(PhaseList(names=["f", "g"], space_groups=[60, 70]))
>>> pl
Id  Name  Space group  Point group  Proper point group       Color
 0     a         P2/m          2/m                 112    tab:blue
 1     b        C2221          222                 222  tab:orange
 2     c         Pnc2          mm2                 211   tab:green
 3     d         Ama2          mm2                 211     tab:red
 4     e         None         None                None  tab:purple
 5     f         Pbcn          mmm                 222   tab:brown
 6     g         Fddd          mmm                 222    tab:pink
```

By design, when a `PhaseList` is added to another `PhaseList`, the old `PhaseList` IDs are lost. I couldn't think of a time when you would want to keep the old IDs.

Decided on `add()` instead of `append()` because
* a `PhaseList.add_not_indexed()` method already existed
* I felt that with the `append()` method, and since the class has "list" in the name, people might think that other parts of the Python `list` API (which `append()` is a part of) was supported as well, which it is not.