### PR TITLE
Bugfix for get_sample_local()

### DIFF
--- a/orix/sampling/sample_generators.py
+++ b/orix/sampling/sample_generators.py
@@ -86,7 +86,8 @@ def get_sample_local(resolution=2, center=None, grid_width=10):
     q = uniform_SO3_sample(resolution)
     half_angle = (np.deg2rad(grid_width / 2))
     half_angles = np.arccos(q.a.data)
-    q = q[half_angles < half_angle]
+    mask = np.logical_or(half_angles<half_angle,half_angles>(2*np.pi-half_angle))
+    q = q[mask]
     if center is not None:
         q = center * q
     return q

--- a/orix/sampling/sample_generators.py
+++ b/orix/sampling/sample_generators.py
@@ -84,9 +84,11 @@ def get_sample_local(resolution=2, center=None, grid_width=10):
     """
 
     q = uniform_SO3_sample(resolution)
-    half_angle = (np.deg2rad(grid_width / 2))
+    half_angle = np.deg2rad(grid_width / 2)
     half_angles = np.arccos(q.a.data)
-    mask = np.logical_or(half_angles<half_angle,half_angles>(2*np.pi-half_angle))
+    mask = np.logical_or(
+        half_angles < half_angle, half_angles > (2 * np.pi - half_angle)
+    )
     q = q[mask]
     if center is not None:
         q = center * q

--- a/orix/sampling/sample_generators.py
+++ b/orix/sampling/sample_generators.py
@@ -84,8 +84,9 @@ def get_sample_local(resolution=2, center=None, grid_width=10):
     """
 
     q = uniform_SO3_sample(resolution)
-    grid_cosine = np.arccos(np.deg2rad(grid_width / 2))
-    q = q[q.a > grid_cosine]
+    half_angle = (np.deg2rad(grid_width / 2))
+    half_angles = np.arccos(q.a.data)
+    q = q[half_angles < half_angle]
     if center is not None:
         q = center * q
     return q

--- a/orix/tests/test_sampling.py
+++ b/orix/tests/test_sampling.py
@@ -55,17 +55,24 @@ def test_uniform_SO3_sample_resolution(sample):
     assert np.isclose(x, y, rtol=0.025)
 
 
-def test_get_sample_local_width(fr):
+@pytest.mark.parametrize("big,small",[(77,52),(48,37)])
+def test_get_sample_local_width(big,small):
     """ Checks that width follows the expected trend (X - Sin(X)) """
-    x = get_sample_local(resolution=np.pi,grid_width=15).size
-    y = get_sample_local(resolution=np.pi,grid_width=30).size
-    x_v = np.deg2rad(15) - np.sin(np.deg2rad(15))
-    y_v = np.deg2rad(30) - np.sin(np.deg2rad(30))
+    x = get_sample_local(resolution=np.pi,grid_width=small).size
+    y = get_sample_local(resolution=np.pi,grid_width=big).size
+    x_v = np.deg2rad(small) - np.sin(np.deg2rad(small))
+    y_v = np.deg2rad(big) - np.sin(np.deg2rad(big))
     exp = y/x
     theory = y_v/x_v
     assert x > 0
-    assert np.isclose(exp,theory, rtol=0.025)
+    # resolution/width is high, so we must be generous on tolerance
+    assert np.isclose(exp,theory, rtol=0.2)
 
+@pytest.mark.parametrize("width",[60,33])
+def test_get_sample_local_center(fr,width):
+    """ Checks that the center argument works as expected """
+    x = get_sample_local(resolution=8,center=fr,grid_width=width)
+    assert np.all((x.angle_with(fr) < np.deg2rad(width))).data
 
 @pytest.fixture(scope="session")
 def C6_sample():

--- a/orix/tests/test_sampling.py
+++ b/orix/tests/test_sampling.py
@@ -55,24 +55,26 @@ def test_uniform_SO3_sample_resolution(sample):
     assert np.isclose(x, y, rtol=0.025)
 
 
-@pytest.mark.parametrize("big,small",[(77,52),(48,37)])
-def test_get_sample_local_width(big,small):
+@pytest.mark.parametrize("big,small", [(77, 52), (48, 37)])
+def test_get_sample_local_width(big, small):
     """ Checks that width follows the expected trend (X - Sin(X)) """
-    x = get_sample_local(resolution=np.pi,grid_width=small).size
-    y = get_sample_local(resolution=np.pi,grid_width=big).size
+    x = get_sample_local(resolution=np.pi, grid_width=small).size
+    y = get_sample_local(resolution=np.pi, grid_width=big).size
     x_v = np.deg2rad(small) - np.sin(np.deg2rad(small))
     y_v = np.deg2rad(big) - np.sin(np.deg2rad(big))
-    exp = y/x
-    theory = y_v/x_v
+    exp = y / x
+    theory = y_v / x_v
     assert x > 0
     # resolution/width is high, so we must be generous on tolerance
-    assert np.isclose(exp,theory, rtol=0.2)
+    assert np.isclose(exp, theory, rtol=0.2)
 
-@pytest.mark.parametrize("width",[60,33])
-def test_get_sample_local_center(fr,width):
+
+@pytest.mark.parametrize("width", [60, 33])
+def test_get_sample_local_center(fr, width):
     """ Checks that the center argument works as expected """
-    x = get_sample_local(resolution=8,center=fr,grid_width=width)
+    x = get_sample_local(resolution=8, center=fr, grid_width=width)
     assert np.all((x.angle_with(fr) < np.deg2rad(width))).data
+
 
 @pytest.fixture(scope="session")
 def C6_sample():

--- a/orix/tests/test_sampling.py
+++ b/orix/tests/test_sampling.py
@@ -56,11 +56,15 @@ def test_uniform_SO3_sample_resolution(sample):
 
 
 def test_get_sample_local_width(fr):
-    """ Checks that doubling the width 8 folds the number of points """
-    x = get_sample_local(np.pi, fr, 15).size * 8
-    y = get_sample_local(np.pi, fr, 30).size
+    """ Checks that width follows the expected trend (X - Sin(X)) """
+    x = get_sample_local(resolution=np.pi,grid_width=15).size
+    y = get_sample_local(resolution=np.pi,grid_width=30).size
+    x_v = np.deg2rad(15) - np.sin(np.deg2rad(15))
+    y_v = np.deg2rad(30) - np.sin(np.deg2rad(30))
+    exp = y/x
+    theory = y_v/x_v
     assert x > 0
-    assert np.isclose(x, y, rtol=0.025)
+    assert np.isclose(exp,theory, rtol=0.025)
 
 
 @pytest.fixture(scope="session")

--- a/orix/tests/test_sampling.py
+++ b/orix/tests/test_sampling.py
@@ -58,13 +58,21 @@ def test_uniform_SO3_sample_resolution(sample):
 @pytest.mark.parametrize("big,small", [(77, 52), (48, 37)])
 def test_get_sample_local_width(big, small):
     """ Checks that width follows the expected trend (X - Sin(X)) """
-    x = get_sample_local(resolution=np.pi, grid_width=small).size
-    y = get_sample_local(resolution=np.pi, grid_width=big).size
+    resolution = np.pi
+
+    z = get_sample_local(resolution=resolution, grid_width=small)
+
+    assert np.all(z.angle_with(Rotation([1,0,0,0])) < np.deg2rad(small))
+    assert np.any(z.angle_with(Rotation([1,0,0,0])) > np.deg2rad(small - 1.5*resolution))
+
+    x_size = z.size
+    assert x_size > 0
+    y_size = get_sample_local(resolution=np.pi, grid_width=big).size
     x_v = np.deg2rad(small) - np.sin(np.deg2rad(small))
     y_v = np.deg2rad(big) - np.sin(np.deg2rad(big))
-    exp = y / x
+    exp = y_size / x_size
     theory = y_v / x_v
-    assert x > 0
+
     # resolution/width is high, so we must be generous on tolerance
     assert np.isclose(exp, theory, rtol=0.2)
 
@@ -72,8 +80,11 @@ def test_get_sample_local_width(big, small):
 @pytest.mark.parametrize("width", [60, 33])
 def test_get_sample_local_center(fr, width):
     """ Checks that the center argument works as expected """
-    x = get_sample_local(resolution=8, center=fr, grid_width=width)
-    assert np.all((x.angle_with(fr) < np.deg2rad(width))).data
+    resolution=8
+    x = get_sample_local(resolution=resolution, center=fr, grid_width=width)
+    assert np.all((x.angle_with(fr) < np.deg2rad(width)))
+    # makes sure some of our rotations are inner the outer region
+    assert np.any(x.angle_with(fr) > np.deg2rad(width - resolution*1.5))
 
 
 @pytest.fixture(scope="session")

--- a/orix/tests/test_sampling.py
+++ b/orix/tests/test_sampling.py
@@ -59,6 +59,7 @@ def test_get_sample_local_width(fr):
     """ Checks that doubling the width 8 folds the number of points """
     x = get_sample_local(np.pi, fr, 15).size * 8
     y = get_sample_local(np.pi, fr, 30).size
+    assert x > 0
     assert np.isclose(x, y, rtol=0.025)
 
 


### PR DESCRIPTION
This code was incorrect, and was only able to pass testing as it return a size 0 grid in all cases. This PR corrects that bug and shores up the testing. 

This bit of the API is now tested by two tests which:
(1) ~ Make sure the "width" argument scales as theory suggests. Making a grid twice as wide leads to a non-linear expansion (although for small widths this is very close to 2^3 = 8)

(2) ~ Make sure some obvious rotation are out (by size) and in (near the far end, but in) 

(3) Makes sure the center argument obeys as expected. If width=x and the center is z, you expect all outputs to be within x of the rotation z. 