### PR TITLE
Improve speed of uniform_SO3_sample by avoiding lists

### DIFF
--- a/orix/sampling/sampling_utils.py
+++ b/orix/sampling/sampling_utils.py
@@ -20,7 +20,6 @@
 the grid generation within rotation space """
 
 import numpy as np
-from itertools import product
 
 from orix.quaternion.rotation import Rotation
 
@@ -48,7 +47,7 @@ def uniform_SO3_sample(resolution):
     alpha = np.linspace(0, 2 * np.pi, num=num_steps, endpoint=False)
     beta = np.arccos(np.linspace(1, -1, num=half_steps, endpoint=False))
     gamma = np.linspace(0, 2 * np.pi, num=num_steps, endpoint=False)
-    q = np.asarray(list(product(alpha, beta, gamma)))
+    q = np.array(np.meshgrid(alpha, beta, gamma)).T.reshape((-1, 3))
 
     # convert to quaternions
     q = Rotation.from_euler(q, convention="bunge", direction="crystal2lab")

--- a/orix/tests/test_sampling.py
+++ b/orix/tests/test_sampling.py
@@ -62,8 +62,10 @@ def test_get_sample_local_width(big, small):
 
     z = get_sample_local(resolution=resolution, grid_width=small)
 
-    assert np.all(z.angle_with(Rotation([1,0,0,0])) < np.deg2rad(small))
-    assert np.any(z.angle_with(Rotation([1,0,0,0])) > np.deg2rad(small - 1.5*resolution))
+    assert np.all(z.angle_with(Rotation([1, 0, 0, 0])) < np.deg2rad(small))
+    assert np.any(
+        z.angle_with(Rotation([1, 0, 0, 0])) > np.deg2rad(small - 1.5 * resolution)
+    )
 
     x_size = z.size
     assert x_size > 0
@@ -80,11 +82,11 @@ def test_get_sample_local_width(big, small):
 @pytest.mark.parametrize("width", [60, 33])
 def test_get_sample_local_center(fr, width):
     """ Checks that the center argument works as expected """
-    resolution=8
+    resolution = 8
     x = get_sample_local(resolution=resolution, center=fr, grid_width=width)
     assert np.all((x.angle_with(fr) < np.deg2rad(width)))
     # makes sure some of our rotations are inner the outer region
-    assert np.any(x.angle_with(fr) > np.deg2rad(width - resolution*1.5))
+    assert np.any(x.angle_with(fr) > np.deg2rad(width - resolution * 1.5))
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

* One-line improvement of `orix.sampling.sampling_utils.uniform_SO3_sample()` by using `numpy.meshgrid` instead of `list(product())`. The change resulted in, locally, that tests in `test_sampling.py` ran for 18.56 s instead of 25.21 s. The order of the elements in the old and new `q` are different, but I checked that they returned the same results by `np.allclose(np.sort(q_old, axis=0), np.sqrt(q_new, axis=0)) is True` -> `True`. No tests were changed, and all passed locally. 
* Ran black formatting before commiting, so some test lines got formatted.