### PR TITLE
Enable setting of ND properties in CrystalMapProperties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This project now keeps a Changelog
 
 ### Fixed
-- CrystalMap properties allows > 2D arrays
+- CrystalMap properties allow arrays with number of dimensions greater than 2
 - ANG file reader now recognises phase IDs defined in the header

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - This project now keeps a Changelog
+
+### Fixed
+- CrystalMap.prop (CrystalMapProperties) allows setting of ND arrays when
+  the first axis' length equals the number of map points.

--- a/orix/crystal_map/crystal_map_properties.py
+++ b/orix/crystal_map/crystal_map_properties.py
@@ -33,7 +33,6 @@ class CrystalMapProperties(dict):
     is_in_data : numpy.ndarray
         1D boolean array with True for points in the data, of the same size
         as the data.
-
     """
 
     def __init__(self, dictionary, id, is_in_data=None):
@@ -51,7 +50,6 @@ class CrystalMapProperties(dict):
             1D boolean array with True for points in the data. If ``None``
             is passed (default), all points are considered to be in the
             data.
-
         """
         super().__init__(**dictionary)
         self.id = id
@@ -64,25 +62,28 @@ class CrystalMapProperties(dict):
         """Add a 1D array to or update an existing array in the
         dictionary. If `key` is the name of an existing array, only the
         points in the data (where `self.is_in_data` is True) are set.
-
         """
-        # Get array values if `key` already present, or zeros
-        array = self.setdefault(key, np.zeros(self.is_in_data.size))
-
-        # Determine array data type from input
-        if hasattr(value, "__iter__"):
-            value_type = type(value[0])
+        # Set array shape
+        value = np.asarray(value)
+        ndim = value.ndim
+        if ndim > 1:
+            # Assume length of first axis equals self.is_in_data.size
+            array_shape = value.shape
         else:
-            value_type = type(value)
-        array = array.astype(value_type)
+            array_shape = (self.is_in_data.size,)
 
-        array[self.is_in_data] = value
+        # Get array values if `key` already present, or zeros
+        array = self.setdefault(key, np.zeros(array_shape))
+
+        # Set correct data type
+        array = array.astype(value.dtype)
+
+        array[self.is_in_data, ...] = value
         super().__setitem__(key, array)
 
     def __getitem__(self, item):
         """Return a dictionary entry, ensuring that only points in the data
         are returned.
-
         """
         array = super().__getitem__(item)
         return array[self.is_in_data]

--- a/orix/crystal_map/crystal_map_properties.py
+++ b/orix/crystal_map/crystal_map_properties.py
@@ -59,9 +59,14 @@ class CrystalMapProperties(dict):
             self.is_in_data = is_in_data
 
     def __setitem__(self, key, value):
-        """Add a 1D array to or update an existing array in the
-        dictionary. If `key` is the name of an existing array, only the
-        points in the data (where `self.is_in_data` is True) are set.
+        """Add an array to or update an existing array in the
+        dictionary.
+
+        If `key` is the name of an existing array, only the points in the
+        data (where `self.is_in_data` is True) are set.
+
+        If a 2D array is added, its first axis must have the same length
+        as `self.id`.
         """
         # Set array shape
         value = np.asarray(value)

--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -54,7 +54,7 @@ class CrystalMapPlot(Axes):
         depth=None,
         **kwargs,
     ) -> AxesImage:
-        """Plot a 2D map with any CrystalMap attribute as map values.
+        r"""Plot a 2D map with any CrystalMap attribute as map values.
 
         Wraps :meth:`matplotlib.axes.Axes.imshow`, see that method for
         relevant keyword arguments.
@@ -128,7 +128,8 @@ class CrystalMapPlot(Axes):
 
         >>> ax = plt.subplot(projection="plot_map")
         >>> ax.plot_map(
-        ...     cm, cm.dp, cmap="cividis", scalebar_properties={"loc": 4})
+        ...     cm, cm.dp, cmap="cividis", scalebar_properties={"loc": 4}
+        ... )
 
         Add a colorbar
 
@@ -153,7 +154,7 @@ class CrystalMapPlot(Axes):
         ...     "/some/directory/image.png",
         ...     pad_inches=0,
         ...     bbox_inches="tight"
-        ...)
+        ... )
 
         Write un-annotated image to file
 

--- a/orix/tests/io/test_orix_plugin.py
+++ b/orix/tests/io/test_orix_plugin.py
@@ -243,3 +243,29 @@ class TestOrixHDF5Plugin:
         assert np.allclose(
             crystal_map.phases[0].point_group.data, cm2.phases[0].point_group.data
         )
+
+    def test_write_read_nd_crystalmap_properties(self, temp_file_path, crystal_map):
+        """Crystal map properties with more than one value in each point
+        (e.g. top matching scores from dictionary indexing) can be written
+        and read from file correctly.
+        """
+        xmap = crystal_map
+        map_size = xmap.size
+
+        prop2d_name = "prop2d"
+        prop2d_shape = (map_size, 2)
+        prop2d = np.arange(map_size * 2).reshape(prop2d_shape)
+        xmap.prop[prop2d_name] = prop2d
+
+        prop3d_name = "prop3d"
+        prop3d_shape = (map_size, 2, 2)
+        prop3d = np.arange(map_size * 4).reshape(prop3d_shape)
+        xmap.prop[prop3d_name] = prop3d
+
+        save(filename=temp_file_path, object2write=xmap)
+        xmap2 = load(temp_file_path)
+
+        assert np.allclose(xmap2.prop[prop2d_name], xmap.prop[prop2d_name])
+        assert np.allclose(xmap2.prop[prop3d_name], xmap.prop[prop3d_name])
+        assert np.allclose(xmap2.prop[prop2d_name].reshape(prop2d_shape), prop2d)
+        assert np.allclose(xmap2.prop[prop3d_name].reshape(prop3d_shape), prop3d)

--- a/orix/tests/test_crystal_map_properties.py
+++ b/orix/tests/test_crystal_map_properties.py
@@ -67,17 +67,25 @@ class TestCrystalMapProperties:
         props = CrystalMapProperties(d, id=np.arange(map_size))
 
         # 2D
-        prop_2d = np.random.random(20).reshape((10, 2))
+        prop_2d = np.arange(map_size * 2).reshape((10, 2))
         props["prop_2d"] = prop_2d
         assert np.allclose(props["prop_2d"], prop_2d)
 
         # 3D
-        prop_3d = np.random.random(40).reshape((10, 2, 2))
+        prop_3d = np.arange(map_size * 4).reshape((10, 2, 2))
         props["prop_3d"] = prop_3d
         assert np.allclose(props["prop_3d"], prop_3d)
 
         with pytest.raises(IndexError, match="boolean index did not match indexed"):
             props["prop_3d_wrong"] = np.random.random(40).reshape((2, 10, 2))
+
+        # Update 2D array, accounting for in data values
+        is_in_data = np.ones(map_size, dtype=bool)
+        is_in_data[5] = False
+        props.is_in_data = is_in_data
+        new_prop_2d = np.arange(map_size * 2).reshape((map_size, 2))
+        props["prop_2d"] = new_prop_2d[is_in_data]
+        np.allclose(props["prop_2d"], new_prop_2d[is_in_data])
 
     def test_set_item_error(self):
         map_size = 10

--- a/orix/tests/test_crystal_map_properties.py
+++ b/orix/tests/test_crystal_map_properties.py
@@ -55,11 +55,29 @@ class TestCrystalMapProperties:
         expected_array = np.array([1, 2, 3, 4, 5, 5, 6, 7, 8, 9])
         assert np.allclose(props.get("iq"), expected_array)
 
-        # Set array with one value
+        # Set array with one value (broadcasting works)
         props["iq"] = 2
         expected_array2 = np.ones(map_size) * 2
         expected_array2[5] = expected_array[5]
         assert np.allclose(props.get("iq"), expected_array2)
+
+    def test_set_item_nd(self):
+        map_size = 10
+        d = {"iq": np.arange(map_size)}
+        props = CrystalMapProperties(d, id=np.arange(map_size))
+
+        # 2D
+        prop_2d = np.random.random(20).reshape((10, 2))
+        props["prop_2d"] = prop_2d
+        assert np.allclose(props["prop_2d"], prop_2d)
+
+        # 3D
+        prop_3d = np.random.random(40).reshape((10, 2, 2))
+        props["prop_3d"] = prop_3d
+        assert np.allclose(props["prop_3d"], prop_3d)
+
+        with pytest.raises(IndexError, match="boolean index did not match indexed"):
+            props["prop_3d_wrong"] = np.random.random(40).reshape((2, 10, 2))
 
     def test_set_item_error(self):
         map_size = 10
@@ -71,11 +89,11 @@ class TestCrystalMapProperties:
         props = CrystalMapProperties(d, id=np.arange(map_size), is_in_data=is_in_data)
 
         # Set array with an array
-        with pytest.raises(ValueError, match="NumPy boolean array indexing assignment"):
+        with pytest.raises(ValueError, match="shape mismatch: value array of shape"):
             props["iq"] = np.arange(map_size) + 1
 
         # Set new 2D array
         props.is_in_data[id_to_change] = True
-        with pytest.raises(TypeError, match="NumPy boolean array indexing assignment"):
+        with pytest.raises(IndexError, match="boolean index did not match indexed"):
             new_shape = (10 // 2, 10 // 5)
             props["dp"] = np.arange(map_size).reshape(new_shape)

--- a/orix/tests/test_io.py
+++ b/orix/tests/test_io.py
@@ -960,3 +960,29 @@ class TestOrixHDF5Plugin:
         assert np.allclose(
             crystal_map.phases[0].point_group.data, cm2.phases[0].point_group.data
         )
+
+    def test_write_read_nd_crystalmap_properties(self, temp_file_path, crystal_map):
+        """Crystal map properties with more than one value in each point (e.g. top
+        matching scores from dictionary indexing) can be written and read from file
+        correctly.
+        """
+        xmap = crystal_map
+        map_size = xmap.size
+
+        prop2d_name = "prop2d"
+        prop2d_shape = (map_size, 2)
+        prop2d = np.arange(map_size * 2).reshape(prop2d_shape)
+        xmap.prop[prop2d_name] = prop2d
+
+        prop3d_name = "prop3d"
+        prop3d_shape = (map_size, 2, 2)
+        prop3d = np.arange(map_size * 4).reshape(prop3d_shape)
+        xmap.prop[prop3d_name] = prop3d
+
+        save(filename=temp_file_path, object2write=xmap)
+        xmap2 = load(temp_file_path)
+
+        assert np.allclose(xmap2.prop[prop2d_name], xmap.prop[prop2d_name])
+        assert np.allclose(xmap2.prop[prop3d_name], xmap.prop[prop3d_name])
+        assert np.allclose(xmap2.prop[prop2d_name].reshape(prop2d_shape), prop2d)
+        assert np.allclose(xmap2.prop[prop3d_name].reshape(prop3d_shape), prop3d)


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

Todo:
- [x] Ensure these ND arrays are written to the orix HDF5 file correctly (add tests for this)

With this small change in `CrystalMapProperties` we can now add properties with more than one value in each map point, enabling e.g. to store multiple best matching indices from a list of simulated patterns.

Tests are added.

(Note that even if a map is 2D [which it usually is], properties are always stored as 1D arrays.)

```python
>>> import numpy as np
>>> from orix.crystal_map.crystal_map_properties import CrystalMapProperties
>>> map_size = 10
>>> d = {"prop_1d": np.arange(map_size)}  # 1D
>>> props = CrystalMapProperties(d, id=np.arange(map_size))
>>> props
{'prop_1d': array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])}
>>> props["prop_2d"] np.arange(map_size * 2).reshape((map_size, 2))
>>> props
{'prop_1d': array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
 'prop_2d': array([[ 0,  1],
        [ 2,  3],
        [ 4,  5],
        [ 6,  7],
        [ 8,  9],
        [10, 11],
        [12, 13],
        [14, 15],
        [16, 17],
        [18, 19]])}
>>> props["prop_2d_wrong_shape"] = np.arange(map_size * 2).reshape((2, map_size))
Traceback (most recent call last):
  File "/home/hakon/miniconda3/envs/orix-dev/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3417, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-10-ec06fc2f2380>", line 1, in <module>
    props["prop_2d_wrong"] = np.arange(map_size * 2).reshape((2, map_size))
  File "/home/hakon/kode/orix/orix/crystal_map/crystal_map_properties.py", line 81, in __setitem__
    array[self.is_in_data, ...] = value
IndexError: boolean index did not match indexed array along dimension 0; dimension is 2 but corresponding boolean dimension is 10
```

The first axis of the new array must have the same length as the map size (I've added this explanation to the `CrystalMapProperties.__setitem__()` docstring).

@onatlandsmyr: could you pull this branch of orix into your kikuchipy dev environment and see that it works as expected? After you've done that, I'll remove the WIP label and this can be reviewed and merged.

Although I initially set CrystalMapProperties up to only allow 1D arrays, I consider this a bug since it obviously should allow for ND arrays. I hope this can be part of a patch release, since we need this in kikuchipy for v0.3.