### PR TITLE
Ensure correct phase ID from ANG reader, update point group aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# Visual Studio Code
+*.code-workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This project now keeps a Changelog
 
 ### Fixed
-- Phase IDs found in the ANG file header are used when returning av CrystalMap from this
-  file format.
+- ANG file reader now recognises phase IDs defined in the header

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - This project now keeps a Changelog
+
+### Fixed
+- Phase IDs found in the ANG file header are used when returning av CrystalMap from this
+  file format.

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -26,22 +26,18 @@ from diffpy.structure.spacegroups import GetSpaceGroup, SpaceGroup
 import matplotlib.colors as mcolors
 import numpy as np
 
-from orix.quaternion.symmetry import _groups, get_point_group, Symmetry
+from orix.quaternion.symmetry import (
+    _groups,
+    get_point_group,
+    Symmetry,
+    POINT_GROUP_ALIASES,
+)
 
 # All named Matplotlib colors (tableau and xkcd already lower case hex)
 ALL_COLORS = mcolors.TABLEAU_COLORS
 for k, v in {**mcolors.BASE_COLORS, **mcolors.CSS4_COLORS}.items():
     ALL_COLORS[k] = mcolors.to_hex(v)
 ALL_COLORS.update(mcolors.XKCD_COLORS)
-
-# Point group alias mapping
-# Why is this needed? Well, e.g. in EDAX TSL OIM Analysis 7.2, point
-# group 432 is entered as 43...
-POINT_GROUP_ALIASES = {
-    "432": "43",
-    "121": "20",
-    "222": "22",
-}
 
 
 class Phase:
@@ -180,8 +176,8 @@ class Phase:
         if isinstance(value, int):
             value = str(value)
         if isinstance(value, str):
-            for correct, alias in POINT_GROUP_ALIASES.items():
-                if value == alias:
+            for correct, aliases in POINT_GROUP_ALIASES.items():
+                if value in aliases:
                     value = correct
                     break
             for point_group in _groups:

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -39,6 +39,8 @@ ALL_COLORS.update(mcolors.XKCD_COLORS)
 # group 432 is entered as 43...
 POINT_GROUP_ALIASES = {
     "432": "43",
+    "121": "20",
+    "222": "22",
 }
 
 

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -30,7 +30,7 @@ from orix.quaternion.symmetry import (
     _groups,
     get_point_group,
     Symmetry,
-    POINT_GROUP_ALIASES,
+    point_group_aliases,
 )
 
 # All named Matplotlib colors (tableau and xkcd already lower case hex)
@@ -176,7 +176,7 @@ class Phase:
         if isinstance(value, int):
             value = str(value)
         if isinstance(value, str):
-            for correct, aliases in POINT_GROUP_ALIASES.items():
+            for correct, aliases in point_group_aliases.items():
                 if value in aliases:
                     value = correct
                     break

--- a/orix/io/plugins/ang.py
+++ b/orix/io/plugins/ang.py
@@ -96,7 +96,6 @@ def file_reader(filename):
             data_dict["prop"][name] = file_data[:, column]
 
     # Add phase list to dictionary
-    # unique_phase_ids = np.unique(data_dict["phase_id"]).astype(int)
     data_dict["phase_list"] = PhaseList(
         names=phase_names,
         point_groups=symmetries,

--- a/orix/quaternion/symmetry.py
+++ b/orix/quaternion/symmetry.py
@@ -496,7 +496,9 @@ def get_point_group(space_group_number, proper=False):
         return spacegroup2pointgroup_dict[pgn]["improper"]
 
 
-# Point group alias mapping
+# Point group alias mapping. This is needed because in EDAX TSL OIM
+# Analysis 7.2, e.g. point group 432 is entered as 43.
+# Used when reading a phase's point group from an EDAX ANG file header
 POINT_GROUP_ALIASES = {
     "432": ["43",],
     "121": ["20",],

--- a/orix/quaternion/symmetry.py
+++ b/orix/quaternion/symmetry.py
@@ -494,3 +494,11 @@ def get_point_group(space_group_number, proper=False):
         return spacegroup2pointgroup_dict[pgn]["proper"]
     else:
         return spacegroup2pointgroup_dict[pgn]["improper"]
+
+
+# Point group alias mapping
+POINT_GROUP_ALIASES = {
+    "432": ["43",],
+    "121": ["20",],
+    "222": ["22",],
+}

--- a/orix/quaternion/symmetry.py
+++ b/orix/quaternion/symmetry.py
@@ -499,7 +499,7 @@ def get_point_group(space_group_number, proper=False):
 # Point group alias mapping. This is needed because in EDAX TSL OIM
 # Analysis 7.2, e.g. point group 432 is entered as 43.
 # Used when reading a phase's point group from an EDAX ANG file header
-POINT_GROUP_ALIASES = {
+point_group_aliases = {
     "432": ["43",],
     "121": ["20",],
     "222": ["22",],

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -53,14 +53,14 @@ ANGFILE_TSL_HEADER = (
     "# hklFamilies        1 -1 -1 1 8.469246 1\n"
     "# ElasticConstants  -1.000000 -1.000000 -1.000000 -1.000000 -1.000000 -1.000000\n"
     "# Categories0 0 0 0 0 \n"
-    "# Phase 1\n"
-    "# MaterialName      Diopside\n"
-    "# Formula       Ca(FeMg)Si2O6\n"
-    "# Info      \n"
-    "# Symmetry              20\n"
-    "# LatticeConstants      9.585 8.776 5.260  90.000 106.850  90.000\n"
-    "# NumberFamilies        41\n"
-    "# hklFamilies       -2  2  1 1 100.000000 1\n"
+    "# Phase 3\n"
+    "# MaterialName  	Iron Titanium Oxide\n"
+    "# Formula     	FeTiO3\n"
+    "# Info 		\n"
+    "# Symmetry              32\n"
+    "# LatticeConstants      5.123 5.123 13.760  90.000  90.000 120.000\n"
+    "# NumberFamilies        60\n"
+    "# hklFamilies   	 3  0  0 1 100.000000 1\n"
     "# ElasticConstants  -1.000000 -1.000000 -1.000000 -1.000000 -1.000000 -1.000000\n"
     "# Categories0 0 0 0 0\n"
     "#\n"
@@ -161,7 +161,7 @@ def temp_file_path(request):
         (
             (7, 13),  # map_shape
             (0.1, 0.1),  # step_sizes
-            np.random.choice([1, 2], 7 * 13),  # phase_id
+            np.random.choice([2, 3], 7 * 13),  # phase_id
             5,  # Number of unknown columns (one between ci and fit, the rest after fit)
             np.array(
                 [[4.48549, 0.95242, 0.79150], [1.34390, 0.27611, 0.82589],]

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -43,7 +43,7 @@ ANGFILE_TSL_HEADER = (
     "# z-star                0.514900\n"
     "# WorkingDistance       27.100000\n"
     "#\n"
-    "# Phase 1\n"
+    "# Phase 2\n"
     "# MaterialName      Aluminum\n"
     "# Formula       Al\n"
     "# Info      \n"
@@ -53,6 +53,16 @@ ANGFILE_TSL_HEADER = (
     "# hklFamilies        1 -1 -1 1 8.469246 1\n"
     "# ElasticConstants  -1.000000 -1.000000 -1.000000 -1.000000 -1.000000 -1.000000\n"
     "# Categories0 0 0 0 0 \n"
+    "# Phase 1\n"
+    "# MaterialName      Diopside\n"
+    "# Formula       Ca(FeMg)Si2O6\n"
+    "# Info      \n"
+    "# Symmetry              20\n"
+    "# LatticeConstants      9.585 8.776 5.260  90.000 106.850  90.000\n"
+    "# NumberFamilies        41\n"
+    "# hklFamilies       -2  2  1 1 100.000000 1\n"
+    "# ElasticConstants  -1.000000 -1.000000 -1.000000 -1.000000 -1.000000 -1.000000\n"
+    "# Categories0 0 0 0 0\n"
     "#\n"
     "# GRID: SqrGrid\n"
     "# XSTEP: 0.100000\n"
@@ -151,7 +161,7 @@ def temp_file_path(request):
         (
             (7, 13),  # map_shape
             (0.1, 0.1),  # step_sizes
-            np.random.choice([0], 7 * 13),  # phase_id
+            np.random.choice([1, 2], 7 * 13),  # phase_id
             5,  # Number of unknown columns (one between ci and fit, the rest after fit)
             np.array(
                 [[4.48549, 0.95242, 0.79150], [1.34390, 0.27611, 0.82589],]

--- a/orix/tests/io/__init__.py
+++ b/orix/tests/io/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 the orix developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.

--- a/orix/tests/io/test_ang_plugin.py
+++ b/orix/tests/io/test_ang_plugin.py
@@ -16,9 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-from contextlib import contextmanager
-import sys
-
 import pytest
 import numpy as np
 
@@ -34,14 +31,6 @@ from orix.tests.conftest import (
     ANGFILE_ASTAR_HEADER,
     ANGFILE_EMSOFT_HEADER,
 )
-
-
-@contextmanager
-def replace_stdin(target):
-    orig = sys.stdin
-    sys.stdin = target
-    yield
-    sys.stdin = orig
 
 
 @pytest.mark.parametrize(
@@ -464,11 +453,12 @@ class TestAngPlugin:
 
     @pytest.mark.parametrize(
         "header_phase_part, expected_names, expected_point_groups, "
-        "expected_lattice_constants",
+        "expected_lattice_constants, expected_phase_id",
         [
             (
                 [
                     [
+                        "# Phase 42",
                         "# MaterialName      Nickel",
                         "# Formula",
                         "# Symmetry          43",
@@ -486,6 +476,7 @@ class TestAngPlugin:
                 ["Nickel", "Aluminium"],
                 ["43", "m3m"],
                 [[3.52, 3.52, 3.52, 90, 90, 90], [3.52, 3.52, 3.52, 90, 90, 90]],
+                [42, 43],
             ),
         ],
     )
@@ -495,6 +486,7 @@ class TestAngPlugin:
         expected_names,
         expected_point_groups,
         expected_lattice_constants,
+        expected_phase_id,
     ):
         # Create header from parts
         header = [
@@ -516,8 +508,9 @@ class TestAngPlugin:
             "#",
             "# GRID: SqrGrid#",
         ]
-        names, point_groups, lattice_constants = _get_phases_from_header(header)
+        ids, names, point_groups, lattice_constants = _get_phases_from_header(header)
 
         assert names == expected_names
         assert point_groups == expected_point_groups
         assert np.allclose(lattice_constants, expected_lattice_constants)
+        assert np.allclose(ids, expected_phase_id)

--- a/orix/tests/io/test_emsoft_plugin.py
+++ b/orix/tests/io/test_emsoft_plugin.py
@@ -16,22 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-from contextlib import contextmanager
-import sys
-
 from diffpy.structure import Lattice, Structure
 import pytest
 import numpy as np
 
 from orix.io import load
-
-
-@contextmanager
-def replace_stdin(target):
-    orig = sys.stdin
-    sys.stdin = target
-    yield
-    sys.stdin = orig
 
 
 class TestEMsoftPlugin:

--- a/orix/tests/io/test_emsoft_plugin.py
+++ b/orix/tests/io/test_emsoft_plugin.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 the orix developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+from contextlib import contextmanager
+import sys
+
+from diffpy.structure import Lattice, Structure
+import pytest
+import numpy as np
+
+from orix.io import load
+
+
+@contextmanager
+def replace_stdin(target):
+    orig = sys.stdin
+    sys.stdin = target
+    yield
+    sys.stdin = orig
+
+
+class TestEMsoftPlugin:
+    @pytest.mark.parametrize(
+        (
+            "temp_emsoft_h5ebsd_file, map_shape, step_sizes, example_rot, "
+            "n_top_matches, refined"
+        ),
+        [
+            (
+                (
+                    (7, 3),  # map_shape
+                    (1.5, 1.5),  # step_sizes
+                    np.array(
+                        [
+                            [6.148271, 0.792205, 1.324879],
+                            [6.155951, 0.793078, 1.325229],
+                        ]
+                    ),  # rotations as rows of Euler angle triplets
+                    50,  # n_top_matches
+                    True,  # refined
+                ),
+                (7, 3),
+                (1.5, 1.5),
+                np.array(
+                    [[6.148271, 0.792205, 1.324879], [6.155951, 0.793078, 1.325229],]
+                ),
+                50,
+                True,
+            ),
+            (
+                (
+                    (5, 17),
+                    (0.5, 0.5),
+                    np.array(
+                        [
+                            [6.148271, 0.792205, 1.324879],
+                            [6.155951, 0.793078, 1.325229],
+                        ]
+                    ),
+                    20,
+                    False,
+                ),
+                (5, 17),
+                (0.5, 0.5),
+                np.array(
+                    [[6.148271, 0.792205, 1.324879], [6.155951, 0.793078, 1.325229],]
+                ),
+                20,
+                False,
+            ),
+        ],
+        indirect=["temp_emsoft_h5ebsd_file"],
+    )
+    def test_load_emsoft(
+        self,
+        temp_emsoft_h5ebsd_file,
+        map_shape,
+        step_sizes,
+        example_rot,
+        n_top_matches,
+        refined,
+    ):
+        cm = load(temp_emsoft_h5ebsd_file.filename, refined=refined)
+
+        assert cm.shape == map_shape
+        assert (cm.dy, cm.dx) == step_sizes
+        if refined:
+            n_top_matches = 1
+        assert cm.rotations_per_point == n_top_matches
+
+        # Properties
+        expected_props = [
+            "AvDotProductMap",
+            "CI",
+            "CIMap",
+            "IQ",
+            "IQMap",
+            "ISM",
+            "ISMap",
+            "KAM",
+            "OSM",
+            "TopDotProductList",
+            "TopMatchIndices",
+        ]
+        if refined:
+            expected_props += ["RefinedDotProducts"]
+        actual_props = list(cm.prop.keys())
+        actual_props.sort()
+        expected_props.sort()
+        assert actual_props == expected_props
+
+        assert cm.phases["austenite"].structure == Structure(
+            title="austenite",
+            lattice=Lattice(a=3.595, b=3.595, c=3.595, alpha=90, beta=90, gamma=90),
+        )

--- a/orix/tests/io/test_io.py
+++ b/orix/tests/io/test_io.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 the orix developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+from contextlib import contextmanager
+from collections import OrderedDict
+from io import StringIO
+from numbers import Number
+import os
+import sys
+
+from diffpy.structure import Structure
+from h5py import File
+import pytest
+import numpy as np
+
+from orix.crystal_map import Phase, PhaseList
+from orix.io import (
+    load,
+    save,
+    loadctf,
+    _plugin_from_footprints,
+    _overwrite_or_not,
+)
+from orix.io.plugins import ang, emsoft_h5ebsd, orix_hdf5
+from orix.quaternion.rotation import Rotation
+
+plugin_list = [ang, emsoft_h5ebsd, orix_hdf5]
+
+
+@contextmanager
+def replace_stdin(target):
+    orig = sys.stdin
+    sys.stdin = target
+    yield
+    sys.stdin = orig
+
+
+def assert_dictionaries_are_equal(input_dict, output_dict):
+    for key in output_dict.keys():
+        output_value = output_dict[key]
+        input_value = input_dict[key]
+        if isinstance(output_value, (dict, OrderedDict)):
+            assert_dictionaries_are_equal(input_value, output_value)
+        else:
+            if isinstance(output_value, (np.ndarray, Number)):
+                assert np.allclose(input_value, output_value)
+            elif isinstance(output_value, Rotation):
+                assert np.allclose(input_value.to_euler(), output_value.to_euler())
+            elif isinstance(output_value, Phase):
+                assert_dictionaries_are_equal(
+                    input_value.__dict__, output_value.__dict__
+                )
+            elif isinstance(output_value, PhaseList):
+                assert_dictionaries_are_equal(input_value._dict, output_value._dict)
+            elif isinstance(output_value, Structure):
+                assert np.allclose(output_value.xyz, input_value.xyz)
+                assert str(output_value.element) == str(input_value.element)
+                assert np.allclose(output_value.occupancy, input_value.occupancy)
+            else:
+                assert input_value == output_value
+
+
+class TestGeneralIO:
+    def test_load_no_filename_match(self):
+        fname = "what_is_hip.ang"
+        with pytest.raises(IOError, match=f"No filename matches '{fname}'."):
+            _ = load(fname)
+
+    @pytest.mark.parametrize("temp_file_path", ["ctf"], indirect=["temp_file_path"])
+    def test_load_unsupported_format(self, temp_file_path):
+        np.savetxt(temp_file_path, X=np.random.rand(100, 8))
+        with pytest.raises(IOError, match=f"Could not read "):
+            _ = load(temp_file_path)
+
+    @pytest.mark.parametrize(
+        "top_group, expected_plugin",
+        [("Scan 1", emsoft_h5ebsd), ("crystal_map", orix_hdf5), ("Scan 2", None)],
+    )
+    def test_plugin_from_footprints(self, temp_file_path, top_group, expected_plugin):
+        with File(temp_file_path, mode="w") as f:
+            f.create_group(top_group)
+            assert (
+                _plugin_from_footprints(
+                    temp_file_path, plugins=[emsoft_h5ebsd, orix_hdf5]
+                )
+                is expected_plugin
+            )
+
+    def test_overwrite_or_not(self, crystal_map, temp_file_path):
+        save(temp_file_path, crystal_map)
+        with pytest.warns(UserWarning, match="Not overwriting, since your terminal "):
+            _overwrite_or_not(temp_file_path)
+
+    @pytest.mark.parametrize(
+        "answer, expected", [("y", True), ("n", False), ("m", None)]
+    )
+    def test_overwrite_or_not_input(
+        self, crystal_map, temp_file_path, answer, expected
+    ):
+        save(temp_file_path, crystal_map)
+        if answer == "m":
+            with replace_stdin(StringIO(answer)):
+                with pytest.raises(EOFError):
+                    _overwrite_or_not(temp_file_path)
+        else:
+            with replace_stdin(StringIO(answer)):
+                assert _overwrite_or_not(temp_file_path) is expected
+
+    @pytest.mark.parametrize("temp_file_path", ["angs", "hdf4", "h6"])
+    def test_save_unsupported_raises(self, temp_file_path, crystal_map):
+        _, ext = os.path.splitext(temp_file_path)
+        with pytest.raises(IOError, match=f"'{ext}' does not correspond to any "):
+            save(temp_file_path, crystal_map)
+
+    def test_save_overwrite_raises(self, temp_file_path, crystal_map):
+        with pytest.raises(ValueError, match="`overwrite` parameter can only be "):
+            save(temp_file_path, crystal_map, overwrite=1)
+
+    @pytest.mark.parametrize(
+        "overwrite, expected_phase_name", [(True, "hepp"), (False, "")]
+    )
+    def test_save_overwrite(
+        self, temp_file_path, crystal_map, overwrite, expected_phase_name
+    ):
+        assert crystal_map.phases[0].name == ""
+        save(temp_file_path, crystal_map)
+        assert os.path.isfile(temp_file_path) is True
+
+        crystal_map.phases[0].name = "hepp"
+        save(temp_file_path, crystal_map, overwrite=overwrite)
+
+        crystal_map2 = load(temp_file_path)
+        assert crystal_map2.phases[0].name == expected_phase_name
+
+
+def test_loadctf():
+    """ Crude test of the ctf loader """
+    z = np.random.rand(100, 8)
+    fname = "temp.ctf"
+    np.savetxt(fname, z)
+
+    _ = loadctf(fname)
+    os.remove(fname)

--- a/orix/tests/io/test_orix_plugin.py
+++ b/orix/tests/io/test_orix_plugin.py
@@ -1,0 +1,245 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 the orix developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+from diffpy.structure.spacegroups import GetSpaceGroup
+from h5py import File
+import pytest
+import numpy as np
+
+from orix import __version__ as orix_version
+from orix.crystal_map import CrystalMap, Phase
+from orix.io import load, save
+from orix.io.plugins.orix_hdf5 import (
+    hdf5group2dict,
+    dict2crystalmap,
+    dict2phaselist,
+    dict2phase,
+    dict2structure,
+    dict2lattice,
+    dict2atom,
+    dict2hdf5group,
+    crystalmap2dict,
+    phaselist2dict,
+    phase2dict,
+    structure2dict,
+    lattice2dict,
+    atom2dict,
+)
+from orix.io.plugins import ang, emsoft_h5ebsd, orix_hdf5
+from orix.tests.io.test_io import assert_dictionaries_are_equal
+
+plugin_list = [ang, emsoft_h5ebsd, orix_hdf5]
+
+
+class TestOrixHDF5Plugin:
+    def test_file_writer(self, crystal_map, temp_file_path):
+        save(filename=temp_file_path, object2write=crystal_map)
+
+        with File(temp_file_path, mode="r") as f:
+            assert f["manufacturer"][()][0].decode() == "orix"
+            assert f["version"][()][0].decode() == orix_version
+
+    @pytest.mark.parametrize(
+        "crystal_map_input",
+        [
+            ((4, 4, 3), (1, 1.5, 1.5), 1, [0, 1]),
+            ((2, 4, 3), (1, 1.5, 1.5), 2, [0, 1, 2]),
+        ],
+        indirect=["crystal_map_input"],
+    )
+    def test_write_read_masked(self, crystal_map_input, temp_file_path):
+        cm = CrystalMap(**crystal_map_input)
+        save(filename=temp_file_path, object2write=cm[cm.x > 2])
+        cm2 = load(temp_file_path)
+
+        assert cm2.size != cm.size
+        with pytest.raises(ValueError, match="operands could not be broadcast"):
+            _ = np.allclose(cm2.x, cm.x)
+
+        cm2.is_in_data = cm.is_in_data
+        assert cm2.size == cm.size
+        assert np.allclose(cm2.x, cm.x)
+
+    def test_file_writer_raises(self, temp_file_path, crystal_map):
+        with pytest.raises(OSError, match="Cannot write to the already open file "):
+            with File(temp_file_path, mode="w") as _:
+                save(temp_file_path, crystal_map, overwrite=True)
+
+    def test_dict2hdf5group(self, temp_file_path):
+        with File(temp_file_path, mode="w") as f:
+            group = f.create_group(name="a_group")
+            with pytest.warns(UserWarning, match="The orix HDF5 writer could not"):
+                dict2hdf5group(
+                    dictionary={"a": [np.array(24.5)], "c": set()}, group=group
+                )
+
+    def test_crystalmap2dict(self, temp_file_path, crystal_map_input):
+        cm = CrystalMap(**crystal_map_input)
+        cm_dict = crystalmap2dict(cm)
+
+        this_dict = {"hello": "there"}
+        cm_dict2 = crystalmap2dict(cm, dictionary=this_dict)
+
+        cm_dict2.pop("hello")
+        assert_dictionaries_are_equal(cm_dict, cm_dict2)
+
+        assert np.allclose(cm_dict["data"]["x"], crystal_map_input["x"])
+        assert cm_dict["header"]["z_step"] == cm.dz
+
+    def test_phaselist2dict(self, phase_list):
+        pl_dict = phaselist2dict(phase_list)
+        this_dict = {"hello": "there"}
+        this_dict = phaselist2dict(phase_list, dictionary=this_dict)
+        this_dict.pop("hello")
+
+        assert_dictionaries_are_equal(pl_dict, this_dict)
+
+    def test_phase2dict(self, phase_list):
+        phase_dict = phase2dict(phase_list[0])
+        this_dict = {"hello": "there"}
+        this_dict = phase2dict(phase_list[0], dictionary=this_dict)
+        this_dict.pop("hello")
+
+        assert_dictionaries_are_equal(phase_dict, this_dict)
+
+    def test_phase2dict_spacegroup(self):
+        """Space group is written to dict as an int or "None"."""
+        sg100 = 100
+        phase = Phase(space_group=sg100)
+        phase_dict1 = phase2dict(phase)
+        assert phase_dict1["space_group"] == sg100
+
+        sg200 = GetSpaceGroup(200)
+        phase.space_group = sg200
+        phase_dict2 = phase2dict(phase)
+        assert phase_dict2["space_group"] == sg200.number
+
+        phase.space_group = None
+        phase_dict3 = phase2dict(phase)
+        assert phase_dict3["space_group"] == "None"
+
+    def test_structure2dict(self, phase_list):
+        structure = phase_list[0].structure
+        structure_dict = structure2dict(structure)
+        this_dict = {"hello": "there"}
+        this_dict = structure2dict(structure, this_dict)
+        this_dict.pop("hello")
+
+        lattice1 = structure_dict["lattice"]
+        lattice2 = this_dict["lattice"]
+        assert np.allclose(lattice1["abcABG"], lattice2["abcABG"])
+        assert np.allclose(lattice1["baserot"], lattice2["baserot"])
+        assert_dictionaries_are_equal(structure_dict["atoms"], this_dict["atoms"])
+
+    def test_hdf5group2dict_update_dict(self, temp_file_path, crystal_map):
+        save(temp_file_path, crystal_map)
+        with File(temp_file_path, mode="r") as f:
+            this_dict = {"hello": "there"}
+            this_dict = hdf5group2dict(f["crystal_map"], dictionary=this_dict)
+
+            assert this_dict["hello"] == "there"
+            assert this_dict["data"] == f["crystal_map/data"]
+            assert this_dict["header"] == f["crystal_map/header"]
+
+    def test_file_reader(self, crystal_map, temp_file_path):
+        save(filename=temp_file_path, object2write=crystal_map)
+        cm2 = load(filename=temp_file_path)
+        assert_dictionaries_are_equal(crystal_map.__dict__, cm2.__dict__)
+
+    def test_dict2crystalmap(self, crystal_map):
+        cm2 = dict2crystalmap(crystalmap2dict(crystal_map))
+        assert_dictionaries_are_equal(crystal_map.__dict__, cm2.__dict__)
+
+    def test_dict2phaselist(self, phase_list):
+        phase_list2 = dict2phaselist(phaselist2dict(phase_list))
+
+        assert phase_list.size == phase_list2.size
+        assert phase_list.ids == phase_list2.ids
+        assert phase_list.names == phase_list2.names
+        assert phase_list.colors == phase_list2.colors
+        assert [
+            s1.name == s2.name
+            for s1, s2 in zip(phase_list.point_groups, phase_list2.point_groups)
+        ]
+
+    def test_dict2phase(self, phase_list):
+        phase1 = phase_list[0]
+        phase2 = dict2phase(phase2dict(phase1))
+
+        assert phase1.name == phase2.name
+        assert phase1.color == phase2.color
+        assert phase1.space_group.number == phase2.space_group.number
+        assert phase1.point_group.name == phase2.point_group.name
+        assert phase1.structure.lattice.abcABG() == phase2.structure.lattice.abcABG()
+
+    def test_dict2phase_spacegroup(self):
+        """Space group number int or None is properly parsed from a dict.
+        """
+        phase1 = Phase(space_group=200)
+        phase_dict = phase2dict(phase1)
+        phase2 = dict2phase(phase_dict)
+        assert phase1.space_group.number == phase2.space_group.number
+
+        phase_dict.pop("space_group")
+        phase3 = dict2phase(phase_dict)
+        assert phase3.space_group is None
+
+    def test_dict2structure(self, phase_list):
+        structure1 = phase_list[0].structure
+        structure2 = dict2structure(structure2dict(structure1))
+
+        lattice1 = structure1.lattice
+        lattice2 = structure2.lattice
+        assert lattice1.abcABG() == lattice2.abcABG()
+        assert np.allclose(lattice1.baserot, lattice2.baserot)
+
+        assert str(structure1.element) == str(structure2.element)
+        assert np.allclose(structure1.xyz, structure2.xyz)
+
+    def test_dict2lattice(self, phase_list):
+        lattice = phase_list[0].structure.lattice
+        lattice2 = dict2lattice(lattice2dict(lattice))
+
+        assert lattice.abcABG() == lattice2.abcABG()
+        assert np.allclose(lattice.baserot, lattice2.baserot)
+
+    def test_dict2atom(self, phase_list):
+        atom = phase_list[0].structure[0]
+        atom2 = dict2atom(atom2dict(atom))
+
+        assert str(atom.element) == str(atom2.element)
+        assert np.allclose(atom.xyz, atom2.xyz)
+
+    def test_read_point_group_from_v0_3_x(self, temp_file_path, crystal_map):
+        crystal_map.phases[0].point_group = "1"
+        save(filename=temp_file_path, object2write=crystal_map)
+
+        # First, ensure point group data set name is named "symmetry", as in v0.3.0
+        with File(temp_file_path, mode="r+") as f:
+            for phase in f["crystal_map/header/phases"].values():
+                phase["symmetry"] = phase["point_group"]
+                del phase["point_group"]
+
+        # Then, make sure it can still be read
+        cm2 = load(filename=temp_file_path)
+        # And that the symmetry operations are the same, for good measure
+        print(crystal_map)
+        print(cm2)
+        assert np.allclose(
+            crystal_map.phases[0].point_group.data, cm2.phases[0].point_group.data
+        )


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

* Ensure phase IDs are read from ANG file and phases in the header are returned with correct ID
* Add some more point group aliases found in an ANG file, move this dictionary to the `orix.quaternion.symmetry` module
* Separate IO tests into their own files (general IO and ANG, EMsoft and orix plugins)