### PR TITLE
Convert unrefined Euler angles from degrees to radians in EMsoft IO plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ ENV/
 
 # Visual Studio Code
 *.code-workspace
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This project now keeps a Changelog
 
 ### Fixed
+- EMsoft file reader reads Euler angles correctly
 - ANG file reader now recognises phase IDs defined in the header

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This project now keeps a Changelog
 
 ### Fixed
-- EMsoft file reader reads Euler angles correctly
+- EMsoft file reader reads unrefined Euler angles correctly
 - ANG file reader now recognises phase IDs defined in the header

--- a/orix/io/plugins/emsoft_h5ebsd.py
+++ b/orix/io/plugins/emsoft_h5ebsd.py
@@ -91,7 +91,7 @@ def file_reader(filename, refined=False, **kwargs):
         dictionary_size = data_group["FZcnt"][:][0]
         dictionary_euler = data_group["DictionaryEulerAngles"][:][:dictionary_size]
         euler = dictionary_euler[top_match_idx, :]
-    data_dict["rotations"] = Rotation.from_euler(euler)
+    data_dict["rotations"] = Rotation.from_euler(np.deg2rad(euler))
 
     # Get number of top matches kept per data point
     n_top_matches = f["NMLparameters/EBSDIndexingNameListType/nnk"][:][0]

--- a/orix/io/plugins/emsoft_h5ebsd.py
+++ b/orix/io/plugins/emsoft_h5ebsd.py
@@ -85,13 +85,15 @@ def file_reader(filename, refined=False, **kwargs):
 
     # Get rotations
     if refined:
-        euler = data_group["RefinedEulerAngles"][:]
+        euler = data_group["RefinedEulerAngles"][:]  # Radians
     else:  # Get n top matches for each pixel
         top_match_idx = data_group["TopMatchIndices"][:][:map_size] - 1
         dictionary_size = data_group["FZcnt"][:][0]
+        # Degrees
         dictionary_euler = data_group["DictionaryEulerAngles"][:][:dictionary_size]
+        dictionary_euler = np.deg2rad(dictionary_euler)
         euler = dictionary_euler[top_match_idx, :]
-    data_dict["rotations"] = Rotation.from_euler(np.deg2rad(euler))
+    data_dict["rotations"] = Rotation.from_euler(euler)
 
     # Get number of top matches kept per data point
     n_top_matches = f["NMLparameters/EBSDIndexingNameListType/nnk"][:][0]

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -445,11 +445,10 @@ def temp_emsoft_h5ebsd_file(tmpdir, request):
         data=np.vstack((np.random.random(size=n_top_matches),) * map_size),
         dtype=np.float32,
     )
+    # In degrees
     data_group.create_dataset(
         "DictionaryEulerAngles",
-        data=np.column_stack(
-            (np.random.uniform(low=0, high=2 * np.pi, size=n_sampled_oris),) * 3
-        ),
+        data=np.column_stack((np.linspace(150, 160, n_sampled_oris),) * 3),
         dtype=np.float32,
     )
 

--- a/orix/tests/io/test_emsoft_plugin.py
+++ b/orix/tests/io/test_emsoft_plugin.py
@@ -84,13 +84,13 @@ class TestEMsoftPlugin:
         n_top_matches,
         refined,
     ):
-        cm = load(temp_emsoft_h5ebsd_file.filename, refined=refined)
+        xmap = load(temp_emsoft_h5ebsd_file.filename, refined=refined)
 
-        assert cm.shape == map_shape
-        assert (cm.dy, cm.dx) == step_sizes
+        assert xmap.shape == map_shape
+        assert (xmap.dy, xmap.dx) == step_sizes
         if refined:
             n_top_matches = 1
-        assert cm.rotations_per_point == n_top_matches
+        assert xmap.rotations_per_point == n_top_matches
 
         # Properties
         expected_props = [
@@ -108,12 +108,17 @@ class TestEMsoftPlugin:
         ]
         if refined:
             expected_props += ["RefinedDotProducts"]
-        actual_props = list(cm.prop.keys())
+        actual_props = list(xmap.prop.keys())
         actual_props.sort()
         expected_props.sort()
         assert actual_props == expected_props
 
-        assert cm.phases["austenite"].structure == Structure(
+        assert xmap.phases["austenite"].structure == Structure(
             title="austenite",
             lattice=Lattice(a=3.595, b=3.595, c=3.595, alpha=90, beta=90, gamma=90),
         )
+
+        # Ensure Euler angles in degrees are read correctly from file
+        if not refined:
+            assert np.rad2deg(xmap.rotations.to_euler().min()) >= 150
+            assert np.rad2deg(xmap.rotations.to_euler().max()) <= 160


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

Fixes major bug in the EMsoft IO plugin where unrefined Euler angles read from the array of all Euler angles used for simulating patterns, in degrees, were passed to `quaternion.Rotation.from_euler()`... They are now converted to radians:

* Rotations from DictionaryEulerAngles HDF5 data set are converted to radians correctly in the EMsoft h5ebsd plugin.
* Artificial EMsoft h5ebsd file (ment to reflect what's returned by EMsofts EMEBSDDI program) now writes dictionary Euler angles in degrees (not radians, as before) to DictionaryEulerAngles HDF5 data set in `conftest.py`, in the angle range [150, 160].
* A test is added to ensure that the dictionary Euler angles read from the artificial file is in the range [150, 160].

Did not discover this previously because I always performed orientation refinement with EMsoft and read those rotations from file instead of the initial best matching rotations (`orix.io.plugin.emsoft_h5ebsd.file_reader(filename, refined=True)`.