### PR TITLE
Adds testing for OSX 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,28 +8,37 @@ env:
 
 jobs:
   include:
+  - name: "Python 3.9 on Linux"
+    env: export PYTHON=3.9
+    before_install: wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+
   - name: "Python 3.8 on Linux"
     env: export PYTHON=3.8
     before_install: wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-  
+
   - name: "Python 3.7 on Linux"
     env: export PYTHON=3.7
     before_install: wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-  
+
   - name: "Python 3.6 on Linux"
     env: export PYTHON=3.6
     before_install: wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-  
+
+  - name: "Python 3.8 on MacOS"
+    os: osx
+    env: export PYTHON=3.8
+    before_install: wget "https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh" -O miniconda.sh
+
   - name: "Python 3.7 on MacOS"
     os: osx
     env: export PYTHON=3.7
     before_install: wget "https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh" -O miniconda.sh
-  
+
   - name: "Python 3.8 on Windows"
     os: windows
     env: EXPORT PYTHON=3.8; PATH="/c/tools/miniconda3/:/c/tools/miniconda3/Scripts:$PATH"
     before_install: choco install -y miniconda3 openssl.light
-  
+
   - name: "Python 3.7 on Windows"
     os: windows
     env: EXPORT PYTHON=3.7; PATH="/c/tools/miniconda3/:/c/tools/miniconda3/Scripts:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ env:
 
 jobs:
   include:
-  - name: "Python 3.9 on Linux"
-    env: export PYTHON=3.9
-    before_install: wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-
   - name: "Python 3.8 on Linux"
     env: export PYTHON=3.8
     before_install: wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - This project now keeps a Changelog
-- Testing for Py3.9 on Linux and Py3.8 on OSX
+- Testing for Py3.8 on OSX
 
 ### Fixed
 - ANG file reader now recognises phase IDs defined in the header

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - This project now keeps a Changelog
+- Testing for Py3.9 on Linux and Py3.8 on OSX
 
 ### Fixed
 - ANG file reader now recognises phase IDs defined in the header


### PR DESCRIPTION
Addressing #132, I've attempted to 3.9 for a bit of future proofing but we aren't ready for it yet. I left 3.6 for some past proofing, and completed our coverage on 3.7 and 3.8 over all three major operating systems.