### PR TITLE
Update copyright to 2018-2021

### DIFF
--- a/orix/base/__init__.py
+++ b/orix/base/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/crystal_map/__init__.py
+++ b/orix/crystal_map/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/crystal_map/crystal_map_properties.py
+++ b/orix/crystal_map/crystal_map_properties.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/io/__init__.py
+++ b/orix/io/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/io/plugins/__init__.py
+++ b/orix/io/plugins/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/io/plugins/ang.py
+++ b/orix/io/plugins/ang.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/io/plugins/emsoft_h5ebsd.py
+++ b/orix/io/plugins/emsoft_h5ebsd.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/io/plugins/orix_hdf5.py
+++ b/orix/io/plugins/orix_hdf5.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/plot/__init__.py
+++ b/orix/plot/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/plot/rotation_plot.py
+++ b/orix/plot/rotation_plot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/quaternion/__init__.py
+++ b/orix/quaternion/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/quaternion/orientation_region.py
+++ b/orix/quaternion/orientation_region.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/quaternion/symmetry.py
+++ b/orix/quaternion/symmetry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/sampling/__init__.py
+++ b/orix/sampling/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/sampling/sample_generators.py
+++ b/orix/sampling/sample_generators.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/sampling/sampling_utils.py
+++ b/orix/sampling/sampling_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/scalar/__init__.py
+++ b/orix/scalar/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/io/__init__.py
+++ b/orix/tests/io/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/io/test_ang_plugin.py
+++ b/orix/tests/io/test_ang_plugin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/io/test_emsoft_plugin.py
+++ b/orix/tests/io/test_emsoft_plugin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/io/test_io.py
+++ b/orix/tests/io/test_io.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/io/test_orix_plugin.py
+++ b/orix/tests/io/test_orix_plugin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/test_axangle.py
+++ b/orix/tests/test_axangle.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/test_crystal_map_plot.py
+++ b/orix/tests/test_crystal_map_plot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/test_crystal_map_properties.py
+++ b/orix/tests/test_crystal_map_properties.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/test_phase_list.py
+++ b/orix/tests/test_phase_list.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/test_rotation_plot.py
+++ b/orix/tests/test_rotation_plot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/test_sampling.py
+++ b/orix/tests/test_sampling.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/vector/__init__.py
+++ b/orix/vector/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/vector/neo_euler.py
+++ b/orix/vector/neo_euler.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/vector/spherical_region.py
+++ b/orix/vector/spherical_region.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 the orix developers
+# Copyright 2018-2021 the orix developers
 #
 # This file is part of orix.
 #


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

Update copyright to 2019-2021 with a [fork of licenseheaders](https://github.com/johann-petrak/licenseheaders/issues/47).