### PR TITLE
Rename Vector3d spherical coordinates to azimuth, polar, radial

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Added
 
 Changed
 -------
+- Names of spherical coordinates for the Vector3d class, "phi" to "azimuth", "theta" to
+  "polar", and "r" to "radial". Similar changes to to/from_polar parameter names.
 - CrystalMap.get_map_data() tries to respect input data type, other minor improvements
 - Continuous integration migrated from Travis CI to GitHub Actions
 

--- a/doc/stereographic_projection.ipynb
+++ b/doc/stereographic_projection.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "massive-richardson",
+   "id": "running-hungary",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "comparable-price",
+   "id": "related-justice",
    "metadata": {},
    "source": [
     "# Stereographic projection\n",
@@ -39,7 +39,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "existing-ambassador",
+   "id": "theoretical-jenny",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +65,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "duplicate-aquarium",
+   "id": "incorporate-saudi",
    "metadata": {},
    "source": [
     "## Plot vectors"
@@ -73,7 +73,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "negative-asset",
+   "id": "medical-preview",
    "metadata": {},
    "source": [
     "Plotting three vectors with\n",
@@ -84,7 +84,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "searching-recognition",
+   "id": "responsible-junior",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "later-wheat",
+   "id": "subjective-place",
    "metadata": {},
    "source": [
     "Hover the cursor over the equatorial plane to see the spherical coordinates when\n",
@@ -107,7 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dental-programming",
+   "id": "accurate-lewis",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "expressed-modem",
+   "id": "civil-taste",
    "metadata": {},
    "source": [
     "### Upper and lower hemisphere\n",
@@ -130,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "featured-amendment",
+   "id": "bizarre-signal",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +150,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "robust-velvet",
+   "id": "muslim-faculty",
    "metadata": {},
    "source": [
     "Here,\n",
@@ -163,7 +163,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "nasty-avenue",
+   "id": "powerful-industry",
    "metadata": {},
    "source": [
     "### Control grid\n",
@@ -178,7 +178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "radical-memphis",
+   "id": "engaging-beach",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,7 +199,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "banned-float",
+   "id": "funny-basin",
    "metadata": {},
    "source": [
     "### Annotate vectors\n",
@@ -211,7 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "normal-prescription",
+   "id": "close-farming",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,7 +236,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "frozen-rhythm",
+   "id": "acoustic-antigua",
    "metadata": {},
    "source": [
     "### Pass spherical coordinates\n",
@@ -247,7 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "organized-correlation",
+   "id": "secondary-twelve",
    "metadata": {
     "tags": [
      "nbsphinx-thumbnail"
@@ -266,7 +266,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "disabled-candle",
+   "id": "proper-current",
    "metadata": {},
    "source": [
     "Here, we also passed `None` to\n",
@@ -276,7 +276,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "posted-consent",
+   "id": "about-victorian",
    "metadata": {},
    "source": [
     "## Experimental functionality\n",
@@ -288,7 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "collective-puppy",
+   "id": "manufactured-fluid",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/orix/plot/_symmetry_marker.py
+++ b/orix/plot/_symmetry_marker.py
@@ -40,7 +40,7 @@ class SymmetryMarker:
 
     @property
     def angle_deg(self):
-        return np.rad2deg(self._vector.phi.data) + 90
+        return np.rad2deg(self._vector.azimuth.data) + 90
 
     @property
     def size(self):
@@ -61,7 +61,7 @@ class TwoFoldMarker(SymmetryMarker):
     @property
     def size(self):
         # Assuming maximum polar angle is 90 degrees
-        radial = np.tan(self._vector.theta.data / 2)
+        radial = np.tan(self._vector.polar.data / 2)
         radial = np.where(radial == 0, 1, radial)
         return self._size / np.sqrt(radial)
 
@@ -74,7 +74,7 @@ class TwoFoldMarker(SymmetryMarker):
         ellipse = mpath.Path(verts, circle.codes)
 
         # Set up rotations of ellipse
-        azimuth = self._vector.phi.data
+        azimuth = self._vector.azimuth.data
         trans = [mtransforms.Affine2D().rotate(a + (np.pi / 2)) for a in azimuth]
 
         return [ellipse.deepcopy().transformed(i) for i in trans]

--- a/orix/plot/stereographic_plot.py
+++ b/orix/plot/stereographic_plot.py
@@ -326,7 +326,7 @@ class StereographicPlot(Axes):
         Parameters
         ----------
         resolution : float, optional
-            Aziumuth grid resolution in degrees. Default is 30 degrees.
+            Aziumuth grid resolution in degrees. Default is 15 degrees.
             This can also be set upon initialization of the axes by
             passing `azimuth_resolution` to `subplot_kw`.
 
@@ -346,7 +346,7 @@ class StereographicPlot(Axes):
         Parameters
         ----------
         resolution : float, optional
-            Polar grid resolution in degrees. Default is 30 degrees.
+            Polar grid resolution in degrees. Default is 15 degrees.
             This can also be set upon initialization of the axes by
             passing `polar_resolution` to the `subplot_kw` dictionary.
 
@@ -430,8 +430,8 @@ class StereographicPlot(Axes):
             value = values[0]
             if isinstance(value, Vector3d):
                 value = value.unit
-                azimuth = value.phi.data
-                polar = value.theta.data
+                azimuth = value.azimuth.data
+                polar = value.polar.data
             else:
                 raise ValueError(
                     "Accepts only one (Vector3d) or two (azimuth, polar) input "

--- a/orix/projections/stereographic.py
+++ b/orix/projections/stereographic.py
@@ -111,7 +111,7 @@ class StereographicProjection:
         --------
         vector2xy
         """
-        v = Vector3d.from_polar(theta=polar, phi=azimuth)
+        v = Vector3d.from_polar(azimuth=azimuth, polar=polar)
         return self.vector2xy(v)
 
     @staticmethod
@@ -181,7 +181,7 @@ class StereographicProjection:
         --------
         vector2xy
         """
-        v = Vector3d.from_polar(theta=polar, phi=azimuth)
+        v = Vector3d.from_polar(azimuth=azimuth, polar=polar)
         return self.vector2xy_split(v)
 
     @property
@@ -296,14 +296,15 @@ class InverseStereographicProjection:
 
         Returns
         -------
-        phi : numpy.ndarray
+        azimuth : numpy.ndarray
+            Azimuth spherical coordinate corresponding to (X, Y).
             Whether the coordinates for the upper or lower hemisphere
             points are returned is controlled by `pole` (-1 = upper,
             1 = lower).
         theta : numpy.ndarray
-            Whether the coordinates for the upper or lower hemisphere
-            points are returned is controlled by `pole` (-1 = upper,
-            1 = lower).
+            Polar spherical coordinate corresponding to (X, Y). Whether
+            the coordinates for the upper or lower hemisphere points are
+            returned is controlled by `pole` (-1 = upper, 1 = lower).
 
         See Also
         --------
@@ -311,4 +312,4 @@ class InverseStereographicProjection:
         StereographicProjection.spherical2xy
         """
         v = self.xy2vector(x=x, y=y)
-        return v.phi.data, v.theta.data
+        return v.azimuth.data, v.polar.data

--- a/orix/tests/test_stereographic_plot.py
+++ b/orix/tests/test_stereographic_plot.py
@@ -51,10 +51,10 @@ class TestStereographicPlot:
 
         v = vector.Vector3d([[0, 0, 1], [2, 0, 2]])
         ax.scatter(v[0])
-        ax.scatter(v[1].phi.data, v[1].theta.data)
+        ax.scatter(v[1].azimuth.data, v[1].polar.data)
 
         with pytest.raises(ValueError, match="Accepts only one "):
-            ax.scatter(v[1].phi)
+            ax.scatter(v[1].azimuth)
 
         plt.close("all")
 

--- a/orix/tests/test_stereographic_projection.py
+++ b/orix/tests/test_stereographic_projection.py
@@ -87,8 +87,8 @@ class TestStereographicProjection:
 
     def test_spherical2xy(self, vectors):
         sp_up = StereographicProjection(pole=-1)
-        azimuth = vectors.phi.data
-        polar = vectors.theta.data
+        azimuth = vectors.azimuth.data
+        polar = vectors.polar.data
         x_up, y_up, x_down, y_down = sp_up.spherical2xy_split(
             azimuth=azimuth, polar=polar
         )
@@ -121,10 +121,10 @@ class TestStereographicProjection:
         is_up = vectors.z >= 0
         v_up = vectors[is_up]
         v_down = vectors[~is_up]
-        azimuth_up_in = v_up.phi.data
-        polar_up_in = v_up.theta.data
-        azimuth_down_in = v_down.phi.data
-        polar_down_in = v_down.theta.data
+        azimuth_up_in = v_up.azimuth.data
+        polar_up_in = v_up.polar.data
+        azimuth_down_in = v_down.azimuth.data
+        polar_down_in = v_down.polar.data
 
         sp_up = StereographicProjection(pole=-1)
         sp_down = StereographicProjection(pole=1)

--- a/orix/tests/test_vector3d.py
+++ b/orix/tests/test_vector3d.py
@@ -168,15 +168,17 @@ def test_cross_error(vector, number):
 
 
 @pytest.mark.parametrize(
-    "theta, phi, r, expected",
+    "azimuth, polar, radial, expected",
     [
         (np.pi / 4, np.pi / 4, 1, Vector3d((0.5, 0.5, 0.707107))),
-        (2 * np.pi / 3, 7 * np.pi / 6, 1, Vector3d((-0.75, -0.433013, -0.5))),
+        (7 * np.pi / 6, 2 * np.pi / 3, 1, Vector3d((-0.75, -0.433013, -0.5))),
     ],
 )
-def test_polar(theta, phi, r, expected):
+def test_polar(azimuth, polar, radial, expected):
     assert np.allclose(
-        Vector3d.from_polar(theta, phi, r).data, expected.data, atol=1e-5
+        Vector3d.from_polar(azimuth=azimuth, polar=polar, radial=radial).data,
+        expected.data,
+        atol=1e-5,
     )
 
 
@@ -298,7 +300,7 @@ def test_mean_xyz():
 @pytest.mark.xfail(strict=True, reason=ValueError)
 def test_zero_perpendicular():
     t = Vector3d(np.asarray([0, 0, 0]))
-    tperp = t.perpendicular()
+    _ = t.perpendicular()
 
 
 @pytest.mark.xfail(strict=True, reason=TypeError)
@@ -315,19 +317,21 @@ class TestSpareNotImplemented:
 
 class TestSphericalCoordinates:
     @pytest.mark.parametrize(
-        "vector, theta_desired, phi_desired, r_desired",
+        "v, polar_desired, azimuth_desired, radial_desired",
         [
             (Vector3d((0.5, 0.5, 0.707107)), np.pi / 4, np.pi / 4, 1),
             (Vector3d((-0.75, -0.433013, -0.5)), 2 * np.pi / 3, 7 * np.pi / 6, 1),
         ],
     )
-    def test_to_polar(self, vector, theta_desired, phi_desired, r_desired):
-        theta, phi, r = vector.to_polar()
-        assert np.allclose(theta.data, theta_desired)
-        assert np.allclose(phi.data, phi_desired)
-        assert np.allclose(r.data, r_desired)
+    def test_to_polar(self, v, polar_desired, azimuth_desired, radial_desired):
+        azimuth, polar, radial = v.to_polar()
+        assert np.allclose(polar.data, polar_desired)
+        assert np.allclose(azimuth.data, azimuth_desired)
+        assert np.allclose(radial.data, radial_desired)
 
     def test_polar_loop(self, vector):
-        theta, phi, r = vector.to_polar()
-        vector2 = Vector3d.from_polar(theta=theta.data, phi=phi.data, r=r.data)
+        azimuth, polar, radial = vector.to_polar()
+        vector2 = Vector3d.from_polar(
+            azimuth=azimuth.data, polar=polar.data, radial=radial.data
+        )
         assert np.allclose(vector.data, vector2.data)

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -251,18 +251,18 @@ class Vector3d(Object3d):
         return other.__class__(np.cross(self.data, other.data))
 
     @classmethod
-    def from_polar(cls, theta, phi, r=1):
-        """Create a :class:`~orix.vector.vector3d.Vector3d` from spherical
+    def from_polar(cls, azimuth, polar, radial=1):
+        """Create a :class:`~orix.vector.Vector3d` from spherical
         coordinates according to the ISO 31-11 standard
         [SphericalWolfram]_.
 
         Parameters
         ----------
-        theta : array_like
+        azimuth : array_like
+            The azimuth angle, in radians.
+        polar : array_like
             The polar angle, in radians.
-        phi : array_like
-            The azimuthal angle, in radians.
-        r : array_like
+        radial : array_like
             The radial distance. Defaults to 1 to produce unit vectors.
 
         Returns
@@ -275,12 +275,13 @@ class Vector3d(Object3d):
             *From MathWorld--A Wolfram Web Resource*,
             url: https://mathworld.wolfram.com/SphericalCoordinates.html
         """
-        theta = np.atleast_1d(theta)
-        phi = np.atleast_1d(phi)
-        x = np.cos(phi) * np.sin(theta)
-        y = np.sin(phi) * np.sin(theta)
-        z = np.cos(theta)
-        return r * cls(np.stack((x, y, z), axis=-1))
+        azimuth = np.atleast_1d(azimuth)
+        polar = np.atleast_1d(polar)
+        sin_polar = np.sin(polar)
+        x = np.cos(azimuth) * sin_polar
+        y = np.sin(azimuth) * sin_polar
+        z = np.cos(polar)
+        return radial * cls(np.stack((x, y, z), axis=-1))
 
     @classmethod
     def zero(cls, shape=(1,)):
@@ -345,9 +346,9 @@ class Vector3d(Object3d):
         return self.x.data, self.y.data, self.z.data
 
     @property
-    def r(self):
-        """Radial spherical coordinate, i.e. the distance from a point on
-        the sphere to the origin, according to the ISO 31-11 standard
+    def radial(self):
+        """Radial spherical coordinate, i.e. the distance from a point
+        on the sphere to the origin, according to the ISO 31-11 standard
         [SphericalWolfram]_.
 
         Returns
@@ -361,32 +362,32 @@ class Vector3d(Object3d):
         )
 
     @property
-    def phi(self):
-        r"""Azimuthal spherical coordinate, i.e. the angle
-        :math:`\phi \in [0, 2\pi]` from the positive z-axis to a point on
-        the sphere, according to the ISO 31-11 standard
+    def azimuth(self):
+        r"""Azimuth spherical coordinate, i.e. the angle
+        :math:`\phi \in [0, 2\pi]` from the positive z-axis to a point
+        on the sphere, according to the ISO 31-11 standard
         [SphericalWolfram]_.
 
         Returns
         -------
         Scalar
         """
-        phi = np.arctan2(self.data[..., 1], self.data[..., 0])
-        phi += (phi < 0) * 2 * np.pi
-        return Scalar(phi)
+        azimuth = np.arctan2(self.data[..., 1], self.data[..., 0])
+        azimuth += (azimuth < 0) * 2 * np.pi
+        return Scalar(azimuth)
 
     @property
-    def theta(self):
+    def polar(self):
         r"""Polar spherical coordinate, i.e. the angle
-        :math:`\theta \in [0, \pi]` from the positive z-axis to a point on
-        the sphere, according to the ISO 31-11 standard
+        :math:`\theta \in [0, \pi]` from the positive z-axis to a point
+        on the sphere, according to the ISO 31-11 standard
         [SphericalWolfram]_.
 
         Returns
         -------
         Scalar
         """
-        return Scalar(np.arccos(self.data[..., 2] / self.r.data))
+        return Scalar(np.arccos(self.data[..., 2] / self.radial.data))
 
     def angle_with(self, other):
         """Calculate the angles between vectors in 'self' and 'other'
@@ -492,13 +493,13 @@ class Vector3d(Object3d):
         return self.__class__(self.data.mean(axis=axis))
 
     def to_polar(self):
-        r"""Return the polar :math:`\theta`, azimuthal :math:`\phi` and
-        radial :math:`r` spherical coordinates, the angles in radians. The
-        coordinates are defined as in the ISO 31-11 standard
+        r"""Return the azimuth :math:`\phi`, polar :math:`\theta`, and
+        radial :math:`r` spherical coordinates, the angles in radians.
+        The coordinates are defined as in the ISO 31-11 standard
         [SphericalWolfram]_.
 
         Returns
         -------
-        theta, phi, r : Scalar
+        azimuth, polar, r : Scalar
         """
-        return self.theta, self.phi, self.r
+        return self.azimuth, self.polar, self.radial


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

* As discussed in #153, the `Vector3d` spherical coordinate attributes are renamed from `Vector3d.phi`, `Vector3d.theta` and `Vector3d.r` to `Vector3d.azimuth`, `Vector3d.polar` and `Vector3d.radial`. This is done to reduce potential confusion about how the coordinates are defined. Tests and documentation are updated.
* Fix typo grid resolution in `StereographicPlot.polar_grid()` and `StereographicPlot.azimuth_grid()`.