### PR TITLE
Warn when trying to create rotations from large Euler angles 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Unreleased
 
 Added
 -----
+- Warning when trying to create rotations with large angles (degrees, not radians).
 - Vector3d.scatter() and Vector3d.draw_circle() methods to show unit vectors and
   great/small circles in stereographic projection
 - User guide with Jupyter notebooks as part of the Read the Docs documentation

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Unreleased
 
 Added
 -----
-- Warning when trying to create rotations with large angles (degrees, not radians).
+- Warning when trying to create rotations from large Euler angles
 - Vector3d.scatter() and Vector3d.draw_circle() methods to show unit vectors and
   great/small circles in stereographic projection
 - User guide with Jupyter notebooks as part of the Read the Docs documentation

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -338,13 +338,13 @@ class Rotation(Quaternion):
         direction : str
             "lab2crystal" or "crystal2lab".
         """
-        conventions = ["bunge", "krakow_hielscher"]
-        if convention.lower() not in conventions:
+        conventions = ["bunge", "Krakow_Hielscher"]
+        if convention not in conventions:
             raise ValueError(
                 f"The chosen convention is not one of the allowed options {conventions}"
             )
         directions = ["lab2crystal", "crystal2lab"]
-        if direction.lower() not in directions:
+        if direction not in directions:
             raise ValueError(
                 f"The chosen direction is not one of the allowed options {directions}"
             )
@@ -358,7 +358,7 @@ class Rotation(Quaternion):
         n = euler.shape[:-1]
         alpha, beta, gamma = euler[..., 0], euler[..., 1], euler[..., 2]
 
-        if convention.lower() == "krakow_hielscher":
+        if convention == "Krakow_Hielscher":
             # To be applied to the data found at:
             # https://www.repository.cam.ac.uk/handle/1810/263510
             alpha -= np.pi / 2
@@ -378,7 +378,7 @@ class Rotation(Quaternion):
             rot = cls(data.data)
             rot.improper = zero
             return rot
-        elif convention.lower() == "bunge":
+        elif convention == "bunge":
             # Uses A.5 & A.6 from Modelling Simul. Mater. Sci. Eng. 23
             # (2015) 083501
             sigma = 0.5 * np.add(alpha, gamma)

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -350,7 +350,7 @@ class Rotation(Quaternion):
             )
 
         euler = np.array(euler)
-        if np.any(euler > 9):
+        if np.any(np.abs(euler) > 9):
             warnings.warn(
                 "Angles are assumed to be in radians, but degrees might have been "
                 "passed"

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -279,7 +279,7 @@ class Rotation(Quaternion):
             Array of Euler angles in radians.
         """
         # TODO: other conventions
-        if convention.lower() != "bunge":
+        if convention != "bunge":
             raise ValueError(
                 "The chosen convention is not supported, 'bunge' is the only option"
             )

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -19,28 +19,29 @@
 """Point transformations of objects.
 
 Rotations are transformations of three-dimensional space leaving the
-origin in place. Rotations can be parametrized numerous ways, but in orix are
-handled as unit quaternions. Rotations can act on vectors, or other rotations,
-but not scalars. They are often most easily visualised as being a turn of a
-certain angle about a certain axis.
+origin in place. Rotations can be parametrized numerous ways, but in
+orix are handled as unit quaternions. Rotations can act on vectors, or
+other rotations, but not scalars. They are often most easily visualised
+as being a turn of a certain angle about a certain axis.
 
 .. image:: /_static/img/rotation.png
    :width: 200px
    :alt: Rotation of an object illustrated with an axis and rotation angle.
    :align: center
 
-Rotations can also be *improper*. An improper rotation in orix operates on
-vectors as a rotation by the unit quaternion, followed by inversion. Hence,
-a mirroring through the x-y plane can be considered an improper rotation of
-180° about the z-axis, illustrated in the figure below.
+Rotations can also be *improper*. An improper rotation in orix operates
+on vectors as a rotation by the unit quaternion, followed by inversion.
+Hence, a mirroring through the x-y plane can be considered an improper
+rotation of 180° about the z-axis, illustrated in the figure below.
 
 .. image:: /_static/img/inversion.png
    :width: 200px
    :alt: 180° rotation followed by inversion, leading to a mirror operation.
    :align: center
-
-
 """
+
+import warnings
+
 import numpy as np
 from scipy.special import hyp0f1
 
@@ -48,7 +49,8 @@ from orix.quaternion import Quaternion
 from orix.vector import Vector3d
 from orix.scalar import Scalar
 
-_FLOAT_EPS = np.finfo(np.float).eps  # Used to round values below 1e-16 to zero
+# Used to round values below 1e-16 to zero
+_FLOAT_EPS = np.finfo(float).eps
 
 
 class Rotation(Quaternion):
@@ -65,7 +67,6 @@ class Rotation(Quaternion):
 
     Rotations can be converted to other parametrizations, notably the neo-Euler
     representations. See :class:`NeoEuler`.
-
     """
 
     def __init__(self, data):
@@ -118,27 +119,28 @@ class Rotation(Quaternion):
         return r
 
     def unique(self, return_index=False, return_inverse=False, antipodal=True):
-        """Returns a new object containing only this object's unique entries.
+        """Returns a new object containing only this object's unique
+        entries.
 
         Two rotations are not unique if:
 
             - they have the same propriety AND
                 - they have the same numerical value OR
-                - the numerical value of one is the negative of the other
+                - the numerical value of one is the negative of the
+                  other
 
         Parameters
         ----------
         return_index : bool, optional
-            If True, will also return the indices of the (flattened) data where
-            the unique entries were found.
+            If True, will also return the indices of the (flattened)
+            data where the unique entries were found.
         return_inverse : bool, optional
-            If True, will also return the indices to reconstruct the (flattened)
-            data from the unique data.
+            If True, will also return the indices to reconstruct the
+            (flattened) data from the unique data.
         antipodal : bool, optional
             If False, rotations representing the same transformation
-            whose values are numerically different (negative) will *not* be
-            considered unique.
-
+            whose values are numerically different (negative) will *not*
+            be considered unique.
         """
         if len(self.data) == 0:
             return self.__class__(self.data)
@@ -194,12 +196,12 @@ class Rotation(Quaternion):
         return abcd
 
     def angle_with(self, other):
-        """The angle of rotation transforming this rotation to the other.
+        """The angle of rotation transforming this rotation to the
+        other.
 
         Returns
         -------
         Scalar
-
         """
         other = Rotation(other)
         angles = Scalar(
@@ -208,7 +210,9 @@ class Rotation(Quaternion):
         return angles
 
     def outer(self, other):
-        """Compute the outer product of this rotation and the other object."""
+        """Compute the outer product of this rotation and the other
+        object.
+        """
         r = super(Rotation, self).outer(other)
         if isinstance(r, Rotation):
             r.improper = np.logical_xor.outer(self.improper, other.improper)
@@ -232,7 +236,9 @@ class Rotation(Quaternion):
         self._data[..., -1] = value
 
     def dot_outer(self, other):
-        """Scalar : the outer dot product of this rotation and the other."""
+        """Scalar : the outer dot product of this rotation and the
+        other.
+        """
         cosines = np.abs(super(Rotation, self).dot_outer(other).data)
         if isinstance(other, Rotation):
             improper = self.improper.reshape(self.shape + (1,) * len(other.shape))
@@ -250,7 +256,6 @@ class Rotation(Quaternion):
         ----------
         neo_euler : NeoEuler
             Vector parametrization of a rotation.
-
         """
         s = np.sin(neo_euler.angle.data / 2)
         a = np.cos(neo_euler.angle.data / 2)
@@ -260,23 +265,24 @@ class Rotation(Quaternion):
         r = cls(np.stack([a, b, c, d], axis=-1))
         return r
 
-    def to_euler(self, convention="bunge"):  # TODO: other conventions
+    def to_euler(self, convention="bunge"):
         """Rotations as Euler angles.
 
         Parameters
         ----------
-        convention : 'bunge'
-            The Euler angle convention used. Only 'bunge'
-            is supported as present
+        convention : str, optional
+            The Euler angle convention used. Only "bunge" is supported.
 
         Returns
         -------
         ndarray
             Array of Euler angles in radians.
-
         """
-        if convention != "bunge":
-            raise ValueError("The convention you have specified is not supported")
+        # TODO: other conventions
+        if convention.lower() != "bunge":
+            raise ValueError(
+                "The chosen convention is not supported, 'bunge' is the only option"
+            )
         # A.14 from Modelling Simul. Mater. Sci. Eng. 23 (2015) 083501
         n = self.data.shape[:-1]
         e = np.zeros(n + (3,))
@@ -321,28 +327,40 @@ class Rotation(Quaternion):
 
     @classmethod
     def from_euler(cls, euler, convention="bunge", direction="crystal2lab"):
-        """Creates a rotation from an array of Euler angles.
+        """Creates a rotation from an array of Euler angles in radians.
 
         Parameters
         ----------
         euler : array-like
-            Euler angles in the Bunge convention.
+            Euler angles in radians in the Bunge convention.
         convention : str
-            Only 'bunge' is currently supported for new data
+            Only "bunge" is supported for new data.
         direction : str
-            'lab2crystal' or 'crystal2lab'
+            "lab2crystal" or "crystal2lab".
         """
-        if convention not in ["bunge", "Krakow_Hielscher"]:
-            raise ValueError("The chosen convention is not one of the allowed options")
-        if direction not in ["lab2crystal", "crystal2lab"]:
-            raise ValueError("The chosen direction is not one of the allowed options")
+        conventions = ["bunge", "krakow_hielscher"]
+        if convention.lower() not in conventions:
+            raise ValueError(
+                f"The chosen convention is not one of the allowed options {conventions}"
+            )
+        directions = ["lab2crystal", "crystal2lab"]
+        if direction.lower() not in directions:
+            raise ValueError(
+                f"The chosen direction is not one of the allowed options {directions}"
+            )
 
-        if convention == "Krakow_Hielscher":
+        euler = np.array(euler)
+        if np.any(euler > 9):
+            warnings.warn(
+                "Angles are assumed to be in radians, it appears you might instead be "
+                " using degrees"
+            )
+        n = euler.shape[:-1]
+        alpha, beta, gamma = euler[..., 0], euler[..., 1], euler[..., 2]
+
+        if convention.lower() == "krakow_hielscher":
             # To be applied to the data found at:
             # https://www.repository.cam.ac.uk/handle/1810/263510
-            euler = np.array(euler)
-            n = euler.shape[:-1]
-            alpha, beta, gamma = euler[..., 0], euler[..., 1], euler[..., 2]
             alpha -= np.pi / 2
             gamma -= 3 * np.pi / 2
             zero = np.zeros(n)
@@ -360,17 +378,9 @@ class Rotation(Quaternion):
             rot = cls(data.data)
             rot.improper = zero
             return rot
-
-        elif convention == "bunge":
-            euler = np.array(euler)
-            n = euler.shape[:-1]
-
-            # Uses A.5 & A.6 from Modelling Simul. Mater. Sci. Eng. 23 (2015) 083501
-
-            alpha = euler[..., 0]  # psi1
-            beta = euler[..., 1]  # Psi
-            gamma = euler[..., 2]  # psi3
-
+        elif convention.lower() == "bunge":
+            # Uses A.5 & A.6 from Modelling Simul. Mater. Sci. Eng. 23
+            # (2015) 083501
             sigma = 0.5 * np.add(alpha, gamma)
             delta = 0.5 * np.subtract(alpha, gamma)
             c = np.cos(beta / 2)
@@ -405,11 +415,11 @@ class Rotation(Quaternion):
 
         References
         ----------
-        .. [Rowenhorst2015] D. Rowenhorst, A. D. Rollett, G. S. Rohrer, M.
-            Groeber, M. Jackson, P. J. Konijnenberg, M. De Graef,
+        .. [Rowenhorst2015] D. Rowenhorst, A. D. Rollett, G. S. Rohrer,
+            M. Groeber, M. Jackson, P. J. Konijnenberg, M. De Graef,
             "Consistent representations of and conversions between 3D
-            rotations," *Modelling and Simulation in Materials Science and
-            Engineering* **23** (2015), doi:
+            rotations," *Modelling and Simulation in Materials Science
+            and Engineering* **23** (2015), doi:
             https://doi.org/10.1088/0965-0393/23/8/083501
 
         Examples
@@ -450,7 +460,8 @@ class Rotation(Quaternion):
 
     @classmethod
     def from_matrix(cls, matrix):
-        """Creates rotations from orientation matrices [Rowenhorst2015]_.
+        """Creates rotations from orientation matrices
+        [Rowenhorst2015]_.
 
         Parameters
         ----------
@@ -469,7 +480,8 @@ class Rotation(Quaternion):
         True
         """
         om = np.asarray(matrix)
-        n = (1,) if om.ndim == 2 else om.shape[:-2]  # Assuming (3, 3) as last two dims
+        # Assuming (3, 3) as last two dims
+        n = (1,) if om.ndim == 2 else om.shape[:-2]
         q = np.zeros(n + (4,))
 
         # Compute quaternion components
@@ -496,8 +508,7 @@ class Rotation(Quaternion):
         Parameters
         ----------
         shape : tuple
-            The shape out of which to construct identity quaternions
-
+            The shape out of which to construct identity quaternions.
         """
         data = np.zeros(shape + (4,))
         data[..., 0] = 1
@@ -527,7 +538,6 @@ class Rotation(Quaternion):
         ----------
         shape : int or tuple of int, optional
             The shape of the required object.
-
         """
         shape = (shape,) if isinstance(shape, int) else shape
         n = int(np.prod(shape))
@@ -540,21 +550,19 @@ class Rotation(Quaternion):
         return cls(np.array(rotations[:n])).reshape(*shape)
 
     @classmethod
-    def random_vonmises(cls, shape=(1,), alpha=1.0, reference=(1, 0, 0, 0), eps=1e-6):
-        """Random rotations with a simplified Von Mises-Fisher distribution.
+    def random_vonmises(cls, shape=(1,), alpha=1.0, reference=(1, 0, 0, 0)):
+        """Random rotations with a simplified Von Mises-Fisher
+        distribution.
 
         Parameters
         ----------
         shape : int or tuple of int, optional
             The shape of the required object.
         alpha : float
-            Parameter for the VM-F distribution. Lower values lead to "looser"
-            distributions.
+            Parameter for the VM-F distribution. Lower values lead to
+            "looser" distributions.
         reference : Rotation
             The center of the distribution.
-        eps : float
-            A small fixed variable.
-
         """
         shape = (shape,) if isinstance(shape, int) else shape
         reference = Rotation(reference)
@@ -586,21 +594,21 @@ def von_mises(x, alpha, reference=Rotation((1, 0, 0, 0))):
     x : Rotation
     alpha : float
         Lower values of alpha lead to "looser" distributions.
-    reference : Rotation
+    reference : Rotation, optional
 
     Notes
     -----
     This simplified version of the distribution is calculated using
 
-    .. math:: \\frac{\\exp\\left(2\\alpha\\cos\\left(\\omega\\right)\\right)}{_0F_1\\left(\\frac{N}{2}, \\alpha^2\\right)}
+    .. math::
+        \frac{\\exp\\left(2\alpha\\cos\\left(\omega\right)\right)}{\_0F\_1\left(\frac{N}{2}, \alpha^2\right)}
 
-    where :math:`\omega` is the angle between orientations and :math:`N` is the
-    number of relevant dimensions, in this case 3.
+    where :math:`\omega` is the angle between orientations and :math:`N`
+    is the number of relevant dimensions, in this case 3.
 
     Returns
     -------
-    ndarray
-
+    numpy.ndarray
     """
     angle = x.angle_with(reference)
     return np.exp(2 * alpha * np.cos(angle.data)) / hyp0f1(1.5, alpha ** 2)

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -352,8 +352,8 @@ class Rotation(Quaternion):
         euler = np.array(euler)
         if np.any(euler > 9):
             warnings.warn(
-                "Angles are assumed to be in radians, it appears you might instead be "
-                " using degrees"
+                "Angles are assumed to be in radians, but degrees might have been "
+                "passed"
             )
         n = euler.shape[:-1]
         alpha, beta, gamma = euler[..., 0], euler[..., 1], euler[..., 2]
@@ -587,7 +587,7 @@ class Rotation(Quaternion):
 
 
 def von_mises(x, alpha, reference=Rotation((1, 0, 0, 0))):
-    """A vastly simplified Von Mises-Fisher distribution calculation.
+    r"""A vastly simplified Von Mises-Fisher distribution calculation.
 
     Parameters
     ----------
@@ -601,7 +601,7 @@ def von_mises(x, alpha, reference=Rotation((1, 0, 0, 0))):
     This simplified version of the distribution is calculated using
 
     .. math::
-        \frac{\\exp\\left(2\alpha\\cos\\left(\omega\right)\right)}{\_0F\_1\left(\frac{N}{2}, \alpha^2\right)}
+        \frac{\exp\left(2\alpha\cos\left(\omega\right)\right)}{\_0F\_1\left(\frac{N}{2}, \alpha^2\right)}
 
     where :math:`\omega` is the angle between orientations and :math:`N`
     is the number of relevant dimensions, in this case 3.

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -670,12 +670,10 @@ class TestCrystalMapGetMapData:
     def test_get_boolean_array(self, crystal_map):
         xmap = crystal_map
 
-        assert np.issubdtype(xmap.get_map_data("is_indexed").dtype, np.bool_)
-        assert np.issubdtype(xmap.get_map_data(xmap.is_in_data).dtype, np.bool_)
+        assert np.issubdtype(xmap.get_map_data("is_indexed").dtype, bool)
+        assert np.issubdtype(xmap.get_map_data(xmap.is_in_data).dtype, bool)
 
-    @pytest.mark.parametrize(
-        "dtype_in", [np.uint8, np.int64, np.float32, np.float64, np.bool]
-    )
+    @pytest.mark.parametrize("dtype_in", [np.uint8, int, np.float32, float, bool])
     def test_preserve_dtype(self, crystal_map, dtype_in):
         xmap = crystal_map
         prop_name = "new_prop"
@@ -683,7 +681,7 @@ class TestCrystalMapGetMapData:
 
         assert xmap.get_map_data(prop_name).dtype == dtype_in
 
-    @pytest.mark.parametrize("dtype_in", [np.bool, np.int64])
+    @pytest.mark.parametrize("dtype_in", [bool, int])
     def test_not_preserve_dtype(self, crystal_map, dtype_in):
         xmap = crystal_map
         prop_name = "new_prop"
@@ -691,7 +689,7 @@ class TestCrystalMapGetMapData:
         xmap.is_in_data[0] = False
 
         assert not xmap.is_in_data.all()
-        assert xmap.get_map_data(prop_name, fill_value=None).dtype == np.float64
+        assert xmap.get_map_data(prop_name, fill_value=None).dtype == float
 
 
 class TestCrystalMapRepresentation:

--- a/orix/tests/test_rotation.py
+++ b/orix/tests/test_rotation.py
@@ -232,8 +232,8 @@ class TestToFromEuler:
 
     def test_passing_degrees_warns(self):
         with pytest.warns(UserWarning, match="Angles are assumed to be in radians, "):
-            r = Rotation.from_euler([90, 45, 90])
-            assert np.allclose(r.data, [0.3913, 0.4872, 0, 0.7807], atol=1e-4)
+            r = Rotation.from_euler([90, 0, 0])
+            assert np.allclose(r.data, [0.5253, 0, 0, -0.8509], atol=1e-4)
 
 
 @pytest.mark.parametrize(

--- a/orix/tests/test_rotation.py
+++ b/orix/tests/test_rotation.py
@@ -232,7 +232,7 @@ class TestToFromEuler:
 
     def test_passing_degrees_warns(self):
         with pytest.warns(UserWarning, match="Angles are assumed to be in radians, "):
-            r = Rotation.from_euler([90, 0, 0])
+            r = Rotation.from_euler([90, 0, 0], convention="bunge")
             assert np.allclose(r.data, [0.5253, 0, 0, -0.8509], atol=1e-4)
 
 

--- a/orix/tests/test_rotation.py
+++ b/orix/tests/test_rotation.py
@@ -190,52 +190,50 @@ def test_neg(rotation, i, expected_i):
     assert np.allclose(r.improper, expected_i)
 
 
-""" these tests address .to_euler() and .from_euler()"""
-
-
 @pytest.fixture()
 def e():
-    e = np.random.rand(10, 3)
-    return e
+    return np.random.rand(10, 3)
 
 
-def test_to_from_euler(e):
-    """ Checks that going euler2quat2euler gives no change """
-    r = Rotation.from_euler(e)
-    e2 = r.to_euler()
-    assert np.allclose(e.data, e2.data)
+class TestToFromEuler:
+    """These tests address .to_euler() and .from_euler()."""
 
+    def test_to_from_euler(self, e):
+        """Checks that going euler2quat2euler gives no change."""
+        r = Rotation.from_euler(e)
+        e2 = r.to_euler()
+        assert np.allclose(e, e2.data)
 
-def test_direction_kwarg(e):
-    r = Rotation.from_euler(e, direction="lab2crystal")
+    def test_direction_kwarg(self, e):
+        _ = Rotation.from_euler(e, direction="lab2crystal")
 
+    def test_Krakow_Hielscher(self, e):
+        _ = Rotation.from_euler(e, convention="Krakow_Hielscher")
 
-def test_Krakow_Hielscher(e):
-    r = Rotation.from_euler(e, convention="Krakow_Hielscher")
+    def test_direction_kwarg_dumb(self, e):
+        with pytest.raises(ValueError, match="The chosen direction is not one of "):
+            _ = Rotation.from_euler(e, direction="dumb_direction")
 
+    def test_unsupported_conv_to(self, e):
+        r = Rotation.from_euler(e)
+        with pytest.raises(ValueError, match="The chosen convention is not supported,"):
+            _ = r.to_euler(convention="unsupported")
 
-@pytest.mark.xfail()
-def test_direction_kwarg_dumb(e):
-    r = Rotation.from_euler(e, direction="dumb_direction")
+    def test_unsupported_conv_from(self, e):
+        with pytest.raises(ValueError, match="The chosen convention is not one of "):
+            _ = Rotation.from_euler(e, convention="unsupported")
 
+    def test_edge_cases_to_euler(self):
+        x = np.sqrt(1 / 2)
+        q = Rotation(np.asarray([x, 0, 0, x]))
+        _ = q.to_euler()
+        q = Rotation(np.asarray([0, x, 0, 0]))
+        _ = q.to_euler()
 
-@pytest.mark.xfail()
-def test_unsupported_conv_to(e):
-    r = Rotation.from_euler(e)
-    r.to_euler(convention="unsupported")
-
-
-@pytest.mark.xfail()
-def test_unsupported_conv_from(e):
-    r = Rotation.from_euler(e, convention="unsupported")
-
-
-def test_edge_cases_to_euler():
-    x = np.sqrt(1 / 2)
-    q = Rotation(np.asarray([x, 0, 0, x]))
-    e = q.to_euler()
-    q = Rotation(np.asarray([0, x, 0, 0]))
-    e = q.to_euler()
+    def test_passing_degrees_warns(self):
+        with pytest.warns(UserWarning, match="Angles are assumed to be in radians, "):
+            r = Rotation.from_euler([90, 45, 90])
+            assert np.allclose(r.data, [0.3913, 0.4872, 0, 0.7807], atol=1e-4)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### Description of the change
* Address #168. I chose to raise the warning when any of the Euler angle values are above 9, which is [what MTEX does](https://github.com/mtex-toolbox/mtex/blob/afa615d1481174155b434a9d259afd6b1eea732e/geometry/geometry_tools/euler2quat.m#L44).
* Also touched up docstrings in `rotation.py` and in some tests.

Close #168.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> from orix.quaternion import Rotation
>>> r = Rotation.from_euler([90, 45, 90])
/home/hakon/kode/orix/orix/quaternion/rotation.py:354: UserWarning: Angles are assumed to be in radians, but degrees might have been passed
  warnings.warn(
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
