### PR TITLE
Allow passing a symmetry when initializing an Orientation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Unreleased
 
 Added
 -----
-- Initialization of Orientation from Euler angles and a point group symmetry.
+- Passing symmetry when initializing an Orientation.
 - Vector3d.scatter() and Vector3d.draw_circle() methods to show unit vectors and
   great/small circles in stereographic projection
 - User guide with Jupyter notebooks as part of the Read the Docs documentation

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Unreleased
 
 Added
 -----
+- Initialization of Orientation from Euler angles and a point group symmetry.
 - Vector3d.scatter() and Vector3d.draw_circle() methods to show unit vectors and
   great/small circles in stereographic projection
 - User guide with Jupyter notebooks as part of the Read the Docs documentation

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -18,12 +18,14 @@
 
 """Rotations respecting symmetry.
 
-An orientation is simply a rotation with respect to some reference frame. In
-this respect, an orientation is in fact a *misorientation* - a change of
-orientation - with respect to a reference of the identity rotation.
+An orientation is simply a rotation with respect to some reference
+frame. In this respect, an orientation is in fact a *misorientation* -
+a change of orientation - with respect to a reference of the identity
+rotation.
 
-In orix, orientations and misorientations are distinguished from rotations
-only by the inclusion of a notion of symmetry. Consider the following example:
+In orix, orientations and misorientations are distinguished from
+rotations only by the inclusion of a notion of symmetry. Consider the
+following example:
 
 .. image:: /_static/img/orientation.png
    :width: 200px
@@ -31,30 +33,29 @@ only by the inclusion of a notion of symmetry. Consider the following example:
          fourfold symmetry, has the same orientation in both cases.
    :align: center
 
-Both objects have undergone the same *rotations* with respect to the reference.
-However, because the square has fourfold symmetry, it is indistinguishable
-in both cases, and hence has the same orientation.
+Both objects have undergone the same *rotations* with respect to the
+reference. However, because the square has fourfold symmetry, it is
+indistinguishable in both cases, and hence has the same orientation.
 """
 
 from itertools import product as iproduct
 from itertools import combinations_with_replacement as icombinations
+
 import numpy as np
-import warnings
 from tqdm import tqdm
 
-
+from orix.quaternion.orientation_region import OrientationRegion
 from orix.quaternion.rotation import Rotation
 from orix.quaternion.symmetry import C1
-from orix.quaternion.orientation_region import OrientationRegion
 
 
 def _distance(misorientation, verbose, split_size=100):
-    """ private function to find the symmetry reduced distance between all
-    pairs of (mis)orientations
+    """Private function to find the symmetry reduced distance between
+    all pairs of (mis)orientations
 
     Parameters
     ----------
-    misorientation : orix.Misorientation object
+    misorientation : orix.quaternion.Misorientation
         The misorientation to be considered.
     verbose : bool
         Output progress bar while computing.
@@ -63,7 +64,7 @@ def _distance(misorientation, verbose, split_size=100):
 
     Returns
     -------
-    distance : np.array
+    distance : numpy.ndarray
         2D matrix containing the angular distance between every
         orientation, considering symmetries.
     """
@@ -105,37 +106,37 @@ def _distance(misorientation, verbose, split_size=100):
 
 
 class Misorientation(Rotation):
-    """Misorientation object.
+    r"""Misorientation object.
 
     Misorientations represent transformations from one orientation,
     :math:`o_1` to another, :math:`o_2`: :math:`o_2 \\cdot o_1^{-1}`.
 
-    They have symmetries associated with each of the starting orientations.
-
+    They have symmetries associated with each of the starting
+    orientations.
     """
 
     _symmetry = (C1, C1)
 
     def __getitem__(self, key):
-        m = super(Misorientation, self).__getitem__(key)
+        m = super().__getitem__(key)
         m._symmetry = self._symmetry
         return m
 
     @property
     def symmetry(self):
-        """tuple of Symmetry"""
+        """Tuple of Symmetry"""
         return self._symmetry
 
     def equivalent(self, grain_exchange=False):
         """Equivalent misorientations
 
         grain_exchange : bool
-            If true the rotation g and g^{-1} are considered to be identical
+            If True the rotation g and g^{-1} are considered to be
+            identical. Default is False.
 
         Returns
         -------
         Misorientation
-
         """
         Gl, Gr = self._symmetry
 
@@ -150,8 +151,8 @@ class Misorientation(Rotation):
     def set_symmetry(self, Gl, Gr, verbose=False):
         """Assign symmetries to this misorientation.
 
-        Computes equivalent transformations which have the smallest angle of
-        rotation and assigns these in-place.
+        Computes equivalent transformations which have the smallest
+        angle of rotation and assigns these in-place.
 
         Parameters
         ----------
@@ -171,7 +172,6 @@ class Misorientation(Rotation):
         Misorientation (2,) 4, 2
         [[-0.7071  0.7071  0.      0.    ]
         [ 0.      1.      0.      0.    ]]
-
         """
         symmetry_pairs = iproduct(Gl, Gr)
         if verbose:
@@ -192,19 +192,19 @@ class Misorientation(Rotation):
     def distance(self, verbose=False, split_size=100):
         """Symmetry reduced distance
 
-        Compute the shortest distance between all orientations considering
-        symmetries.
+        Compute the shortest distance between all orientations
+        considering symmetries.
 
         Parameters
         ---------
         verbose : bool
-            Output progress bar while computing.
+            Output progress bar while computing. Default is False.
         split_size : int
-            Size of block to compute at a time.
+            Size of block to compute at a time. Default is 100.
 
         Returns
         -------
-        distance : np.array
+        distance : numpy.ndarray
             2D matrix containing the angular distance between every
             orientation, considering symmetries.
 
@@ -223,6 +223,7 @@ class Misorientation(Rotation):
         return distance.reshape(self.shape + self.shape)
 
     def __repr__(self):
+        """String representation."""
         cls = self.__class__.__name__
         shape = str(self.shape)
         s1, s2 = self._symmetry[0].name, self._symmetry[1].name
@@ -234,27 +235,33 @@ class Misorientation(Rotation):
 
 
 class Orientation(Misorientation):
-    """Orientation object.
+    """Orientations represent misorientations away from a reference of
+    identity and have only one associated symmetry.
 
-    Orientations represent misorientations away from a reference of identity
-    and have only one associated symmetry.
-
-    Orientations support binary subtraction, producing a misorientation. That
-    is, to compute the misorientation from :math:`o_1` to :math:`o_2`,
-    call :code:`o_2 - o_1`.
-
+    Orientations support binary subtraction, producing a misorientation.
+    That is, to compute the misorientation from :math:`o_1` to
+    :math:`o_2`, call :code:`o_2 - o_1`.
     """
+
+    @classmethod
+    def from_euler(
+        cls, euler, symmetry=None, convention="bunge", direction="crystal2lab"
+    ):
+        o = super().from_euler(euler=euler, convention=convention, direction=direction)
+        if symmetry:
+            o = o.set_symmetry(symmetry)
+        return o
 
     @property
     def symmetry(self):
-        """Symmetry"""
+        """Symmetry."""
         return self._symmetry[1]
 
     def set_symmetry(self, symmetry):
         """Assign a symmetry to this orientation.
 
-        Computes equivalent transformations which have the smallest angle of
-        rotation and assigns these in-place.
+        Computes equivalent transformations which have the smallest
+        angle of rotation and assigns these in-place.
 
         Parameters
         ----------
@@ -274,9 +281,8 @@ class Orientation(Misorientation):
         Orientation (2,) 4
         [[-0.7071  0.     -0.7071  0.    ]
         [ 0.      1.      0.      0.    ]]
-
         """
-        return super(Orientation, self).set_symmetry(C1, symmetry)
+        return super().set_symmetry(C1, symmetry)
 
     def __sub__(self, other):
         if isinstance(other, Orientation):

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -247,7 +247,57 @@ class Orientation(Misorientation):
     def from_euler(
         cls, euler, symmetry=None, convention="bunge", direction="crystal2lab"
     ):
+        """Creates orientation(s) from an array of Euler angles.
+
+        Parameters
+        ----------
+        euler : array-like
+            Euler angles in the Bunge convention.
+        symmetry : Symmetry, optional
+            Symmetry of orientation(s). If None (default), no symmetry
+            is set.
+        convention : str
+            Only 'bunge' is currently supported for new data
+        direction : str
+            'lab2crystal' or 'crystal2lab'
+        """
         o = super().from_euler(euler=euler, convention=convention, direction=direction)
+        if symmetry:
+            o = o.set_symmetry(symmetry)
+        return o
+
+    @classmethod
+    def from_matrix(cls, matrix, symmetry=None):
+        """Creates orientation(s) from orientation matrices
+        [Rowenhorst2015]_.
+
+        Parameters
+        ----------
+        matrix : array_like
+            Array of orientation matrices.
+        symmetry : Symmetry, optional
+            Symmetry of orientation(s). If None (default), no symmetry
+            is set.
+        """
+        o = super().from_matrix(matrix)
+        if symmetry:
+            o = o.set_symmetry(symmetry)
+        return o
+
+    @classmethod
+    def from_neo_euler(cls, neo_euler, symmetry=None):
+        """Creates orientation(s) from a neo-euler (vector)
+        representation.
+
+        Parameters
+        ----------
+        neo_euler : NeoEuler
+            Vector parametrization of orientation(s).
+        symmetry : Symmetry, optional
+            Symmetry of orientation(s). If None (default), no symmetry
+            is set.
+        """
+        o = super().from_neo_euler(neo_euler)
         if symmetry:
             o = o.set_symmetry(symmetry)
         return o

--- a/orix/tests/test_orientation.py
+++ b/orix/tests/test_orientation.py
@@ -1,8 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2021 the orix developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
 import numpy as np
 import pytest
 
 from orix.quaternion.orientation import Orientation, Misorientation
-from orix.quaternion.symmetry import C1, C2, C3, C4, D2, D3, D6, T, O
+from orix.quaternion.symmetry import C1, C2, C3, C4, D2, D3, D6, T, O, Oh
 from orix.vector import Vector3d
 
 
@@ -106,18 +124,28 @@ def test_equivalent(Gl):
 
 def test_repr():
     m = Misorientation([1, 1, 1, 1])  # any will do
-    print(m)  # hits __repr__
-    return None
+    _ = repr(m)
 
 
 def test_sub():
     m = Orientation([1, 1, 1, 1])  # any will do
     m.set_symmetry(C4)  # only one as it a O
-    _ = m - m  # this should give a set of zeroes
-    return None
+    assert np.allclose((m - m).data, [1, 0, 0, 0])
 
 
-@pytest.mark.xfail(strict=True, reason=TypeError)
 def test_sub_orientation_and_other():
     m = Orientation([1, 1, 1, 1])  # any will do
-    _ = m - 3
+    with pytest.raises(TypeError):
+        _ = m - 3
+
+
+def test_from_euler_symmetry():
+    euler = np.deg2rad([90, 45, 90])
+    o1 = Orientation.from_euler(euler)
+    assert np.allclose(o1.data, [0, -0.3827, 0, -0.9239], atol=1e-4)
+    assert o1.symmetry.name == "1"
+    o2 = Orientation.from_euler(euler, symmetry=Oh)
+    assert np.allclose(o2.data, [0.9239, 0, 0.3827, 0], atol=1e-4)
+    assert o2.symmetry.name == "m-3m"
+    o3 = o1.set_symmetry(Oh)
+    assert np.allclose(o3.data, o2.data)


### PR DESCRIPTION
#### Description of the change
* Allow passing a `orix.quaternion.Symmetry` to `Orientation.from_euler()`, `Orientation.from_matrix()`, and `Orientation.from_neo_euler()`.
* Also touched up some docstrings and added some explanations of defaults.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
I find it cumbersome to do

```python
>>> import numpy as np
>>> from orix.quaternion import Orientation
>>> from orix.quaternion.symmetry import Oh
>>> o1 = Orientation.from_euler(np.deg2rad([90, 45, 90])
>>> o1 = o1.set_symmetry(Oh)
>>> o1
Orientation (1,) 1, m-3m
[[0.9239 0.     0.3827 0.    ]]
```
instead of just

```python
>>> o2 = Orientation.from_euler(np.deg2rad([90, 45, 90]), symmetry=Oh)
>>> o2
Orientation (1,) 1, m-3m
[[0.9239 0.     0.3827 0.    ]]
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
