### PR TITLE
Improving the performance of the samplings utils (see #175)

### DIFF
--- a/orix/sampling/SO3_sampling.py
+++ b/orix/sampling/SO3_sampling.py
@@ -95,8 +95,14 @@ def _three_uniform_samples_method(resolution, max_angle):
         e_1_min = np.cos(np.deg2rad(max_angle / 2))
         u_1_max = 1 - np.square(e_1_min)
         u_2_min = np.arcsin(e_1_min) / 2 / np.pi
-        u_1 = np.linspace(0, u_1_max, num=int(num_steps * (u_1_max)), endpoint=True)
-        u_2 = np.linspace(u_2_min, 1, num=int(num_steps * (1 - u_2_min)), endpoint=True)
+
+        # avoids the zero selection
+        num_1 = int(num_steps * (u_1_max)) if int(num_steps * (u_1_max)) > 1 else 2
+        num_2 = int(num_steps * (1 - u_2_min)) if int(num_steps * (1 - u_2_min)) > 1 else 2
+
+
+        u_1 = np.linspace(0, u_1_max, num=num_1, endpoint=True)
+        u_2 = np.linspace(u_2_min, 1, num=num_2, endpoint=True)
 
     u_3 = np.linspace(0, 1, num=num_steps, endpoint=True)
 

--- a/orix/sampling/SO3_sampling.py
+++ b/orix/sampling/SO3_sampling.py
@@ -98,8 +98,9 @@ def _three_uniform_samples_method(resolution, max_angle):
 
         # avoids the zero selection
         num_1 = int(num_steps * (u_1_max)) if int(num_steps * (u_1_max)) > 1 else 2
-        num_2 = int(num_steps * (1 - u_2_min)) if int(num_steps * (1 - u_2_min)) > 1 else 2
-
+        num_2 = (
+            int(num_steps * (1 - u_2_min)) if int(num_steps * (1 - u_2_min)) > 1 else 2
+        )
 
         u_1 = np.linspace(0, u_1_max, num=num_1, endpoint=True)
         u_2 = np.linspace(u_2_min, 1, num=num_2, endpoint=True)

--- a/orix/sampling/SO3_sampling.py
+++ b/orix/sampling/SO3_sampling.py
@@ -115,7 +115,7 @@ def _three_uniform_samples_method(resolution,max_angle):
 
     # remove duplicates
     q = q.unique()
-    
+
     return q
 
 def _euler_angles_harr_measure(resolution):

--- a/orix/sampling/SO3_sampling.py
+++ b/orix/sampling/SO3_sampling.py
@@ -59,7 +59,7 @@ def uniform_SO3_sample(resolution, max_angle=None, old_method=False):
 def _three_uniform_samples_method(resolution, max_angle):
     """
     Returns rotations that are evenly spaced according to the Haar measure on
-    SO3, the advantage of this method is that it select values from uniform distributions
+    SO3, the advantage of this method is that it selects values from uniform distributions
     so we can more easily restrict to a subregion of SO3
 
     Parameters
@@ -131,7 +131,7 @@ def _euler_angles_harr_measure(resolution):
     ----------
     resolution : float
         The characteristic distance between a rotation and its neighbour (degrees)
-        
+
     Returns
     -------
     q : orix.quaternion.rotation.Rotation

--- a/orix/sampling/SO3_sampling.py
+++ b/orix/sampling/SO3_sampling.py
@@ -24,7 +24,7 @@ import numpy as np
 from orix.quaternion.rotation import Rotation
 
 
-def uniform_SO3_sample(resolution,max_angle=None,old_method=False):
+def uniform_SO3_sample(resolution, max_angle=None, old_method=False):
     """
     Returns rotations that are evenly spaced according to the Haar measure on
     SO3
@@ -37,6 +37,7 @@ def uniform_SO3_sample(resolution,max_angle=None,old_method=False):
         The max angle (ie. distance from the origin) required from the gridding, (degrees)
     old_method : False
         Use the implementation adopted prior to version 0.6, offered for compatibility
+
     Returns
     -------
     q : orix.quaternion.rotation.Rotation
@@ -52,9 +53,10 @@ def uniform_SO3_sample(resolution,max_angle=None,old_method=False):
     if old_method:
         return _euler_angles_harr_measure(resolution)
     else:
-        return _three_uniform_samples_method(resolution,max_angle)
+        return _three_uniform_samples_method(resolution, max_angle)
 
-def _three_uniform_samples_method(resolution,max_angle):
+
+def _three_uniform_samples_method(resolution, max_angle):
     """
     Returns rotations that are evenly spaced according to the Haar measure on
     SO3, the advantage of this method is that it select values from uniform distributions
@@ -66,6 +68,7 @@ def _three_uniform_samples_method(resolution,max_angle):
         The characteristic distance between a rotation and its neighbour (degrees)
     max_angle : float
         The max angle (ie. distance from the origin) required from the gridding, (degrees)
+
     Returns
     -------
     q : orix.quaternion.rotation.Rotation
@@ -85,38 +88,39 @@ def _three_uniform_samples_method(resolution,max_angle):
     # sources can be found in the discussion of issue #175
 
     if max_angle is None:
-        u_1 = np.linspace(0,1,num=num_steps,endpoint=True)
-        u_2 = np.linspace(0,1,num=num_steps,endpoint=True)
+        u_1 = np.linspace(0, 1, num=num_steps, endpoint=True)
+        u_2 = np.linspace(0, 1, num=num_steps, endpoint=True)
     else:
         # e_1 = cos(omega/2) = np.sqrt(1-u_1) * np.sin(2*np.pi*u2)
-        e_1_min = np.cos(np.deg2rad(max_angle/2))
+        e_1_min = np.cos(np.deg2rad(max_angle / 2))
         u_1_max = 1 - np.square(e_1_min)
         u_2_min = np.arcsin(e_1_min) / 2 / np.pi
-        u_1 = np.linspace(0,u_1_max,num=int(num_steps*(u_1_max)),endpoint=True)
-        u_2 = np.linspace(u_2_min,1,num=int(num_steps*(1-u_2_min)),endpoint=True)
+        u_1 = np.linspace(0, u_1_max, num=int(num_steps * (u_1_max)), endpoint=True)
+        u_2 = np.linspace(u_2_min, 1, num=int(num_steps * (1 - u_2_min)), endpoint=True)
 
-    u_3 = np.linspace(0,1,num=num_steps,endpoint=True)
+    u_3 = np.linspace(0, 1, num=num_steps, endpoint=True)
 
-    inputs = np.meshgrid(u_1,u_2,u_3)
+    inputs = np.meshgrid(u_1, u_2, u_3)
     mesh1 = inputs[0].flatten()
     mesh2 = inputs[1].flatten()
     mesh3 = inputs[2].flatten()
 
     # Convert u_1 etc. into the final form used
-    a = np.sqrt(1-mesh1)
+    a = np.sqrt(1 - mesh1)
     b = np.sqrt(mesh1)
-    s_2,c_2 = np.sin(2*np.pi*mesh2),np.cos(2*np.pi*mesh2)
-    s_3,c_3 = np.sin(2*np.pi*mesh3),np.cos(2*np.pi*mesh3)
+    s_2, c_2 = np.sin(2 * np.pi * mesh2), np.cos(2 * np.pi * mesh2)
+    s_3, c_3 = np.sin(2 * np.pi * mesh3), np.cos(2 * np.pi * mesh3)
 
-    q = np.asarray([a*s_2,a*c_2,b*s_3,b*c_3])
+    q = np.asarray([a * s_2, a * c_2, b * s_3, b * c_3])
 
-    #convert to Rotation object
+    # convert to Rotation object
     q = Rotation(q.T)
 
     # remove duplicates
     q = q.unique()
 
     return q
+
 
 def _euler_angles_harr_measure(resolution):
     """
@@ -127,6 +131,7 @@ def _euler_angles_harr_measure(resolution):
     ----------
     resolution : float
         The characteristic distance between a rotation and its neighbour (degrees)
+        
     Returns
     -------
     q : orix.quaternion.rotation.Rotation

--- a/orix/sampling/SO3_sampling.py
+++ b/orix/sampling/SO3_sampling.py
@@ -110,8 +110,8 @@ def _three_uniform_samples_method(resolution,max_angle):
 
     q = np.asarray([a*s_2,a*c_2,b*s_3,b*c_3])
 
-    #convert to quaternion object
-    q = Quaternion(q)
+    #convert to Rotation object
+    q = Rotation(q.T)
 
     # remove duplicates
     q = q.unique()

--- a/orix/sampling/__init__.py
+++ b/orix/sampling/__init__.py
@@ -19,7 +19,7 @@
 """Module for generating grids in orientation spaces."""
 
 from orix.sampling.sample_generators import get_sample_fundamental, get_sample_local
-from orix.sampling.sampling_utils import uniform_SO3_sample
+from orix.sampling.SO3_sampling import uniform_SO3_sample
 
 # Lists what will be imported when calling "from orix.sampling import *"
 __all__ = [

--- a/orix/sampling/sample_generators.py
+++ b/orix/sampling/sample_generators.py
@@ -53,7 +53,7 @@ def get_sample_fundamental(resolution=2, point_group=None, space_group=None):
     if point_group is None:
         point_group = get_point_group(space_group, proper=True)
 
-    #TODO: provide some subspace selection options
+    # TODO: provide some subspace selection options
     q = uniform_SO3_sample(resolution)
     fundamental_region = OrientationRegion.from_symmetry(point_group)
     return q[q < fundamental_region]
@@ -82,7 +82,7 @@ def get_sample_local(resolution=2, center=None, grid_width=10):
     orix.sampling_utils.uniform_SO3_sample
     """
 
-    q = uniform_SO3_sample(resolution,max_angle=grid_width)
+    q = uniform_SO3_sample(resolution, max_angle=grid_width)
 
     # this block may now be redundant
     half_angle = np.deg2rad(grid_width / 2)

--- a/orix/sampling/sample_generators.py
+++ b/orix/sampling/sample_generators.py
@@ -83,6 +83,8 @@ def get_sample_local(resolution=2, center=None, grid_width=10):
     """
 
     q = uniform_SO3_sample(resolution,max_angle=grid_width)
+
+    # this block may now be redundant
     half_angle = np.deg2rad(grid_width / 2)
     half_angles = np.arccos(q.a.data)
     mask = np.logical_or(

--- a/orix/sampling/sample_generators.py
+++ b/orix/sampling/sample_generators.py
@@ -18,7 +18,7 @@
 
 import numpy as np
 
-from orix.sampling.sampling_utils import uniform_SO3_sample
+from orix.sampling.SO3_sampling import uniform_SO3_sample
 from orix.quaternion.orientation_region import OrientationRegion
 from orix.quaternion.symmetry import get_point_group
 

--- a/orix/sampling/sample_generators.py
+++ b/orix/sampling/sample_generators.py
@@ -53,6 +53,7 @@ def get_sample_fundamental(resolution=2, point_group=None, space_group=None):
     if point_group is None:
         point_group = get_point_group(space_group, proper=True)
 
+    #TODO: provide some subspace selection options
     q = uniform_SO3_sample(resolution)
     fundamental_region = OrientationRegion.from_symmetry(point_group)
     return q[q < fundamental_region]
@@ -81,7 +82,7 @@ def get_sample_local(resolution=2, center=None, grid_width=10):
     orix.sampling_utils.uniform_SO3_sample
     """
 
-    q = uniform_SO3_sample(resolution)
+    q = uniform_SO3_sample(resolution,max_angle=grid_width)
     half_angle = np.deg2rad(grid_width / 2)
     half_angles = np.arccos(q.a.data)
     mask = np.logical_or(

--- a/orix/sampling/sampling_utils.py
+++ b/orix/sampling/sampling_utils.py
@@ -24,7 +24,7 @@ import numpy as np
 from orix.quaternion.rotation import Rotation
 
 
-def uniform_SO3_sample(resolution):
+def uniform_SO3_sample(resolution,max_angle=None,old_method=False):
     """
     Returns rotations that are evenly spaced according to the Haar measure on
     SO3
@@ -33,24 +33,67 @@ def uniform_SO3_sample(resolution):
     ----------
     resolution : float
         The characteristic distance between a rotation and its neighbour (degrees)
-
+    max_angle : float
+        The max angle (ie. distance from the origin) required from the gridding, (degrees)
+    old_method : False
+        Use the implementation adopted prior to version 0.6, offered for compatibility
     Returns
     -------
     q : orix.quaternion.rotation.Rotation
         grid containing appropriate rotations
+
+    See Also
+    --------
+    orix.sample_generators.get_local_grid
     """
+    if max_angle is not None and old_method:
+        raise ValueError("old_method=True does not support using the max_angle keyword")
+    #TODO: think more carefully about what resolution should mean
+
     num_steps = int(np.ceil(360 / resolution))
     if num_steps % 2 == 1:
         num_steps = int(num_steps + 1)
     half_steps = int(num_steps / 2)
 
-    alpha = np.linspace(0, 2 * np.pi, num=num_steps, endpoint=False)
-    beta = np.arccos(np.linspace(1, -1, num=half_steps, endpoint=False))
-    gamma = np.linspace(0, 2 * np.pi, num=num_steps, endpoint=False)
-    q = np.array(np.meshgrid(alpha, beta, gamma)).T.reshape((-1, 3))
+    if not old_method:
+        # sources can be found in the discussion of issue #175
+        u_3 = np.linspace(0,1,num=num_steps,endpoint=True)
 
-    # convert to quaternions
-    q = Rotation.from_euler(q, convention="bunge", direction="crystal2lab")
+        if max_angle is None:
+            u_1 = np.linspace(0,1,num=num_steps,endpoint=True)
+            u_2 = np.linspace(0,1,num=num_steps,endpoint=True)
+        else:
+            # e_1 = cos(omega/2) = np.sqrt(1-u_1) * np.sin(2*np.pi*u2)
+            e_1_max = np.cos(np.deg2rad(max_angle/2))
+            u_1_max = 1 - np.square(e_1_max)
+            u_2_max = np.arcsin(e_1_max) / 2 / np.pi
+            u_1 = np.linspace(0,u_1_max,num=int(num_steps*u_1_max),endpoint=True)
+            u_2 = np.linspace(0,u_2_max,num=int(num_steps*u_2_max),endpoint=True)
+
+        # eyeballed this, will need checking
+        inputs = np.meshgrid(u_1,u_2,u_3)
+
+        # Convert u_1 etc. into the final form used
+        a = np.sqrt(1-inputs[:,0])
+        b = np.sqrt(inputs[:,0])
+        s_2,c_2 = np.sin(2*np.pi*inputs[:,1]),np.cos(2*np.pi*inputs[:,1])
+        s_3,c_3 = np.sin(2*np.pi*inputs[:,2]),np.cos(2*np.pi*inputs[:,2])
+
+        q = np.asarray([a*s_2,a*c_2,b*s_3,b*c_3])
+
+        # convert to quaternion object
+        # remove duplicates
+
+    if old_method:
+        alpha = np.linspace(0, 2 * np.pi, num=num_steps, endpoint=False)
+        beta = np.arccos(np.linspace(1, -1, num=half_steps, endpoint=False))
+        gamma = np.linspace(0, 2 * np.pi, num=num_steps, endpoint=False)
+        q = np.array(np.meshgrid(alpha, beta, gamma)).T.reshape((-1, 3))
+
+        # convert to quaternions
+        q = Rotation.from_euler(q, convention="bunge", direction="crystal2lab")
+
     # remove duplicates
     q = q.unique()
+
     return q

--- a/orix/sampling/sampling_utils.py
+++ b/orix/sampling/sampling_utils.py
@@ -79,7 +79,7 @@ def _three_uniform_samples_method(resolution,max_angle):
 
     [1] - http://planning.cs.uiuc.edu/node198.html
     [2] - http://inis.jinr.ru/sl/vol1/CMC/Graphics_Gems_3,ed_D.Kirk.pdf
-    [3] - K. Shoemake. Uniform random rotations. Graphics Gems III, pages 124-132. Academic, New York, 1992. 
+    [3] - K. Shoemake. Uniform random rotations. Graphics Gems III, pages 124-132. Academic, New York, 1992.
     """
     num_steps = int(np.ceil(360 / resolution))
     # sources can be found in the discussion of issue #175
@@ -111,7 +111,11 @@ def _three_uniform_samples_method(resolution,max_angle):
     q = np.asarray([a*s_2,a*c_2,b*s_3,b*c_3])
 
     #convert to quaternion object
+    q = Quaternion(q)
+
     # remove duplicates
+    q = q.unique()
+    
     return q
 
 def _euler_angles_harr_measure(resolution):

--- a/orix/sampling/sampling_utils.py
+++ b/orix/sampling/sampling_utils.py
@@ -51,9 +51,7 @@ def uniform_SO3_sample(resolution,max_angle=None,old_method=False):
     #TODO: think more carefully about what resolution should mean
 
     num_steps = int(np.ceil(360 / resolution))
-    if num_steps % 2 == 1:
-        num_steps = int(num_steps + 1)
-    half_steps = int(num_steps / 2)
+
 
     if not old_method:
         # sources can be found in the discussion of issue #175
@@ -64,27 +62,34 @@ def uniform_SO3_sample(resolution,max_angle=None,old_method=False):
             u_2 = np.linspace(0,1,num=num_steps,endpoint=True)
         else:
             # e_1 = cos(omega/2) = np.sqrt(1-u_1) * np.sin(2*np.pi*u2)
-            e_1_max = np.cos(np.deg2rad(max_angle/2))
-            u_1_max = 1 - np.square(e_1_max)
-            u_2_max = np.arcsin(e_1_max) / 2 / np.pi
-            u_1 = np.linspace(0,u_1_max,num=int(num_steps*u_1_max),endpoint=True)
-            u_2 = np.linspace(0,u_2_max,num=int(num_steps*u_2_max),endpoint=True)
+            e_1_min = np.cos(np.deg2rad(max_angle/2))
+            u_1_max = 1 - np.square(e_1_min)
+            u_2_min = np.arcsin(e_1_min) / 2 / np.pi
+            u_1 = np.linspace(0,u_1_max,num=int(num_steps*(u_1_max)),endpoint=True)
+            u_2 = np.linspace(u_2_min,1,num=int(num_steps*(1-u_2_min)),endpoint=True)
 
-        # eyeballed this, will need checking
         inputs = np.meshgrid(u_1,u_2,u_3)
+        mesh1 = inputs[0].flatten()
+        mesh2 = inputs[1].flatten()
+        mesh3 = inputs[2].flatten()
 
         # Convert u_1 etc. into the final form used
-        a = np.sqrt(1-inputs[:,0])
-        b = np.sqrt(inputs[:,0])
-        s_2,c_2 = np.sin(2*np.pi*inputs[:,1]),np.cos(2*np.pi*inputs[:,1])
-        s_3,c_3 = np.sin(2*np.pi*inputs[:,2]),np.cos(2*np.pi*inputs[:,2])
+        a = np.sqrt(1-mesh1)
+        b = np.sqrt(mesh1)
+        s_2,c_2 = np.sin(2*np.pi*mesh2),np.cos(2*np.pi*mesh2)
+        s_3,c_3 = np.sin(2*np.pi*mesh3),np.cos(2*np.pi*mesh3)
 
         q = np.asarray([a*s_2,a*c_2,b*s_3,b*c_3])
 
-        # convert to quaternion object
+        #convert to quaternion object
         # remove duplicates
-
+        
     if old_method:
+        if num_steps % 2 == 1:
+            num_steps = int(num_steps + 1)
+
+        half_steps = int(num_steps / 2)
+
         alpha = np.linspace(0, 2 * np.pi, num=num_steps, endpoint=False)
         beta = np.arccos(np.linspace(1, -1, num=half_steps, endpoint=False))
         gamma = np.linspace(0, 2 * np.pi, num=num_steps, endpoint=False)

--- a/orix/tests/test_sampling.py
+++ b/orix/tests/test_sampling.py
@@ -38,7 +38,7 @@ def fr():
     return r
 
 def test_old_method():
-    _ = uniform_SO3_sample(5,old_method=True)
+    _ = uniform_SO3_sample(5.1,old_method=True)
 
 def test_old_method_max_angle():
     with pytest.raises(ValueError):

--- a/orix/tests/test_sampling.py
+++ b/orix/tests/test_sampling.py
@@ -41,7 +41,7 @@ def test_old_method():
     _ = uniform_SO3_sample(5,old_method=True)
 
 def test_old_method_max_angle():
-    with pytest.raise ValueError:
+    with pytest.raises(ValueError):
         _ = uniform_SO3_sample(5,old_method=True,max_angle=12)
 
 def test_uniform_SO3_sample_regions(sample, fr):

--- a/orix/tests/test_sampling.py
+++ b/orix/tests/test_sampling.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from orix.quaternion.rotation import Rotation
 from orix.quaternion.symmetry import C2, C6, D6, get_point_group
-from orix.sampling.sampling_utils import uniform_SO3_sample
+from orix.sampling.SO3_sampling import uniform_SO3_sample
 from orix.sampling.sample_generators import get_sample_fundamental, get_sample_local
 
 
@@ -37,6 +37,8 @@ def fr():
     r = Rotation([0.5, 0.5, 0, 0])
     return r
 
+def test_old_method():
+    _ = uniform_SO3_sample(5,old_method=True)
 
 def test_uniform_SO3_sample_regions(sample, fr):
     """ Checks that different regions have the same density"""

--- a/orix/tests/test_sampling.py
+++ b/orix/tests/test_sampling.py
@@ -40,6 +40,10 @@ def fr():
 def test_old_method():
     _ = uniform_SO3_sample(5,old_method=True)
 
+def test_old_method_max_angle():
+    with pytest.raise ValueError:
+        _ = uniform_SO3_sample(5,old_method=True,max_angle=12)
+
 def test_uniform_SO3_sample_regions(sample, fr):
     """ Checks that different regions have the same density"""
     around_zero = sample[sample.a > 0.9]


### PR DESCRIPTION
#### Description of the change
Improving the performance of the gridding utils by allowing a uniform sampling of a subspace (see #175 for details). I've also renamed a file to be more consistent with what I imagine this part of the code will look like in the future.


#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [ ] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
