### PR TITLE
Explicitly state support for Python 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8]
+        python-version: [3.8, 3.9]
+        include:
+          # Oldest supported version of main dependencies on Python 3.6
+          - os: ubuntu-latest
+            python-version: 3.6
+            OLDEST_SUPPORTED_VERSION: true
+            DEPENDENCIES: diffpy.structure==3  matplotlib==3.3
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -25,6 +31,9 @@ jobs:
       - name: Install depedencies and package
         shell: bash
         run: pip install -U -e .'[doc, tests]'
+      - name: Install oldest supported version
+        if: ${{ matrix.OLDEST_SUPPORTED_VERSION }}
+        run: pip install ${{ matrix.DEPENDENCIES }}
       - name: Run tests
         run: pytest --cov=orix --pyargs orix
       - name: Generate line coverage

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Unreleased
 
 Added
 -----
+- Python 3.9 support.
 - Miller class, inherinting functionality from the Vector3d class, to handle operations
   with direct lattice vectors (uvw/UVTW) and reciprocal lattice vectors (hkl/hkil).
 - Warning when trying to create rotations from large Euler angles

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
* Update setup.py to reflect Python 3.9 support.
* Update build matrix to use Python 3.8 and 3.9, with an extra step on Ubuntu checking Python 3.6 and minimal package versions.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
