### PR TITLE
Fix reading of point group symmetries from EMsoft h5ebsd dot product file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,10 @@ Changed
 - CrystalMap.get_map_data() tries to respect input data type, other minor improvements
 - Continuous integration migrated from Travis CI to GitHub Actions
 
+Fixed
+-----
+- Reading of crystal symmetry from EMsoft h5ebsd dot product files in CrystalMap plugin
+
 2020-11-03 - version 0.5.1
 ==========================
 

--- a/orix/io/plugins/emsoft_h5ebsd.py
+++ b/orix/io/plugins/emsoft_h5ebsd.py
@@ -108,8 +108,8 @@ def file_reader(filename, refined=False, **kwargs):
 
 
 def _get_properties(data_group, n_top_matches, map_size):
-    """Return a dictionary of properties within an EMsoft h5ebsd file, with
-    property names as the dictionary key and arrays as the values.
+    """Return a dictionary of properties within an EMsoft h5ebsd file,
+    with property names as the dictionary key and arrays as the values.
 
     Parameters
     ----------
@@ -139,8 +139,6 @@ def _get_properties(data_group, n_top_matches, map_size):
         "TopDotProductList",
         "TopMatchIndices",
     ]
-
-    # Get properties
     properties = {}
     for property_name in expected_properties:
         if property_name in data_group.keys():
@@ -150,7 +148,6 @@ def _get_properties(data_group, n_top_matches, map_size):
             else:
                 prop = prop.reshape(map_size)
             properties[property_name] = prop
-
     return properties
 
 
@@ -174,7 +171,7 @@ def _get_phase(data_group):
     """
     name = re.search(r"([A-z0-9]+)", data_group["MaterialName"][:][0].decode()).group(1)
     point_group = re.search(
-        r"\[([A-z0-9]+)\]", data_group["Point Group"][:][0].decode()
+        r"\[([A-z0-9/]+)\]", data_group["Point Group"][:][0].decode()
     ).group(1)
     lattice = Lattice(
         *tuple(

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -466,14 +466,14 @@ def temp_emsoft_h5ebsd_file(tmpdir, request):
 
     # `phase_group`
     for name, data in [
-        ("Point Group", "Cubic (Oh) [m3m]"),
-        ("MaterialName", "austenite/austenite"),
-        ("Lattice Constant a", "3.595"),
-        ("Lattice Constant b", "3.595"),
-        ("Lattice Constant c", "3.595"),
-        ("Lattice Constant alpha", "90.000"),
-        ("Lattice Constant beta", "90.000"),
-        ("Lattice Constant gamma", "90.000"),
+        ("Point Group", "Monoclinic b (C2h) [2/m]"),
+        ("MaterialName", "fe4al13/fe4al13"),
+        ("Lattice Constant a", "15.009001"),
+        ("Lattice Constant b", "8.066"),
+        ("Lattice Constant c", "12.469"),
+        ("Lattice Constant alpha", "90.0"),
+        ("Lattice Constant beta", "107.72"),
+        ("Lattice Constant gamma", "90.0"),
     ]:
         phase_group.create_dataset(name, data=np.array([data], dtype=np.dtype("S")))
 

--- a/orix/tests/io/test_emsoft_plugin.py
+++ b/orix/tests/io/test_emsoft_plugin.py
@@ -25,10 +25,7 @@ from orix.io import load
 
 class TestEMsoftPlugin:
     @pytest.mark.parametrize(
-        (
-            "temp_emsoft_h5ebsd_file, map_shape, step_sizes, example_rot, "
-            "n_top_matches, refined"
-        ),
+        "temp_emsoft_h5ebsd_file, map_shape, step_sizes, n_top_matches, refined",
         [
             (
                 (
@@ -45,9 +42,6 @@ class TestEMsoftPlugin:
                 ),
                 (7, 3),
                 (1.5, 1.5),
-                np.array(
-                    [[6.148271, 0.792205, 1.324879], [6.155951, 0.793078, 1.325229],]
-                ),
                 50,
                 True,
             ),
@@ -66,9 +60,6 @@ class TestEMsoftPlugin:
                 ),
                 (5, 17),
                 (0.5, 0.5),
-                np.array(
-                    [[6.148271, 0.792205, 1.324879], [6.155951, 0.793078, 1.325229],]
-                ),
                 20,
                 False,
             ),
@@ -76,13 +67,7 @@ class TestEMsoftPlugin:
         indirect=["temp_emsoft_h5ebsd_file"],
     )
     def test_load_emsoft(
-        self,
-        temp_emsoft_h5ebsd_file,
-        map_shape,
-        step_sizes,
-        example_rot,
-        n_top_matches,
-        refined,
+        self, temp_emsoft_h5ebsd_file, map_shape, step_sizes, n_top_matches, refined,
     ):
         xmap = load(temp_emsoft_h5ebsd_file.filename, refined=refined)
 

--- a/orix/tests/io/test_emsoft_plugin.py
+++ b/orix/tests/io/test_emsoft_plugin.py
@@ -98,9 +98,11 @@ class TestEMsoftPlugin:
         expected_props.sort()
         assert actual_props == expected_props
 
-        assert xmap.phases["austenite"].structure == Structure(
-            title="austenite",
-            lattice=Lattice(a=3.595, b=3.595, c=3.595, alpha=90, beta=90, gamma=90),
+        assert xmap.phases["fe4al13"].structure == Structure(
+            title="fe4al13",
+            lattice=Lattice(
+                a=15.009001, b=8.066, c=12.469, alpha=90, beta=107.72, gamma=90
+            ),
         )
 
         # Ensure Euler angles in degrees are read correctly from file


### PR DESCRIPTION
#### Description of the change
* Fix #159.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
