### PR TITLE
Fix bug in reader of EMsoft h5ebsd files with certain map shapes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ Changed
 
 Fixed
 -----
+- Reading of properties (scores etc.) from EMsoft h5ebsd files with certain map shapes
 - Reading of crystal symmetry from EMsoft h5ebsd dot product files in CrystalMap plugin
 
 2020-11-03 - version 0.5.1

--- a/orix/io/plugins/emsoft_h5ebsd.py
+++ b/orix/io/plugins/emsoft_h5ebsd.py
@@ -143,9 +143,11 @@ def _get_properties(data_group, n_top_matches, map_size):
     for property_name in expected_properties:
         if property_name in data_group.keys():
             prop = data_group[property_name][:]
-            if prop.shape[-1] == n_top_matches:
-                prop = prop[:map_size].reshape((map_size,) + (n_top_matches,))
+            if prop.shape[-1] == n_top_matches and np.prod(prop.shape) > map_size:
+                # Not a refined dot product file
+                prop = prop[:map_size].reshape((map_size, n_top_matches))
             else:
+                # Refined dot product file
                 prop = prop.reshape(map_size)
             properties[property_name] = prop
     return properties

--- a/orix/tests/io/test_emsoft_plugin.py
+++ b/orix/tests/io/test_emsoft_plugin.py
@@ -109,3 +109,23 @@ class TestEMsoftPlugin:
         if not refined:
             assert np.rad2deg(xmap.rotations.to_euler().min()) >= 150
             assert np.rad2deg(xmap.rotations.to_euler().max()) <= 160
+
+    @pytest.mark.parametrize(
+        "temp_emsoft_h5ebsd_file",
+        [
+            (
+                (7, 3),  # map_shape
+                (1.5, 1.5),  # step_sizes
+                np.array(
+                    [[6.148271, 0.792205, 1.324879], [6.155951, 0.793078, 1.325229]]
+                ),  # rotations as rows of Euler angle triplets
+                21,  # n_top_matches
+                False,  # refined
+            ),
+        ],
+        indirect=["temp_emsoft_h5ebsd_file"],
+    )
+    def test_load_emsoft_best_matches_shape(self, temp_emsoft_h5ebsd_file):
+        xmap = load(temp_emsoft_h5ebsd_file.filename, refined=False)
+        assert xmap.rotations_per_point == 21
+        assert xmap.TopDotProductList.shape == (21, 21)


### PR DESCRIPTION
#### Description of the change
Fix #160. Add test to catch this case. Updated changelog.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
