### PR TITLE
Fix plotting of multidimensional Vector3d instances and stereographic grid toggling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,7 +37,6 @@ Changed
 
 Fixed
 -----
-- Plotting of multidimensional Vector3d instances
 - Reading of crystal symmetry from EMsoft h5ebsd dot product files in CrystalMap plugin
 
 2020-11-03 - version 0.5.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ Changed
 
 Fixed
 -----
+- Plotting of multidimensional Vector3d instances
 - Reading of crystal symmetry from EMsoft h5ebsd dot product files in CrystalMap plugin
 
 2020-11-03 - version 0.5.1

--- a/doc/stereographic_projection.ipynb
+++ b/doc/stereographic_projection.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "governing-galaxy",
+   "id": "fa336140",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "lucky-bosnia",
+   "id": "2e8bd570",
    "metadata": {},
    "source": [
     "# Stereographic projection\n",
@@ -43,7 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "muslim-andorra",
+   "id": "2db2bd9f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "pursuant-therapy",
+   "id": "91d9b274",
    "metadata": {},
    "source": [
     "## Plot vectors"
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "material-entrepreneur",
+   "id": "7edd3f6f",
    "metadata": {},
    "source": [
     "Plot three vectors on the upper hemisphere with\n",
@@ -88,7 +88,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "incredible-studio",
+   "id": "969ecff1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "revolutionary-collapse",
+   "id": "75d763d5",
    "metadata": {},
    "source": [
     "The spherical coordinates can be viewed while moving the cursor over the\n",
@@ -112,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "informal-scanning",
+   "id": "79c46318",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "modified-character",
+   "id": "33c2503e",
    "metadata": {},
    "source": [
     "From Matplotlib with\n",
@@ -134,7 +134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "liked-completion",
+   "id": "2efffe3c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,7 +144,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "mobile-huntington",
+   "id": "02c31caf",
    "metadata": {},
    "source": [
     "As usual with Matplotlib, the figure axes can be obtained from the returned `fig1`\n",
@@ -154,7 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "circular-quantity",
+   "id": "0655d90e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +163,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "educational-limitation",
+   "id": "04d23514",
    "metadata": {},
    "source": [
     "Let's turn on the azimuth and polar grid by updating the Matplotlib preferences"
@@ -172,7 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "composite-biodiversity",
+   "id": "debb1d3c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,7 +181,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "mature-athletics",
+   "id": "ceb335ae",
    "metadata": {},
    "source": [
     "### Upper and/or lower hemisphere\n",
@@ -194,7 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "intelligent-retailer",
+   "id": "bbf35de5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,7 +216,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "funded-astrology",
+   "id": "e9c8c664",
    "metadata": {},
    "source": [
     "From Matplotlib by setting the\n",
@@ -227,7 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "honey-sixth",
+   "id": "0250ba7f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +245,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "republican-framing",
+   "id": "637daa9d",
    "metadata": {},
    "source": [
     "### Control grid\n",
@@ -261,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fourth-lease",
+   "id": "694a6016",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,7 +271,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "academic-interface",
+   "id": "f2aaab56",
    "metadata": {},
    "source": [
     "These can also be set after the figure is created by returning the figure"
@@ -280,7 +280,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "catholic-refrigerator",
+   "id": "d82125fa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -294,7 +294,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "later-surname",
+   "id": "f2915559",
    "metadata": {},
    "source": [
     "We can also remove the grid if desirable"
@@ -303,7 +303,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "rental-light",
+   "id": "405e571a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +312,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "partial-basic",
+   "id": "f269736b",
    "metadata": {},
    "source": [
     "From Matplotlib, the polar and azimuth grid resolution can be set either upon\n",
@@ -325,7 +325,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "attempted-leader",
+   "id": "d7143bd4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -349,7 +349,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "uniform-depth",
+   "id": "b41401bb",
    "metadata": {},
    "source": [
     "### Annotate vectors\n",
@@ -361,7 +361,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "right-hollywood",
+   "id": "a0ad745b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +374,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "victorian-contractor",
+   "id": "7d1f28fb",
    "metadata": {},
    "source": [
     "From Matplotlib, by looping over the vectors and adding text markers using\n",
@@ -384,7 +384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "accepted-mechanics",
+   "id": "a68fb09d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -408,7 +408,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fancy-public",
+   "id": "2a378c5d",
    "metadata": {},
    "source": [
     "### Pass spherical coordinates\n",
@@ -420,7 +420,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "renewable-haven",
+   "id": "d746fe7d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,7 +436,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "duplicate-carnival",
+   "id": "a03fc417",
    "metadata": {},
    "source": [
     "Here, we also passed `None` to\n",
@@ -449,7 +449,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "spanish-clothing",
+   "id": "9b21afe4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -464,7 +464,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "polar-stuff",
+   "id": "bc51dfd4",
    "metadata": {},
    "source": [
     "### Draw great and small circles\n",
@@ -476,7 +476,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "durable-starter",
+   "id": "c4a28a90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -497,7 +497,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "deluxe-summit",
+   "id": "d6f40fd2",
    "metadata": {},
    "source": [
     "Let's also add the vector perpendicular to the last two vectors and its great\n",
@@ -510,7 +510,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "alike-phoenix",
+   "id": "4026c090",
    "metadata": {
     "tags": [
      "nbsphinx-thumbnail"
@@ -528,7 +528,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "precise-denmark",
+   "id": "36c92e03",
    "metadata": {},
    "source": [
     "From Matplotlib using\n",
@@ -539,7 +539,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "structured-virginia",
+   "id": "aa8c9e6a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -570,7 +570,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "architectural-arrow",
+   "id": "9eeb812d",
    "metadata": {},
    "source": [
     "### Create a Wulff net\n",
@@ -581,7 +581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "successful-davis",
+   "id": "a40b2663",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -608,7 +608,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "utility-scope",
+   "id": "d5f54cc4",
    "metadata": {},
    "source": [
     "## Experimental functionality\n",
@@ -620,7 +620,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "spare-vacation",
+   "id": "86c81602",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -666,7 +666,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "played-airplane",
+   "id": "8112f4eb",
    "metadata": {
     "nbsphinx": "hidden"
    },

--- a/orix/plot/stereographic_plot.py
+++ b/orix/plot/stereographic_plot.py
@@ -136,9 +136,11 @@ class StereographicPlot(Axes):
     def __init__(self, *args, azimuth_resolution=10, polar_resolution=10, **kwargs):
         self._azimuth_cap = 2 * np.pi
         self._azimuth_resolution = azimuth_resolution
-
         self._polar_cap = np.pi / 2
         self._polar_resolution = polar_resolution
+
+        # Custom attribute to keep track of whether grid is on or off
+        self._stereographic_grid = False
 
         super().__init__(*args, **kwargs)
         # Set ratio of y-unit to x-unit by adjusting the physical

--- a/orix/plot/stereographic_plot.py
+++ b/orix/plot/stereographic_plot.py
@@ -140,7 +140,7 @@ class StereographicPlot(Axes):
         self._polar_resolution = polar_resolution
 
         # Custom attribute to keep track of whether grid is on or off
-        self._stereographic_grid = False
+        self._stereographic_grid = None
 
         super().__init__(*args, **kwargs)
         # Set ratio of y-unit to x-unit by adjusting the physical

--- a/orix/plot/stereographic_plot.py
+++ b/orix/plot/stereographic_plot.py
@@ -537,7 +537,7 @@ class StereographicPlot(Axes):
             polar = np.asarray(values[1])
         else:
             try:
-                value = values[0].unit
+                value = values[0].flatten().unit
                 azimuth = value.azimuth.data
                 polar = value.polar.data
             except (ValueError, AttributeError):

--- a/orix/tests/test_stereographic_plot.py
+++ b/orix/tests/test_stereographic_plot.py
@@ -205,6 +205,17 @@ class TestStereographicPlot:
         ax.text(v, s="1")
         assert ax.texts == []
 
+        plt.close("all")
+
+    @pytest.mark.parametrize("shape", [(5, 10), (2, 3)])
+    def test_multidimensional_vector(self, shape):
+        n = np.prod(shape)
+        v = vector.Vector3d(np.random.normal(size=3 * n).reshape(shape + (3,)))
+        v.scatter()
+        v.draw_circle()
+
+        plt.close("all")
+
 
 class TestSymmetryMarker:
     def test_properties(self):

--- a/orix/tests/test_vector3d.py
+++ b/orix/tests/test_vector3d.py
@@ -413,6 +413,42 @@ class TestPlotting:
 
         plt.close("all")
 
+    def test_scatter_grid(self):
+        plt.rcParams["axes.grid"] = True
+        v = self.v
+        fig = v.scatter(grid=False, return_figure=True)
+
+        # Would think this attribute controlled whether a grid was
+        # visible or not, but it doesn't seem like it. This should be
+        # looked into again if this ever is untrue!
+        assert fig.axes[0]._gridOn is True
+
+        # Custom attribute
+        assert fig.axes[0]._stereographic_grid is False
+
+        # Grid remains off, respecting _stereographic_grid
+        v.scatter(figure=fig)
+        assert fig.axes[0]._stereographic_grid is False
+
+        # Grid is turned on, respecting `grid`
+        v.scatter(figure=fig, grid=True)
+        assert fig.axes[0]._stereographic_grid is True
+
+        # Grid remains on, respecting _stereographic_grid
+        plt.rcParams["axes.grid"] = False
+        v.scatter(figure=fig)
+        assert fig.axes[0]._stereographic_grid is True
+
+        # New figure, so _stereographic_grid should be as initialized
+        fig2 = v.scatter(return_figure=True)
+        assert fig2.axes[0]._stereographic_grid is False
+
+        # Grid is turned on, respecting `grid`
+        v.scatter(figure=fig2, grid=True)
+        assert fig2.axes[0]._stereographic_grid is True
+
+        plt.close("all")
+
     def test_scatter_projection(self):
         with pytest.raises(
             NotImplementedError, match="Stereographic is the only supported"
@@ -435,3 +471,24 @@ class TestPlotting:
         assert len(fig1.axes) == 2
         assert all(a.hemisphere == h for a, h in zip(fig1.axes, ["upper", "lower"]))
         assert fig1.axes[0].lines[0]._path._vertices.shape == (steps, 2)
+
+    def test_draw_circle_grid(self):
+        plt.rcParams["axes.grid"] = True
+        v = self.v
+        fig = v.draw_circle(grid=False, return_figure=True)
+
+        # Would think this attribute controlled whether a grid was
+        # visible or not, but it doesn't seem like it. This should be
+        # looked into again if this ever is untrue!
+        assert fig.axes[0]._gridOn is True
+
+        # Custom attribute
+        assert fig.axes[0]._stereographic_grid is False
+
+        v.draw_circle(figure=fig)
+        assert fig.axes[0]._stereographic_grid is False
+
+        v.draw_circle(figure=fig, grid=True)
+        assert fig.axes[0]._stereographic_grid is True
+
+        plt.close("all")

--- a/orix/tests/test_vector3d.py
+++ b/orix/tests/test_vector3d.py
@@ -439,7 +439,7 @@ class TestPlotting:
         v.scatter(figure=fig)
         assert fig.axes[0]._stereographic_grid is True
 
-        # New figure, so _stereographic_grid should be as initialized
+        # New figure, so _stereographic_grid should be as `axes.grid`
         fig2 = v.scatter(return_figure=True)
         assert fig2.axes[0]._stereographic_grid is False
 

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -771,7 +771,8 @@ class Vector3d(Object3d):
         # Whether to plot a grid, and with which resolution
         if grid is None:
             grid = [a._stereographic_grid for a in axes]
-        #            grid = plt.rcParams["axes.grid"]
+            if all(g is None for g in grid):
+                grid = [plt.rcParams["axes.grid"],] * ncols
         else:
             grid = [grid,] * ncols
         if grid_resolution is None:

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -601,7 +601,8 @@ class Vector3d(Object3d):
         for i, ax in enumerate(axes):  # Assumes a maximum of two axes
             ax.hemisphere = hemisphere[i]
             ax.scatter(self, **kwargs)
-            ax.grid(grid)
+            ax.grid(grid[i])
+            ax._stereographic_grid = grid[i]
             ax.azimuth_grid(grid_resolution[0])
             ax.polar_grid(grid_resolution[1])
             ax.set_labels(*axes_labels)
@@ -691,7 +692,8 @@ class Vector3d(Object3d):
         for i, ax in enumerate(axes):  # Assumes a maximum of two axes
             ax.hemisphere = hemisphere[i]
             ax.draw_circle(self, opening_angle=opening_angle, steps=steps, **kwargs)
-            ax.grid(grid)
+            ax.grid(grid[i])
+            ax._stereographic_grid = grid[i]
             ax.azimuth_grid(grid_resolution[0])
             ax.polar_grid(grid_resolution[1])
             ax.set_labels(*axes_labels)
@@ -729,7 +731,7 @@ class Vector3d(Object3d):
         axes : matplotlib.axes.Axes
         hemisphere : tuple of str
         show_hemisphere_label : bool
-        grid : bool
+        grid : list of bool
         grid_resolution : tuple
         """
         if projection.lower() != "stereographic":
@@ -768,7 +770,10 @@ class Vector3d(Object3d):
 
         # Whether to plot a grid, and with which resolution
         if grid is None:
-            grid = plt.rcParams["axes.grid"]
+            grid = [a._stereographic_grid for a in axes]
+        #            grid = plt.rcParams["axes.grid"]
+        else:
+            grid = [grid,] * ncols
         if grid_resolution is None:
             grid_resolution = (None,) * 2
 


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
Fix #167. Fix #170. Added tests to catch behaviours.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)
- [x] Fix #170 properly (not done yet!)

#### Minimal example of the bug fix or new feature
```python
>>> import numpy as np
>>> import matplotlib.pyplot as plt
>>> from orix.vector import Vector3d
>>> shape = (5, 10)
>>> v = Vector3d(np.random.normal(size=3 * np.prod(shape)).reshape(shape + (3,)))
>>> v.scatter()  # Doesn't throw IndexError
>>> plt.rcParams["axes.grid"] = False
>>> fig = v.scatter(return_figure=True)
>>> v.scatter(figure=fig)  # Grid remains off
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
