### PR TITLE
Add .ipynb to .gitignore and update contributing guide accordingly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,7 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
-#*.ipynb
+*.ipynb
 
 # pyenv
 .python-version

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -144,6 +144,12 @@ plaintext markup language. They should be accessible in the browser by typing
 Tips for writing Jupyter Notebooks that are meant to be converted to reST text
 files by `nbsphinx <https://nbsphinx.readthedocs.io/en/latest/>`_:
 
+- Notebooks (with the `.ipynb` file extension) are ignored by git (listed in the
+  `.gitignore` file). The ``-f``
+  `git flag <https://git-scm.com/docs/git-add#Documentation/git-add.txt--f>`_ must be
+  added to ``git add -f notebook.ipynb`` in order to update an existing notebook or add
+  a new one. Notebooks are ignored by git in general to avoid non-documentation changes
+  to notebooks, like cell IDs, being pushed unnecessarily.
 - All notebooks should have a Markdown (MD) cell with this message at the top,
   "This notebook is part of the `orix` documentation https://orix.rtfd.io. Links to the
   documentation won't work from the notebook.", and have ``"nbsphinx": "hidden"`` in the


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
Close #183.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
