### PR TITLE
Add CrystalMap.plot(), use matplotlib-scalebar, add xmap notebook

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Unreleased
 
 Added
 -----
+- CrystalMap.plot() method for easy plotting of phases, properties etc.
 - Python 3.9 support.
 - Miller class, inherinting functionality from the Vector3d class, to handle operations
   with direct lattice vectors (uvw/UVTW) and reciprocal lattice vectors (hkl/hkil).

--- a/doc/crystal_map.ipynb
+++ b/doc/crystal_map.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "48879910",
+   "id": "2fad03e5",
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -12,10 +12,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b3e0bae5",
+   "id": "528d81e2",
    "metadata": {},
    "source": [
-    "# Crystal maps\n",
+    "# Crystal map\n",
     "\n",
     "This notebook details how to load and save crystallographic mapping data in\n",
     "orix, as well as analysing and visualising the data. All interactions with this\n",
@@ -32,59 +32,104 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8f1e7cd0",
+   "id": "bde21dcd",
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib qt5\n",
+    "%matplotlib inline\n",
     "\n",
     "from diffpy.structure import Atom, Lattice, Structure\n",
+    "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
+    "from orix.crystal_map import CrystalMap, Phase, PhaseList\n",
+    "from orix.io import load, save\n",
+    "from orix import plot\n",
+    "from orix.quaternion import Orientation, Rotation, symmetry\n",
     "\n",
-    "from orix import crystal_map, io, quaternion"
+    "\n",
+    "plt.rcParams.update({\n",
+    "    \"figure.figsize\": (7, 7),\n",
+    "    \"font.size\": 15,\n",
+    "})"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1a9dfe70",
+   "id": "102a1eb8",
    "metadata": {},
    "source": [
-    "# Load, create and save\n",
+    "## Load, create and save\n",
     "\n",
     "A CrystalMap instance can be obtained by reading an orientation data set stored\n",
-    "in a format supported by orix using the load function, or by passing the\n",
-    "necessary arrays to the `CrystalMap.__init__()` method. Two file formats are\n",
-    "supported, in addition to orix's own HDF5 format: Data in the .ang format\n",
-    "produced by the softwares EDAX TSL OIM Data Collection v7, NanoMegas ASTAR\n",
-    "Index, and EMsoft v4/v5 via the `EMdpmerge` program, and data in EMsoft v4/v5\n",
-    "HDF5 files produced by the `EMEBSDDI` program.\n",
+    "in a format supported by orix using the\n",
+    "[orix.io.load()](reference.rst#orix.io.load) function, or by passing the\n",
+    "necessary arrays to the\n",
+    "[CrystalMap.\\_\\_init\\_\\_()](reference.rst#orix.crystal_map.CrystalMap)\n",
+    "method. Two file formats are supported, in addition to orix's own HDF5 format:\n",
+    "Data in the .ang format produced by the softwares EDAX TSL OIM Data Collection\n",
+    "v7, NanoMegas ASTAR Index, and EMsoft v4/v5 via the `EMdpmerge` program, and\n",
+    "data in EMsoft v4/v5 HDF5 files produced by the `EMEBSDDI` program.\n",
     "\n",
     "Two writers are supported, namely orix's own HDF5 format, readable by orix only,\n",
     "and the .ang format, readable at least by MTEX and EDAX TSL OIM Analysis v7.\n",
     "\n",
-    "## Load or create\n",
+    "### Load or create\n",
     "\n",
-    "Let's load a crystal map from an .ang file produced by EMsoft and inspect it"
+    "Let's download a small crystal map from an .ang file produced by EMsoft into a\n",
+    "temporary directory"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2b540a3e",
+   "id": "b5e005e4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "datadir = \"/home/hakon/phd/data/jarle_emsoft/sdss/em/\"\n",
-    "fname = \"sdss_ferrite_austenite.ang\"\n",
+    "import os\n",
+    "import tempfile\n",
     "\n",
-    "xmap = io.load(datadir + fname)\n",
-    "print(xmap)\n",
-    "xmap.plot(overlay=\"dp\")  # Dot product values added to the alpha (RGBA) channel"
+    "tempdir = tempfile.mkdtemp() + \"/\"\n",
+    "fname = \"sdss_ferrite_austenite.ang\"\n",
+    "source = f\"https://folk.ntnu.no/hakonwii/files/orix-demos/{fname}\"\n",
+    "target = os.path.join(tempdir, fname)\n",
+    "\n",
+    "try:\n",
+    "    os.mkdir(tempdir)\n",
+    "except:\n",
+    "    pass\n",
+    "if not os.path.exists(target):\n",
+    "    import urllib.request\n",
+    "    urllib.request.urlretrieve(source, target)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "354da649",
+   "id": "686b9184",
+   "metadata": {},
+   "source": [
+    "Let's inspect the data and plot it"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25ff42bc",
+   "metadata": {
+    "tags": [
+     "nbsphinx-thumbnail"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "xmap = load(target)\n",
+    "xmap.plot(overlay=\"dp\")  # Dot product values added to the alpha (RGBA) channel\n",
+    "xmap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f07964d2",
    "metadata": {},
    "source": [
     "The indexing properties returned by EMsoft in their .ang files are the pattern\n",
@@ -93,24 +138,35 @@
     "pattern.\n",
     "\n",
     "The same `CrystalMap` object can be obtained by reading each array from the .ang\n",
-    "file ourselves and passing this to `CrystalMap.__init__()`"
+    "file ourselves and passing this to `CrystalMap.__init__()`\n",
+    "\n",
+    "Let's remove the duplicates in the phase names..."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0e9d3823",
+   "id": "aeb50f4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.phases[1].name = \"austenite\"\n",
+    "xmap.phases[2].name = \"ferrite\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "edd441cc",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Read each column from the file\n",
-    "euler1, euler2, euler3, x, y, iq, dp, phase_id = np.loadtxt(\n",
-    "    datadir + fname, unpack=True\n",
-    ")\n",
+    "euler1, euler2, euler3, x, y, iq, dp, phase_id = np.loadtxt(target, unpack=True)\n",
     "\n",
     "# Create a Rotation object from Euler angles\n",
     "euler_angles = np.column_stack((euler1, euler2, euler3))\n",
-    "rotations = quaternion.Rotation.from_euler(euler_angles)\n",
+    "rotations = Rotation.from_euler(euler_angles)\n",
     "\n",
     "# Create a property dictionary\n",
     "properties = dict(iq=iq, dp=dp)\n",
@@ -128,14 +184,14 @@
     "        lattice=Lattice(0.287, 0.287, 0.287, 90, 90, 90)\n",
     "    ),\n",
     "]\n",
-    "phase_list = crystal_map.PhaseList(\n",
+    "phase_list = PhaseList(\n",
     "    names=[\"austenite\", \"ferrite\"],\n",
     "    point_groups=[\"432\", \"432\"],\n",
     "    structures=structures,\n",
     ")\n",
     "\n",
     "# Create a CrystalMap instance\n",
-    "xmap2 = crystal_map.CrystalMap(\n",
+    "xmap2 = CrystalMap(\n",
     "    rotations=rotations,\n",
     "    phase_id=phase_id,\n",
     "    x=x,\n",
@@ -150,26 +206,26 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e6a639b",
+   "id": "c01ef0b5",
    "metadata": {},
    "source": [
-    "## Save\n",
+    "### Save\n",
     "\n",
-    "### orix HDF5 format\n",
+    "#### orix HDF5 format\n",
     "\n",
     "As mentioned, the two writers implemented are orix's own HDF5 format and the\n",
-    ".ang format"
+    ".ang format, used by calling [orix.io.save()](reference.rst#orix.io.save)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "119cf43a",
+   "id": "836a9489",
    "metadata": {},
    "outputs": [],
    "source": [
-    "io.save(\n",
-    "    filename=datadir + \"sdss_ferrite_austenite2.h5\",\n",
+    "save(\n",
+    "    filename=tempdir + \"sdss_ferrite_austenite2.h5\",\n",
     "    object2write=xmap,\n",
     "    overwrite=True,  # Default is False\n",
     ")"
@@ -177,16 +233,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "760cbce8",
+   "id": "53addb02",
    "metadata": {},
    "source": [
     "Read the file contents back into a `CrystalMap` object using\n",
-    "[orix.io.load()](reference.rst#orix._io.load) function.\n",
+    "[orix.io.load()](reference.rst#orix.io.load) function.\n",
     "\n",
     "All contents in this file can be inspected using any HDF5 viewer and read back\n",
     "into Python using the h5py library (which we use).\n",
     "\n",
-    "### .ang format\n",
+    "#### .ang format\n",
     "\n",
     "The .ang writer supports many use cases. Some of these are demonstrated here,\n",
     "by reloading the saved crystal maps.\n",
@@ -198,25 +254,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6e1f1b79",
+   "id": "514e1f1f",
    "metadata": {},
    "outputs": [],
    "source": [
     "fname_ang1 = \"sdss_dp_ci.ang\"\n",
-    "io.save(\n",
-    "    filename=datadir + fname_ang1,\n",
+    "save(\n",
+    "    filename=tempdir + fname_ang1,\n",
     "    object2write=xmap,\n",
     "    confidence_index_prop=\"dp\"\n",
     ")\n",
     "\n",
-    "xmap_reload1 = io.load(datadir + fname_ang1)\n",
+    "xmap_reload1 = load(tempdir + fname_ang1)\n",
     "print(xmap_reload1)\n",
     "print(xmap_reload1.prop)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d97410a0",
+   "id": "dcd7d67b",
    "metadata": {},
    "source": [
     "Note that points not in data are set to `not_indexed` when reloaded from the\n",
@@ -232,18 +288,20 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dbb8a27e",
+   "id": "5fdcdd4d",
    "metadata": {},
    "source": [
     "## Modify crystal phases\n",
     "\n",
-    "The phases are stored in a `PhaseList` object in the `CrystalMap.phases` attribute"
+    "The phases are stored in a \n",
+    "[PhaseList](reference.rst#orix.crystal_map.PhaseList) instance in the\n",
+    "`CrystalMap.phases` attribute"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "585a464e",
+   "id": "a56f04a0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -252,7 +310,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca0824a3",
+   "id": "4fb5f84a",
    "metadata": {},
    "source": [
     "### Symmetry"
@@ -260,7 +318,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2ece5a97",
+   "id": "a1c85f10",
    "metadata": {},
    "source": [
     "The point group symmetry are stored in the vendor and EMsoft files, however they\n",
@@ -272,7 +330,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4d7b8c27",
+   "id": "0b400b88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,13 +342,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "964bfb82",
+   "id": "091d04cb",
    "metadata": {},
    "source": [
     "Note that this also changed the point group, because this is always determined\n",
     "from the space group. But the proper point group, without any inversion or\n",
     "mirror planes, stayed the same. The `space_group` attribute stores a\n",
-    "`diffpy.structure.spacegroups.SpaceGroup` object (https://www.diffpy.org/diffpy.structure/mod_spacegroup.html#diffpy.structure.spacegroupmod.SpaceGroup).\n",
+    "[diffpy.structure.spacegroups.SpaceGroup](https://www.diffpy.org/diffpy.structure/mod_spacegroup.html#diffpy.structure.spacegroupmod.SpaceGroup)\n",
+    "instance.\n",
     "\n",
     "We can get the point group which a space group is the subgroup of"
    ]
@@ -298,18 +357,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c3791feb",
+   "id": "2c734c4a",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "print(get_point_group(200).name, get_point_group(230).name)"
+    "print(symmetry.get_point_group(200).name, symmetry.get_point_group(230).name)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "00ca5864",
+   "id": "88ed89c2",
    "metadata": {},
    "source": [
     "The point group stores symmetry operations as quaternions. We can get them as\n",
@@ -319,7 +378,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c55678f",
+   "id": "3c00af02",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -329,7 +388,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "664cbf03",
+   "id": "1c559049",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -338,7 +397,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d324243",
+   "id": "2ea378ff",
    "metadata": {},
    "source": [
     "`diffpy.structure` stores rotation symmetry operations as orientation matrices\n",
@@ -348,7 +407,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e7acaa55",
+   "id": "05526ed6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -357,7 +416,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0168a24c",
+   "id": "bb52ae5a",
    "metadata": {},
    "source": [
     "We can get the quaternion representation of these matrices"
@@ -366,7 +425,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c2e9fab5",
+   "id": "c24caba4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,7 +434,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c4a46cc",
+   "id": "9744bea6",
    "metadata": {},
    "source": [
     "### Index phase list"
@@ -383,7 +442,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "605e1de2",
+   "id": "7fdcba28",
    "metadata": {},
    "source": [
     "The phase list can be indexed by phase ID or name"
@@ -392,7 +451,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3a9ee1d3",
+   "id": "5041e67b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -402,7 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5bcde7ad",
+   "id": "7aa6e057",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,7 +471,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c3513049",
+   "id": "bbb0bbe8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -422,7 +481,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a6b50a19",
+   "id": "3f9723ed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -431,18 +490,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fef7c8da",
+   "id": "649f12de",
    "metadata": {},
    "source": [
     "When asking for a single phase, either by an integer or a single string, a\n",
-    "`Phase` object was returned. In the other cases, a `PhaseList` object was\n",
-    "returned"
+    "[Phase](reference.rst#orix.crystal_map.Phase) instance was returned. In the\n",
+    "other cases, a `PhaseList` object was returned"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3cbdbfa8",
+   "id": "4488aaab",
    "metadata": {
     "tags": []
    },
@@ -452,11 +511,9 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ec654200",
+   "cell_type": "markdown",
+   "id": "7385e29d",
    "metadata": {},
-   "outputs": [],
    "source": [
     "Valid point group names to use when setting the point group symmetry are"
    ]
@@ -464,31 +521,28 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6bf8c6e6",
+   "id": "17592135",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from orix.quaternion.symmetry import _groups\n",
-    "\n",
-    "[point_group.name for point_group in _groups]"
+    "[point_group.name for point_group in symmetry._groups]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adaf0629",
+   "id": "f697a849",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
-    "xmap.phases[\"Austenite\"].point_group = \"-43m\"\n",
+    "xmap.phases[\"austenite\"].point_group = \"-43m\"\n",
     "\n",
     "xmap.phases"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "499e5628",
+   "id": "d01809d8",
    "metadata": {},
    "source": [
     "Note that the `space_group` was set to `None` since space group Fm-3m is not a\n",
@@ -500,11 +554,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a25fedca",
+   "id": "b5e94d54",
    "metadata": {},
    "outputs": [],
    "source": [
-    "xmap.phases[\"Austenite\"].name = \"austenite\"\n",
     "xmap.phases[\"austenite\"].space_group = 225\n",
     "\n",
     "xmap.phases"
@@ -512,7 +565,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8d17758f",
+   "id": "a1be7e63",
    "metadata": {},
    "source": [
     "We can add a phase by giving its name and point group symmetry"
@@ -521,7 +574,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0ef19d9",
+   "id": "cf03d2bd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -532,7 +585,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5a71ccd6",
+   "id": "16dd8ad5",
    "metadata": {},
    "source": [
     "When adding a phase to the phase list like this, the phases' structure contains no atoms and the default lattice parameters are used"
@@ -541,7 +594,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b43405a3",
+   "id": "7e01c748",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -550,7 +603,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34e7cafb",
+   "id": "454964a2",
    "metadata": {},
    "source": [
     "So let's set this"
@@ -559,7 +612,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9a60772e",
+   "id": "d8ba2abc",
    "metadata": {
     "tags": []
    },
@@ -571,7 +624,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "03135ea7",
+   "id": "0c7653fb",
    "metadata": {},
    "source": [
     "If some data points are considered as not indexed, a \"not_indexed\" phase can be\n",
@@ -581,7 +634,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b27af5c6",
+   "id": "4f940dbc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -592,7 +645,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8ab94d7e",
+   "id": "024bf954",
    "metadata": {},
    "source": [
     "No points in this data set are considered not indexed. A phase list with only\n",
@@ -602,7 +655,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f1d9aebb",
+   "id": "79d25796",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -611,7 +664,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d950d83",
+   "id": "010dd25f",
    "metadata": {},
    "source": [
     "We can of course remove a phase from the phase list, either by its name or phase ID"
@@ -620,7 +673,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e8e4a860",
+   "id": "25c4c6a5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -632,7 +685,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66280417",
+   "id": "7ef32ea3",
    "metadata": {},
    "source": [
     "### Properties"
@@ -640,7 +693,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0757d30c",
+   "id": "891b1c75",
    "metadata": {},
    "source": [
     "The phase name, space group, point group, proper point group, color and\n",
@@ -650,7 +703,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f88d96e1",
+   "id": "e4664676",
    "metadata": {
     "tags": []
    },
@@ -666,7 +719,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6455171d",
+   "id": "56b63f29",
    "metadata": {},
    "source": [
     "Note that the structures' representations are empty lists since no atoms have been added to them yet."
@@ -675,7 +728,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93dc3baf",
+   "id": "87d83fd3",
    "metadata": {
     "tags": []
    },
@@ -692,7 +745,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a9915b8",
+   "id": "1a942604",
    "metadata": {},
    "source": [
     "These attributes (not the phase ID) can be set *per phase*"
@@ -701,41 +754,40 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "250c0f34",
+   "id": "e6e5a3bc",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "xmap.phases[\"austenite\"].name = \"Austenite\"\n",
-    "\n",
-    "xmap.phases[\"Austenite\"].structure = Structure(\n",
+    "xmap.phases[\"austenite\"].structure = Structure(\n",
     "    lattice=Lattice(0.36, 0.36, 0.36, 90, 90, 90)\n",
     ")\n",
-    "print(xmap.phases[\"Austenite\"].structure)\n",
+    "print(xmap.phases[\"austenite\"].structure)\n",
     "\n",
-    "xmap.phases[\"Austenite\"].color = \"lime\"  # Sets RGB tuple (0, 1, 0)\n",
-    "print(xmap.phases[\"Austenite\"].color_rgb)\n",
+    "xmap.phases[\"austenite\"].color = \"lime\"  # Sets RGB tuple (0, 1, 0)\n",
+    "print(xmap.phases[\"austenite\"].color_rgb)\n",
     "\n",
     "xmap.phases"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "181fe2c1",
+   "id": "0fa737e0",
    "metadata": {},
    "source": [
-    "Valid color strings can be found here: https://matplotlib.org/3.1.0/tutorials/colors/colors.html\n",
+    "Valid color strings can be found here: https://matplotlib.org/stable/tutorials/colors/colors.html\n",
     "\n",
-    "### Create phase list\n",
+    "#### Create phase list\n",
     "\n",
-    "We can create a phase list by calling `PhaseList.__init__()`"
+    "We can create a phase list by calling\n",
+    "[PhaseList.\\_\\_init\\_\\_()](reference.rst#orix.crystal_map.PhaseList)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c12d153",
+   "id": "f0d6b592",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -759,7 +811,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aad2f7fa",
+   "id": "278ff853",
    "metadata": {},
    "source": [
     "or by creating `Phase` objects and passing these to the first argument in\n",
@@ -769,7 +821,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5dc7d775",
+   "id": "b5219e65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -787,7 +839,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50f50b7a",
+   "id": "6c660bd0",
    "metadata": {},
    "source": [
     "Note that the Cu phase name was retrieved from the `Structure` object.\n",
@@ -800,7 +852,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a32db74e",
+   "id": "122c80df",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -812,7 +864,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49be6be5",
+   "id": "f45f1e7e",
    "metadata": {},
    "source": [
     "If we want a deep copy of the phase list"
@@ -821,7 +873,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e9c874a7",
+   "id": "fbe62593",
    "metadata": {
     "tags": []
    },
@@ -836,18 +888,19 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed355d21",
+   "id": "63c1a298",
    "metadata": {},
    "source": [
-    "## Inspect orientation data\n",
+    "## Orientation data\n",
     "\n",
-    "Orientations are stored as rotations in a `Rotation` object"
+    "Orientations are stored as rotations in a \n",
+    "[Rotation](reference.rst#orix.quaternion.Rotation) instance"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d2494835",
+   "id": "8c0ec3b1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -856,7 +909,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b3305c52",
+   "id": "1617db3e",
    "metadata": {},
    "source": [
     "Orientations *per phase* can be obtained by applying the phase point group\n",
@@ -866,7 +919,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2fbc9396",
+   "id": "0bbe2d4d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -877,7 +930,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "591af272",
+   "id": "cc73d06f",
    "metadata": {},
    "source": [
     "The above is equivalent to"
@@ -886,7 +939,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a74902ed",
+   "id": "62fd8b59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -897,7 +950,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4c417d35",
+   "id": "ed2a0c0e",
    "metadata": {},
    "source": [
     "Orientation angles and axes are readily available"
@@ -906,7 +959,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79946e91",
+   "id": "5b3fb5ee",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -916,7 +969,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a55badec",
+   "id": "5e2461ba",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -927,7 +980,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d8c813da",
+   "id": "672c3044",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -936,10 +989,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4e392132",
+   "id": "d902b403",
    "metadata": {},
    "source": [
-    "## Inspect, add and delete map properties\n",
+    "## Map properties\n",
     "\n",
     "Map properties are stored in the `CrystalMap.prop` attribute dictionary"
    ]
@@ -947,7 +1000,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93ac3045",
+   "id": "43048087",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -956,7 +1009,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "120a42a4",
+   "id": "ff14f4c6",
    "metadata": {},
    "source": [
     "All properties in this dictionary are also available directly from the `CrystalMap` as attributes"
@@ -965,7 +1018,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "08865345",
+   "id": "9b40d5d4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -975,7 +1028,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2d3fbf98",
+   "id": "5a6bb246",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -984,7 +1037,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c5cb28b6",
+   "id": "18e73f4f",
    "metadata": {},
    "source": [
     "We can add a map property by specifying its name and an initial value in each map point"
@@ -993,7 +1046,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e7f88a1",
+   "id": "e992f4de",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1005,7 +1058,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b556c3df",
+   "id": "005431a1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1016,7 +1069,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df1a6b8a",
+   "id": "75a93cf4",
    "metadata": {},
    "source": [
     "We can also delete a property from the `prop` dictionary"
@@ -1025,7 +1078,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74ab9e0d",
+   "id": "959673f3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1036,10 +1089,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1935956",
+   "id": "143f164d",
    "metadata": {},
    "source": [
-    "## Select and modify data based upon criteria\n",
+    "## Select and modify data from criteria\n",
     "\n",
     "We can select data in a crystal map in three ways:\n",
     "1. by phase name or \"indexed\"/\"not_indexed\"\n",
@@ -1052,7 +1105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91be8720",
+   "id": "019a3300",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1061,7 +1114,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b688ed1e",
+   "id": "6135699a",
    "metadata": {},
    "source": [
     "or two phases"
@@ -1070,7 +1123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4dab3088",
+   "id": "b6a08db3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1079,7 +1132,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6443007c",
+   "id": "e9797ebd",
    "metadata": {},
    "source": [
     "or all indexed points"
@@ -1088,7 +1141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c6922bf",
+   "id": "eab374d2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1097,7 +1150,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d519b13",
+   "id": "1885abdc",
    "metadata": {},
    "source": [
     "or all non-indexed points"
@@ -1106,7 +1159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f501c987",
+   "id": "b455a975",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1115,7 +1168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b0b5ea02",
+   "id": "27e6e21a",
    "metadata": {},
    "source": [
     "When slicing a crystal map, it is important to know the data size and shape"
@@ -1124,7 +1177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15236dca",
+   "id": "f14e7cc8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1134,7 +1187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9aeab8e6",
+   "id": "b7eeb292",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1143,7 +1196,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "406f4775",
+   "id": "3cbef145",
    "metadata": {},
    "source": [
     "So, to get the data within a rectangle"
@@ -1152,7 +1205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e77c3aa5",
+   "id": "29a2b5ed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1161,7 +1214,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a7b56f87",
+   "id": "d2c94c9e",
    "metadata": {},
    "source": [
     "The most powerful way to select data is by requiring a certain criteria"
@@ -1170,7 +1223,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fa8712c0",
+   "id": "9133b6ba",
    "metadata": {
     "tags": []
    },
@@ -1185,7 +1238,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fbfdfb15",
+   "id": "75abb0d3",
    "metadata": {},
    "source": [
     "Note that when selecting a subset of the data, a shallow copy (view) of the\n",
@@ -1197,7 +1250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f2424776",
+   "id": "bfee64d0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1206,7 +1259,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42bdebbf",
+   "id": "de076e03",
    "metadata": {},
    "source": [
     "We can chain the criteria"
@@ -1215,7 +1268,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f349760d",
+   "id": "c0691b37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1224,50 +1277,77 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4880c262",
+   "id": "4e4ab697",
    "metadata": {},
    "source": [
     "## Plotting\n",
     "\n",
-    "All map plotting is done via a `matplotlib` \"projection\" named \"plot_map\". To plot a phase map"
+    "Map plotting can either be done via the\n",
+    "[CrystalMap.plot()](reference.rst#orix.crystal_map.CrystalMap.plot) method, or\n",
+    "via the [CrystalMapPlot](reference.rst#orix.plot.CrystalMapPlot) `matplotlib`\n",
+    "projection. To plot a phase map via `CrystalMap.plot()`, we simply do"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "011deff9",
+   "id": "8000448e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
-    "im = ax.plot_map(xmap)"
+    "xmap.plot()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "cd1fc6e6",
+   "id": "68f2a102",
    "metadata": {},
    "source": [
-    "Hover over figure points to display the (x,y) position and orientations in that point!\n",
-    "\n",
-    "Note that `plot_map()` wraps `matplotlib.axes.Axes.imshow`. All key word arguments in `plot_map()` are passed to `imshow()`, so be sure to check [its documentation](https://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.imshow.html?highlight=imshow#matplotlib.axes.Axes.imshow) out for any additional arguments.\n",
-    "\n",
-    "We can add any overlay, from any property with a value in each map point, to the map"
+    "Using the `matplotlib` projection"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97843d97",
+   "id": "369fa924",
    "metadata": {},
    "outputs": [],
    "source": [
-    "ax.add_overlay(xmap, xmap.dp)"
+    "#fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
+    "#im = ax.plot_map(xmap)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "313b16dd",
+   "id": "e20f178f",
+   "metadata": {},
+   "source": [
+    "Hover over figure points to display the (x,y) position and orientations in that\n",
+    "point when plotting interactively!\n",
+    "\n",
+    "Note that `plot()` wraps `matplotlib.axes.Axes.imshow`. All key word arguments\n",
+    "in `plot()` are passed to `imshow()`, so be sure to check\n",
+    "[its documentation](https://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.imshow.html?highlight=imshow#matplotlib.axes.Axes.imshow)\n",
+    "out for any additional arguments.\n",
+    "\n",
+    "We can add any overlay, from any property with a value in each map point, to the\n",
+    "map by either passing the property name as a string, or the actual (flattened)\n",
+    "array"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d4b9019",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.plot(overlay=xmap.dp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4bc95a32",
    "metadata": {},
    "source": [
     "To save our phase map with the scalebar and legend, but without white padding"
@@ -1276,115 +1356,103 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c647fd4",
+   "id": "323a1d77",
    "metadata": {},
    "outputs": [],
    "source": [
-    "ax.remove_padding()\n",
-    "fig.savefig(\n",
-    "    datadir + 'phase_map.png',\n",
-    "    bbox_inches=\"tight\",\n",
-    "    pad_inches=0,\n",
-    ")"
+    "fig = xmap.plot(overlay=\"dp\", return_figure=True, remove_padding=True)\n",
+    "fig.savefig(tempdir + \"phase_map.png\", bbox_inches=\"tight\", pad_inches=0)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "410229cc",
+   "id": "0c9a8aa5",
    "metadata": {},
    "source": [
-    "To save phase map without scalebar, legend and white padding, and one image pixel per map point"
+    "To save phase map without a scalebar, legend and white padding, and one image\n",
+    "pixel per map point"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e88a126",
+   "id": "a7d5106e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = fig.axes[0]\n",
+    "ax"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f3c1fd4",
    "metadata": {},
    "outputs": [],
    "source": [
     "plt.imsave(\n",
-    "    datadir + 'phase_no_fluff.png',\n",
-    "    arr=im.get_array()  # 2D NumPy array, possibly with an RGB tuple in each element\n",
+    "    tempdir + 'phase_map_no_fluff.png',\n",
+    "    arr=ax.images[0].get_array()  # 2D NumPy array, possibly with an RGB tuple in each element\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ed572463",
+   "id": "06459a40",
    "metadata": {},
    "source": [
-    "We can plot any property with a value in each map point"
+    "We can plot any property with a value in each map point, also adding a colorbar"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82fc8a12",
+   "id": "b0a677c7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
-    "im = ax.plot_map(xmap, xmap.dp, cmap=\"inferno\")"
+    "fig = xmap.plot(\n",
+    "    xmap.dp,\n",
+    "    cmap=\"inferno\",\n",
+    "    colorbar=True,\n",
+    "    colorbar_label=\"Dottproduct\",\n",
+    "    return_figure=True\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "50446cf6",
+   "id": "955148c2",
    "metadata": {},
    "source": [
-    "And change the colormap later if we want to"
+    "We can update the colorbar"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10c99107",
+   "id": "e0ccb060",
    "metadata": {},
    "outputs": [],
    "source": [
-    "im.set_cmap(\"viridis\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1836e13a",
-   "metadata": {},
-   "source": [
-    "And add a colorbar if we want"
+    "cbar = fig.axes[0].colorbar\n",
+    "cbar"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "761c694c",
+   "id": "96695d87",
    "metadata": {},
    "outputs": [],
    "source": [
-    "cbar = ax.add_colorbar(label=\"Dottproduct\")"
+    "cbar.ax.set_ylabel(\"Dot product\");"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9c0faf81",
-   "metadata": {},
-   "source": [
-    "Which we can update if we mispelled the label or want other adjustements"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ee8604c6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cbar.ax.set_ylabel(\"Dot product\", rotation=270);"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0f0d72ba",
+   "id": "26b7d761",
    "metadata": {},
    "source": [
     "We can also plot orientation related values, like axis and angles etc., and restrict the color bar maximum"
@@ -1393,60 +1461,48 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dabbff0d",
+   "id": "426d03df",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Get rotation angles in degrees\n",
     "angles = xmap.rotations.angle.data * 180 / np.pi\n",
     "\n",
-    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
-    "im = ax.plot_map(xmap, angles, vmax=angles.max() - 10)\n",
-    "\n",
-    "ax.add_overlay(xmap, xmap.iq)\n",
-    "\n",
-    "ax.add_colorbar(label=\"Rotation angle\");"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4443529d",
-   "metadata": {},
-   "source": [
-    "To plot only one phase, while passing custom\n",
-    "* scalebar properties (https://matplotlib.org/mpl_toolkits/axes_grid/api/anchored_artists_api.html#mpl_toolkits.axes_grid1.anchored_artists.AnchoredSizeBar)\n",
-    "* legend properties (https://matplotlib.org/3.3.0/api/_as_gen/matplotlib.pyplot.legend.html)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a47eb54d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
-    "im = ax.plot_map(\n",
-    "    xmap[\"austenite\"],\n",
-    "    scalebar=True,  # False for removed\n",
-    "    scalebar_properties={\n",
-    "        \"loc\": 4,  # 1: upper right, 2: upper left, etc. counter-clockwise\n",
-    "        \"frameon\": False,\n",
-    "        \"sep\": 6,  # Vertical spacing between bar and text\n",
-    "        \"size_vertical\": 0.2,  # Bar height\n",
-    "    },\n",
-    "    legend_properties={\n",
-    "        \"framealpha\": 1,  # 0: fully transparent, 1: opaque\n",
-    "        \"handlelength\": 1.5,  # Colored square width\n",
-    "        \"handletextpad\": 0.1,  # Horizontal space between square and text\n",
-    "        \"borderpad\": 0.1,\n",
-    "    },\n",
+    "xmap.plot(\n",
+    "    angles,\n",
+    "    vmax=angles.max() - 10,\n",
+    "    overlay=xmap.iq,\n",
+    "    colorbar=True,\n",
+    "    colorbar_label=\"Rotation angle\"\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "68163543",
+   "id": "5b26048f",
+   "metadata": {},
+   "source": [
+    "To plot only one phase, while passing custom\n",
+    "* scalebar properties (https://github.com/ppinard/matplotlib-scalebar/)\n",
+    "* legend properties (https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.legend.html)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4d21b04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap[\"austenite\"].plot(\n",
+    "    scalebar_properties=dict(location=\"upper left\", frameon=False, sep=6),\n",
+    "    legend_properties=dict(framealpha=1, handlelength=1.5, handletextpad=0.1)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ba450d5",
    "metadata": {},
    "source": [
     "Plot only a rectangle of the map"
@@ -1455,20 +1511,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18b24e04",
+   "id": "09372905",
    "metadata": {},
    "outputs": [],
    "source": [
     "xmap2 = xmap[20:50, 40:90]\n",
-    "\n",
-    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
-    "ax.plot_map(xmap2)\n",
-    "ax.add_overlay(xmap2, xmap2.dp)"
+    "xmap2.plot(overlay=xmap2.dp)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b74afe67",
+   "id": "6329824a",
    "metadata": {},
    "source": [
     "Plot only parts of a map based on chained conditionals, like belonging to one phase or having a property value above a threshold"
@@ -1477,28 +1530,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6730731a",
+   "id": "08050ad9",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Conditional slicing\n",
-    "xmap2 = xmap[xmap.dp > 0.81]\n",
-    "\n",
-    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
-    "ax.plot_map(xmap2, xmap2.iq, cmap=\"gray\")\n",
-    "ax.add_colorbar(\"Image quality\")\n",
+    "xmap[xmap.dp > 0.81].plot(\"iq\", cmap=\"gray\", colorbar=True, colorbar_label=\"Image quality\")\n",
     "\n",
     "# Chained conditional slicing\n",
-    "xmap2 = xmap[(xmap.dp > 0.81) & (xmap.phase_id == 1)]\n",
-    "\n",
-    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
-    "ax.plot_map(xmap2, xmap2.dp, cmap=\"cividis\")\n",
-    "ax.add_colorbar(\"Dot product\");"
+    "xmap[(xmap.dp > 0.81) & (xmap.phase_id == 1)].plot(\"dp\", cmap=\"viridis\", colorbar=True, colorbar_label=\"Dot product\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b0d668fd",
+   "id": "9bf05467",
    "metadata": {},
    "source": [
     "Plot histogram of a property per phase"
@@ -1507,7 +1552,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "de64ba2e",
+   "id": "b8b43f5d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1515,14 +1560,7 @@
     "this_prop = 'dp'\n",
     "\n",
     "# Plot phase map again to see color changes\n",
-    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
-    "ax.plot_map(xmap)\n",
-    "\n",
-    "# Add overlay, passing str (can also pass numpy.ndarray)\n",
-    "ax.add_overlay(xmap, this_prop)\n",
-    "\n",
-    "# Remove figure padding\n",
-    "ax.remove_padding()\n",
+    "xmap.plot(overlay=this_prop, remove_padding=True)\n",
     "\n",
     "# Declare lists for plotting\n",
     "data = []\n",
@@ -1534,7 +1572,7 @@
     "    labels.append(p.name)\n",
     "    colors.append(p.color)\n",
     "\n",
-    "    # Accessing the property dictionary directly\n",
+    "    # Accessing the property dictionary directlyhttps://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.legend.html\n",
     "    data.append(xmap[p.name].prop[this_prop])\n",
     "    # or indirectly\n",
     "    #data.append(xmap[p.name].dp)\n",
@@ -1552,6 +1590,28 @@
     "ax.set_xlabel(this_prop)\n",
     "ax.set_ylabel(\"Frequency\")\n",
     "ax.legend();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "917b832c",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# Remove files written to disk in this user guide\n",
+    "import os\n",
+    "for f in [\n",
+    "    target,\n",
+    "    tempdir + \"sdss_ferrite_austenite2.h5\",\n",
+    "    tempdir + \"sdss_dp_ci.ang\",\n",
+    "    tempdir + 'phase_map.png',\n",
+    "    tempdir + 'phase_map_no_fluff.png'\n",
+    "]:\n",
+    "    os.remove(f)\n",
+    "os.rmdir(tempdir)"
    ]
   }
  ],

--- a/doc/crystal_maps.ipynb
+++ b/doc/crystal_maps.ipynb
@@ -1,0 +1,1579 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "48879910",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the *orix* documentation https://orix.rtfd.io. Links to the documentation won’t work from the notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3e0bae5",
+   "metadata": {},
+   "source": [
+    "# Crystal maps\n",
+    "\n",
+    "This notebook details how to load and save crystallographic mapping data in\n",
+    "orix, as well as analysing and visualising the data. All interactions with this\n",
+    "type of data is done with the\n",
+    "[orix.crystal_map.CrystalMap](reference.rst#orix.crystal_map.CrystalMap) class.\n",
+    "\n",
+    "Orientations and other properties acquired from a super-duplex stainless steel\n",
+    "EBSD data set with two phases, austenite and ferrite, are used as example data.\n",
+    "The data is available here: http://folk.ntnu.no/hakonwii/files/orix-demos/,\n",
+    "courtesy of Prof. Jarle Hjelen (Norwegian University of Science and Technology,\n",
+    "Norway)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f1e7cd0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib qt5\n",
+    "\n",
+    "from diffpy.structure import Atom, Lattice, Structure\n",
+    "import numpy as np\n",
+    "\n",
+    "from orix import crystal_map, io, quaternion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a9dfe70",
+   "metadata": {},
+   "source": [
+    "# Load, create and save\n",
+    "\n",
+    "A CrystalMap instance can be obtained by reading an orientation data set stored\n",
+    "in a format supported by orix using the load function, or by passing the\n",
+    "necessary arrays to the `CrystalMap.__init__()` method. Two file formats are\n",
+    "supported, in addition to orix's own HDF5 format: Data in the .ang format\n",
+    "produced by the softwares EDAX TSL OIM Data Collection v7, NanoMegas ASTAR\n",
+    "Index, and EMsoft v4/v5 via the `EMdpmerge` program, and data in EMsoft v4/v5\n",
+    "HDF5 files produced by the `EMEBSDDI` program.\n",
+    "\n",
+    "Two writers are supported, namely orix's own HDF5 format, readable by orix only,\n",
+    "and the .ang format, readable at least by MTEX and EDAX TSL OIM Analysis v7.\n",
+    "\n",
+    "## Load or create\n",
+    "\n",
+    "Let's load a crystal map from an .ang file produced by EMsoft and inspect it"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b540a3e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datadir = \"/home/hakon/phd/data/jarle_emsoft/sdss/em/\"\n",
+    "fname = \"sdss_ferrite_austenite.ang\"\n",
+    "\n",
+    "xmap = io.load(datadir + fname)\n",
+    "print(xmap)\n",
+    "xmap.plot(overlay=\"dp\")  # Dot product values added to the alpha (RGBA) channel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "354da649",
+   "metadata": {},
+   "source": [
+    "The indexing properties returned by EMsoft in their .ang files are the pattern\n",
+    "image quality (iq) (according to Niels Krieger Lassen's method), and the highest\n",
+    "normalized dot product (dp) between the experimental and best matching simulated\n",
+    "pattern.\n",
+    "\n",
+    "The same `CrystalMap` object can be obtained by reading each array from the .ang\n",
+    "file ourselves and passing this to `CrystalMap.__init__()`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0e9d3823",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read each column from the file\n",
+    "euler1, euler2, euler3, x, y, iq, dp, phase_id = np.loadtxt(\n",
+    "    datadir + fname, unpack=True\n",
+    ")\n",
+    "\n",
+    "# Create a Rotation object from Euler angles\n",
+    "euler_angles = np.column_stack((euler1, euler2, euler3))\n",
+    "rotations = quaternion.Rotation.from_euler(euler_angles)\n",
+    "\n",
+    "# Create a property dictionary\n",
+    "properties = dict(iq=iq, dp=dp)\n",
+    "\n",
+    "# Create unit cells of the phases\n",
+    "structures = [\n",
+    "    Structure(\n",
+    "        title=\"austenite\",\n",
+    "        atoms=[Atom(\"fe\", [0] * 3)],\n",
+    "        lattice=Lattice(0.360, 0.360, 0.360, 90, 90, 90)\n",
+    "    ),\n",
+    "    Structure(\n",
+    "        title=\"ferrite\",\n",
+    "        atoms=[Atom(\"fe\", [0] * 3)],\n",
+    "        lattice=Lattice(0.287, 0.287, 0.287, 90, 90, 90)\n",
+    "    ),\n",
+    "]\n",
+    "phase_list = crystal_map.PhaseList(\n",
+    "    names=[\"austenite\", \"ferrite\"],\n",
+    "    point_groups=[\"432\", \"432\"],\n",
+    "    structures=structures,\n",
+    ")\n",
+    "\n",
+    "# Create a CrystalMap instance\n",
+    "xmap2 = crystal_map.CrystalMap(\n",
+    "    rotations=rotations,\n",
+    "    phase_id=phase_id,\n",
+    "    x=x,\n",
+    "    y=y,\n",
+    "    phase_list=phase_list,\n",
+    "    prop=properties,\n",
+    ")\n",
+    "xmap2.scan_unit = \"um\"\n",
+    "\n",
+    "xmap2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e6a639b",
+   "metadata": {},
+   "source": [
+    "## Save\n",
+    "\n",
+    "### orix HDF5 format\n",
+    "\n",
+    "As mentioned, the two writers implemented are orix's own HDF5 format and the\n",
+    ".ang format"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "119cf43a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "io.save(\n",
+    "    filename=datadir + \"sdss_ferrite_austenite2.h5\",\n",
+    "    object2write=xmap,\n",
+    "    overwrite=True,  # Default is False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "760cbce8",
+   "metadata": {},
+   "source": [
+    "Read the file contents back into a `CrystalMap` object using\n",
+    "[orix.io.load()](reference.rst#orix._io.load) function.\n",
+    "\n",
+    "All contents in this file can be inspected using any HDF5 viewer and read back\n",
+    "into Python using the h5py library (which we use).\n",
+    "\n",
+    "### .ang format\n",
+    "\n",
+    "The .ang writer supports many use cases. Some of these are demonstrated here,\n",
+    "by reloading the saved crystal maps.\n",
+    "\n",
+    "First, let's write the multi phase map to an .ang file, specifying that the\n",
+    "`xmap.dp` property should be written to the confidence index (CI) column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e1f1b79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fname_ang1 = \"sdss_dp_ci.ang\"\n",
+    "io.save(\n",
+    "    filename=datadir + fname_ang1,\n",
+    "    object2write=xmap,\n",
+    "    confidence_index_prop=\"dp\"\n",
+    ")\n",
+    "\n",
+    "xmap_reload1 = io.load(datadir + fname_ang1)\n",
+    "print(xmap_reload1)\n",
+    "print(xmap_reload1.prop)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d97410a0",
+   "metadata": {},
+   "source": [
+    "Note that points not in data are set to `not_indexed` when reloaded from the\n",
+    ".ang file, and that all properties in points not in the data set are set to\n",
+    "zero, except for the CI column where this property in points not in the data\n",
+    "(the austenite points) are set to -1, which MTEX and EDAX TSL expects in these\n",
+    "points.\n",
+    "\n",
+    "Finally, it is worth mentioning that if a map has more than one rotation/match\n",
+    "and phase ID per point, the index parameter can be passed to write any \"layer\"\n",
+    "of the data to file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dbb8a27e",
+   "metadata": {},
+   "source": [
+    "## Modify crystal phases\n",
+    "\n",
+    "The phases are stored in a `PhaseList` object in the `CrystalMap.phases` attribute"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "585a464e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.phases"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca0824a3",
+   "metadata": {},
+   "source": [
+    "### Symmetry"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ece5a97",
+   "metadata": {},
+   "source": [
+    "The point group symmetry are stored in the vendor and EMsoft files, however they\n",
+    "provide no space group symmetry. We can set this *per phase* by providing a\n",
+    "space group number (1-230) according to the International Tables of\n",
+    "Crystallography (useful link: http://img.chem.ucl.ac.uk/sgp/large/sgp.htm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d7b8c27",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.phases[1].space_group = 225\n",
+    "xmap.phases[2].space_group = 229\n",
+    "\n",
+    "xmap.phases"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "964bfb82",
+   "metadata": {},
+   "source": [
+    "Note that this also changed the point group, because this is always determined\n",
+    "from the space group. But the proper point group, without any inversion or\n",
+    "mirror planes, stayed the same. The `space_group` attribute stores a\n",
+    "`diffpy.structure.spacegroups.SpaceGroup` object (https://www.diffpy.org/diffpy.structure/mod_spacegroup.html#diffpy.structure.spacegroupmod.SpaceGroup).\n",
+    "\n",
+    "We can get the point group which a space group is the subgroup of"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3791feb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(get_point_group(200).name, get_point_group(230).name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00ca5864",
+   "metadata": {},
+   "source": [
+    "The point group stores symmetry operations as quaternions. We can get them as\n",
+    "orientation matrices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c55678f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.phases[1].point_group[:2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "664cbf03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.phases[1].point_group[:2].to_matrix()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d324243",
+   "metadata": {},
+   "source": [
+    "`diffpy.structure` stores rotation symmetry operations as orientation matrices\n",
+    "and translations as 1D arrays"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7acaa55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[(i.R, i.t) for i in xmap.phases[1].space_group.symop_list[:2]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0168a24c",
+   "metadata": {},
+   "source": [
+    "We can get the quaternion representation of these matrices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2e9fab5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[Rotation.from_matrix(i.R) for i in xmap.phases[1].space_group.symop_list[:2]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c4a46cc",
+   "metadata": {},
+   "source": [
+    "### Index phase list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "605e1de2",
+   "metadata": {},
+   "source": [
+    "The phase list can be indexed by phase ID or name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a9ee1d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.phases[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5bcde7ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.phases[\"austenite\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3513049",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.phases[1:]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6b50a19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.phases[\"austenite\", \"ferrite\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fef7c8da",
+   "metadata": {},
+   "source": [
+    "When asking for a single phase, either by an integer or a single string, a\n",
+    "`Phase` object was returned. In the other cases, a `PhaseList` object was\n",
+    "returned"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3cbdbfa8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(type(xmap.phases[1]), type(xmap.phases[1:]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec654200",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Valid point group names to use when setting the point group symmetry are"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6bf8c6e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from orix.quaternion.symmetry import _groups\n",
+    "\n",
+    "[point_group.name for point_group in _groups]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "adaf0629",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "xmap.phases[\"Austenite\"].point_group = \"-43m\"\n",
+    "\n",
+    "xmap.phases"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "499e5628",
+   "metadata": {},
+   "source": [
+    "Note that the `space_group` was set to `None` since space group Fm-3m is not a\n",
+    "subgroup of -43m.\n",
+    "\n",
+    "Let's revert to the correct space group (and the name, for convenience)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a25fedca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.phases[\"Austenite\"].name = \"austenite\"\n",
+    "xmap.phases[\"austenite\"].space_group = 225\n",
+    "\n",
+    "xmap.phases"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d17758f",
+   "metadata": {},
+   "source": [
+    "We can add a phase by giving its name and point group symmetry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0ef19d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.phases.add(Phase(\"sigma\", point_group=\"4/mmm\"))\n",
+    "\n",
+    "xmap.phases"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a71ccd6",
+   "metadata": {},
+   "source": [
+    "When adding a phase to the phase list like this, the phases' structure contains no atoms and the default lattice parameters are used"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b43405a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.phases[\"sigma\"].structure.lattice.abcABG()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34e7cafb",
+   "metadata": {},
+   "source": [
+    "So let's set this"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a60772e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "xmap.phases[\"sigma\"].structure.lattice = Lattice(0.880, 0.880, 0.880, 90, 90, 90)\n",
+    "print(xmap.phases[\"sigma\"].structure.lattice)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03135ea7",
+   "metadata": {},
+   "source": [
+    "If some data points are considered as not indexed, a \"not_indexed\" phase can be\n",
+    "added to the phase list to keep track of these points"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b27af5c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.phases.add_not_indexed()\n",
+    "\n",
+    "xmap.phases"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ab94d7e",
+   "metadata": {},
+   "source": [
+    "No points in this data set are considered not indexed. A phase list with only\n",
+    "the phases in the data is stored in the `phases_in_data` attribute"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1d9aebb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.phases_in_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d950d83",
+   "metadata": {},
+   "source": [
+    "We can of course remove a phase from the phase list, either by its name or phase ID"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8e4a860",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del xmap.phases[\"sigma\"]\n",
+    "del xmap.phases[-1]\n",
+    "\n",
+    "xmap.phases"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66280417",
+   "metadata": {},
+   "source": [
+    "### Properties"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0757d30c",
+   "metadata": {},
+   "source": [
+    "The phase name, space group, point group, proper point group, color and\n",
+    "structure can be accessed for the full phase list or a single phase"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f88d96e1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(xmap.phases.names)\n",
+    "print([i.short_name for i in xmap.phases.space_groups])\n",
+    "print([i.name for i in xmap.phases.point_groups])\n",
+    "print([i.proper_subgroup.name for i in xmap.phases.point_groups])\n",
+    "print(xmap.phases.colors)\n",
+    "print(xmap.phases.structures)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6455171d",
+   "metadata": {},
+   "source": [
+    "Note that the structures' representations are empty lists since no atoms have been added to them yet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93dc3baf",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "xmap.phases[\"austenite\"]\n",
+    "print(xmap.phases[\"austenite\"].name)\n",
+    "print(xmap.phases[\"austenite\"].space_group.short_name)\n",
+    "print(xmap.phases[\"austenite\"].point_group.name)\n",
+    "print(xmap.phases[\"austenite\"].point_group.proper_subgroup.name)\n",
+    "print(xmap.phases[\"austenite\"].color)\n",
+    "print(xmap.phases[\"austenite\"].structure)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a9915b8",
+   "metadata": {},
+   "source": [
+    "These attributes (not the phase ID) can be set *per phase*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "250c0f34",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "xmap.phases[\"austenite\"].name = \"Austenite\"\n",
+    "\n",
+    "xmap.phases[\"Austenite\"].structure = Structure(\n",
+    "    lattice=Lattice(0.36, 0.36, 0.36, 90, 90, 90)\n",
+    ")\n",
+    "print(xmap.phases[\"Austenite\"].structure)\n",
+    "\n",
+    "xmap.phases[\"Austenite\"].color = \"lime\"  # Sets RGB tuple (0, 1, 0)\n",
+    "print(xmap.phases[\"Austenite\"].color_rgb)\n",
+    "\n",
+    "xmap.phases"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "181fe2c1",
+   "metadata": {},
+   "source": [
+    "Valid color strings can be found here: https://matplotlib.org/3.1.0/tutorials/colors/colors.html\n",
+    "\n",
+    "### Create phase list\n",
+    "\n",
+    "We can create a phase list by calling `PhaseList.__init__()`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c12d153",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PhaseList(\n",
+    "    names=['al', 'cu'],\n",
+    "    space_groups=[225, 225],\n",
+    "    colors=['lime', 'xkcd:violet'],\n",
+    "    ids=[0, 1],\n",
+    "    structures=[\n",
+    "        Structure(\n",
+    "            atoms=[Atom(\"al\", [0] * 3)],\n",
+    "            lattice=Lattice(0.405, 0.405, 0.405, 90, 90, 90)\n",
+    "        ),\n",
+    "        Structure(\n",
+    "            atoms=[Atom(\"cu\", [0] * 3)],\n",
+    "            lattice=Lattice(0.361, 0.361, 0.361, 90, 90, 90)\n",
+    "        )\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aad2f7fa",
+   "metadata": {},
+   "source": [
+    "or by creating `Phase` objects and passing these to the first argument in\n",
+    "`PhaseList.__init__()` as a list (or single `Phase` objects)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5dc7d775",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "al = Phase(name='al', space_group=225, color=\"C0\")\n",
+    "cu = Phase(\n",
+    "    color=\"C1\",\n",
+    "    structure=Structure(\n",
+    "        title=\"cu\",\n",
+    "        lattice=Lattice(0.361, 0.361, 0.361, 90, 90, 90)\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "PhaseList([al, cu])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50f50b7a",
+   "metadata": {},
+   "source": [
+    "Note that the Cu phase name was retrieved from the `Structure` object.\n",
+    "\n",
+    "### Copying\n",
+    "\n",
+    "If we want a shallow copy of the phase list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a32db74e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pl = xmap.phases\n",
+    "pl[\"ferrite\"].color = \"red\"\n",
+    "\n",
+    "xmap.phases"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49be6be5",
+   "metadata": {},
+   "source": [
+    "If we want a deep copy of the phase list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9c874a7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "pl = xmap.phases.deepcopy()\n",
+    "pl.add(Phase(\"chi\", point_group=\"-43m\"))\n",
+    "print(pl, \"\\n\")\n",
+    "\n",
+    "print(xmap.phases)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed355d21",
+   "metadata": {},
+   "source": [
+    "## Inspect orientation data\n",
+    "\n",
+    "Orientations are stored as rotations in a `Rotation` object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2494835",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.rotations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3305c52",
+   "metadata": {},
+   "source": [
+    "Orientations *per phase* can be obtained by applying the phase point group\n",
+    "symmetry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2fbc9396",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "o_austenite = xmap[\"austenite\"].orientations\n",
+    "\n",
+    "o_austenite"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "591af272",
+   "metadata": {},
+   "source": [
+    "The above is equivalent to"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a74902ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Orientation(xmap[\"austenite\"].rotations).set_symmetry(\n",
+    "    xmap[\"austenite\"].phases[1].point_group\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c417d35",
+   "metadata": {},
+   "source": [
+    "Orientation angles and axes are readily available"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79946e91",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "o_austenite.angle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a55badec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Obtain as a numpy.ndarray\n",
+    "o_austenite.angle.data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d8c813da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "o_austenite.axis.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e392132",
+   "metadata": {},
+   "source": [
+    "## Inspect, add and delete map properties\n",
+    "\n",
+    "Map properties are stored in the `CrystalMap.prop` attribute dictionary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93ac3045",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.prop"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "120a42a4",
+   "metadata": {},
+   "source": [
+    "All properties in this dictionary are also available directly from the `CrystalMap` as attributes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08865345",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.iq"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d3fbf98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.dp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5cb28b6",
+   "metadata": {},
+   "source": [
+    "We can add a map property by specifying its name and an initial value in each map point"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e7f88a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.prop[\"grain_boundary\"] = 0\n",
+    "\n",
+    "xmap.grain_boundary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b556c3df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.prop[\"grain_boundary2\"] = np.arange(xmap.size, dtype=int)\n",
+    "\n",
+    "xmap.grain_boundary2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df1a6b8a",
+   "metadata": {},
+   "source": [
+    "We can also delete a property from the `prop` dictionary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74ab9e0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del xmap.prop[\"grain_boundary2\"]\n",
+    "\n",
+    "xmap.prop"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1935956",
+   "metadata": {},
+   "source": [
+    "## Select and modify data based upon criteria\n",
+    "\n",
+    "We can select data in a crystal map in three ways:\n",
+    "1. by phase name or \"indexed\"/\"not_indexed\"\n",
+    "2. by a slice\n",
+    "3. by a boolean array\n",
+    "\n",
+    "Getting all data belonging to one phase"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91be8720",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap[\"austenite\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b688ed1e",
+   "metadata": {},
+   "source": [
+    "or two phases"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4dab3088",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap[\"austenite\", \"ferrite\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6443007c",
+   "metadata": {},
+   "source": [
+    "or all indexed points"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c6922bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap[\"indexed\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d519b13",
+   "metadata": {},
+   "source": [
+    "or all non-indexed points"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f501c987",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap[\"not_indexed\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0b5ea02",
+   "metadata": {},
+   "source": [
+    "When slicing a crystal map, it is important to know the data size and shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15236dca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9aeab8e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "406f4775",
+   "metadata": {},
+   "source": [
+    "So, to get the data within a rectangle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e77c3aa5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap[20:50, 40:90]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7b56f87",
+   "metadata": {},
+   "source": [
+    "The most powerful way to select data is by requiring a certain criteria"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa8712c0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "dp_mean = xmap.dp.mean()\n",
+    "print(dp_mean)\n",
+    "\n",
+    "xmap_high_dp = xmap[xmap.dp > dp_mean]\n",
+    "print(xmap_high_dp.dp.min())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fbfdfb15",
+   "metadata": {},
+   "source": [
+    "Note that when selecting a subset of the data, a shallow copy (view) of the\n",
+    "crystal map is obtained. This means that whatever changes made to `xmap_high_dp`\n",
+    "also change `xmap`. When we want a deep copy, we use the `CrystalMap.deepcopy()`\n",
+    "method"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2424776",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap_nobody_owns_me = xmap[xmap.dp > dp_mean].deepcopy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42bdebbf",
+   "metadata": {},
+   "source": [
+    "We can chain the criteria"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f349760d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap[(xmap.dp > 0.81) & (xmap.phase_id == 1)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4880c262",
+   "metadata": {},
+   "source": [
+    "## Plotting\n",
+    "\n",
+    "All map plotting is done via a `matplotlib` \"projection\" named \"plot_map\". To plot a phase map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "011deff9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
+    "im = ax.plot_map(xmap)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd1fc6e6",
+   "metadata": {},
+   "source": [
+    "Hover over figure points to display the (x,y) position and orientations in that point!\n",
+    "\n",
+    "Note that `plot_map()` wraps `matplotlib.axes.Axes.imshow`. All key word arguments in `plot_map()` are passed to `imshow()`, so be sure to check [its documentation](https://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.imshow.html?highlight=imshow#matplotlib.axes.Axes.imshow) out for any additional arguments.\n",
+    "\n",
+    "We can add any overlay, from any property with a value in each map point, to the map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97843d97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax.add_overlay(xmap, xmap.dp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "313b16dd",
+   "metadata": {},
+   "source": [
+    "To save our phase map with the scalebar and legend, but without white padding"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c647fd4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax.remove_padding()\n",
+    "fig.savefig(\n",
+    "    datadir + 'phase_map.png',\n",
+    "    bbox_inches=\"tight\",\n",
+    "    pad_inches=0,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "410229cc",
+   "metadata": {},
+   "source": [
+    "To save phase map without scalebar, legend and white padding, and one image pixel per map point"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e88a126",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imsave(\n",
+    "    datadir + 'phase_no_fluff.png',\n",
+    "    arr=im.get_array()  # 2D NumPy array, possibly with an RGB tuple in each element\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed572463",
+   "metadata": {},
+   "source": [
+    "We can plot any property with a value in each map point"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82fc8a12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
+    "im = ax.plot_map(xmap, xmap.dp, cmap=\"inferno\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50446cf6",
+   "metadata": {},
+   "source": [
+    "And change the colormap later if we want to"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10c99107",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "im.set_cmap(\"viridis\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1836e13a",
+   "metadata": {},
+   "source": [
+    "And add a colorbar if we want"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "761c694c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cbar = ax.add_colorbar(label=\"Dottproduct\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c0faf81",
+   "metadata": {},
+   "source": [
+    "Which we can update if we mispelled the label or want other adjustements"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee8604c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cbar.ax.set_ylabel(\"Dot product\", rotation=270);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f0d72ba",
+   "metadata": {},
+   "source": [
+    "We can also plot orientation related values, like axis and angles etc., and restrict the color bar maximum"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dabbff0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get rotation angles in degrees\n",
+    "angles = xmap.rotations.angle.data * 180 / np.pi\n",
+    "\n",
+    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
+    "im = ax.plot_map(xmap, angles, vmax=angles.max() - 10)\n",
+    "\n",
+    "ax.add_overlay(xmap, xmap.iq)\n",
+    "\n",
+    "ax.add_colorbar(label=\"Rotation angle\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4443529d",
+   "metadata": {},
+   "source": [
+    "To plot only one phase, while passing custom\n",
+    "* scalebar properties (https://matplotlib.org/mpl_toolkits/axes_grid/api/anchored_artists_api.html#mpl_toolkits.axes_grid1.anchored_artists.AnchoredSizeBar)\n",
+    "* legend properties (https://matplotlib.org/3.3.0/api/_as_gen/matplotlib.pyplot.legend.html)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a47eb54d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
+    "im = ax.plot_map(\n",
+    "    xmap[\"austenite\"],\n",
+    "    scalebar=True,  # False for removed\n",
+    "    scalebar_properties={\n",
+    "        \"loc\": 4,  # 1: upper right, 2: upper left, etc. counter-clockwise\n",
+    "        \"frameon\": False,\n",
+    "        \"sep\": 6,  # Vertical spacing between bar and text\n",
+    "        \"size_vertical\": 0.2,  # Bar height\n",
+    "    },\n",
+    "    legend_properties={\n",
+    "        \"framealpha\": 1,  # 0: fully transparent, 1: opaque\n",
+    "        \"handlelength\": 1.5,  # Colored square width\n",
+    "        \"handletextpad\": 0.1,  # Horizontal space between square and text\n",
+    "        \"borderpad\": 0.1,\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68163543",
+   "metadata": {},
+   "source": [
+    "Plot only a rectangle of the map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18b24e04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap2 = xmap[20:50, 40:90]\n",
+    "\n",
+    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
+    "ax.plot_map(xmap2)\n",
+    "ax.add_overlay(xmap2, xmap2.dp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b74afe67",
+   "metadata": {},
+   "source": [
+    "Plot only parts of a map based on chained conditionals, like belonging to one phase or having a property value above a threshold"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6730731a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Conditional slicing\n",
+    "xmap2 = xmap[xmap.dp > 0.81]\n",
+    "\n",
+    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
+    "ax.plot_map(xmap2, xmap2.iq, cmap=\"gray\")\n",
+    "ax.add_colorbar(\"Image quality\")\n",
+    "\n",
+    "# Chained conditional slicing\n",
+    "xmap2 = xmap[(xmap.dp > 0.81) & (xmap.phase_id == 1)]\n",
+    "\n",
+    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
+    "ax.plot_map(xmap2, xmap2.dp, cmap=\"cividis\")\n",
+    "ax.add_colorbar(\"Dot product\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0d668fd",
+   "metadata": {},
+   "source": [
+    "Plot histogram of a property per phase"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de64ba2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Property of interest\n",
+    "this_prop = 'dp'\n",
+    "\n",
+    "# Plot phase map again to see color changes\n",
+    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
+    "ax.plot_map(xmap)\n",
+    "\n",
+    "# Add overlay, passing str (can also pass numpy.ndarray)\n",
+    "ax.add_overlay(xmap, this_prop)\n",
+    "\n",
+    "# Remove figure padding\n",
+    "ax.remove_padding()\n",
+    "\n",
+    "# Declare lists for plotting\n",
+    "data = []\n",
+    "labels = []\n",
+    "colors = []\n",
+    "\n",
+    "# Get property values, name and color per phase\n",
+    "for _, p in xmap.phases_in_data:\n",
+    "    labels.append(p.name)\n",
+    "    colors.append(p.color)\n",
+    "\n",
+    "    # Accessing the property dictionary directly\n",
+    "    data.append(xmap[p.name].prop[this_prop])\n",
+    "    # or indirectly\n",
+    "    #data.append(xmap[p.name].dp)\n",
+    "\n",
+    "# Nice bar plot with property histogram per phase\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.hist(\n",
+    "    data,\n",
+    "    bins=20,\n",
+    "    histtype='bar',\n",
+    "    density=True,\n",
+    "    label=labels,\n",
+    "    color=colors\n",
+    ")\n",
+    "ax.set_xlabel(this_prop)\n",
+    "ax.set_ylabel(\"Frequency\")\n",
+    "ax.legend();"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -24,6 +24,7 @@ Work using orix
 
     crystal_geometry.ipynb
     stereographic_projection.ipynb
+    crystal_maps.ipynb
 
 .. toctree::
     :hidden:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -24,7 +24,7 @@ Work using orix
 
     crystal_geometry.ipynb
     stereographic_projection.ipynb
-    crystal_maps.ipynb
+    crystal_map.ipynb
 
 .. toctree::
     :hidden:

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -79,6 +79,7 @@ CrystalMap
 .. autosummary::
     deepcopy
     get_map_data
+    plot
 .. autoclass:: orix.crystal_map.CrystalMap
     :members:
     :undoc-members:

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -744,6 +744,9 @@ class CrystalMap:
         scalebar_properties=None,
         legend=True,
         legend_properties=None,
+        colorbar=False,
+        colorbar_label=None,
+        colorbar_properties=dict(),
         remove_padding=False,
         return_figure=False,
         figure_kwargs=dict(),
@@ -767,15 +770,22 @@ class CrystalMap:
         scalebar : bool, optional
             Whether to add a scalebar (default is True) along the
             horizontal map dimension.
-        scalebar_properties : dict
+        scalebar_properties : dict, optional
             Keyword arguments passed to
             :class:`matplotlib_scalebar.scalebar.ScaleBar`.
         legend : bool, optional
             Whether to add a legend to the plot. This is only
             implemented for a phase plot (in which case default is
             True).
-        legend_properties : dict
+        legend_properties : dict, optional
             Keyword arguments passed to :meth:`matplotlib.axes.legend`.
+        colorbar : bool, optional
+            Whether to add an opinionated colorbar (default is False).
+        colorbar_label : str, optional
+            Label/title of colorbar.
+        colorbar_properties : dict, optional
+            Keyword arguments passed to
+            :meth:`orix.plot.CrystalMapPlot.add_colorbar`.
         axes : tuple of ints, optional
             Which data axes to plot if data has more than two
             dimensions. The index of data to plot in the final dimension
@@ -824,6 +834,8 @@ class CrystalMap:
             ax.add_overlay(self, overlay)
         if remove_padding:
             ax.remove_padding()
+        if colorbar:
+            ax.add_colorbar(label=colorbar_label, **colorbar_properties)
         if return_figure:
             return fig
 

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -18,6 +18,7 @@
 
 import copy
 
+import matplotlib.pyplot as plt
 import numpy as np
 
 from orix.crystal_map.crystal_map_properties import CrystalMapProperties
@@ -627,6 +628,10 @@ class CrystalMap:
 
         return representation
 
+    def deepcopy(self):
+        """Return a deep copy using :func:`copy.deepcopy` function."""
+        return copy.deepcopy(self)
+
     def get_map_data(self, item, decimals=3, fill_value=None):
         """Return an array of a class instance attribute, with values
         equal to ``False`` in ``self.is_in_data`` set to `fill_value`, of
@@ -731,9 +736,96 @@ class CrystalMap:
 
         return output_array
 
-    def deepcopy(self):
-        """Return a deep copy using :func:`copy.deepcopy` function."""
-        return copy.deepcopy(self)
+    def plot(
+        self,
+        value=None,
+        overlay=None,
+        scalebar=True,
+        scalebar_properties=None,
+        legend=True,
+        legend_properties=None,
+        remove_padding=False,
+        return_figure=False,
+        figure_kwargs=dict(),
+        **kwargs,
+    ):
+        r"""Plot a 2D map with any crystallographic map property as map
+        values.
+
+        Wraps :meth:`matplotlib.axes.Axes.imshow`, see that method for
+        relevant keyword arguments.
+
+        Parameters
+        ----------
+        value : numpy.ndarray, optional
+            Attribute array to plot. If None (default), a phase map is
+            plotted.
+        overlay : str or numpy.ndarray, optional
+            Name of map property or a property array to use in the
+            alpha (RGBA) channel. The property range is adjusted for
+            maximum contrast. Default is None.
+        scalebar : bool, optional
+            Whether to add a scalebar (default is True) along the
+            horizontal map dimension.
+        scalebar_properties : dict
+            Dictionary of keyword arguments passed to
+            :func:`mpl_toolkits.axes_grid1.anchored_artists.AnchoredSizeBar`.
+        legend : bool, optional
+            Whether to add a legend to the plot. This is only
+            implemented for a phase plot (in which case default is
+            True).
+        legend_properties : dict
+            Dictionary of keyword arguments passed to
+            :meth:`matplotlib.axes.legend`.
+        axes : tuple of ints, optional
+            Which data axes to plot if data has more than two
+            dimensions. The index of data to plot in the final dimension
+            is determined by `depth`. If None (default), data along the
+            two last axes is plotted.
+        depth : int, optional
+            Which layer along the third axis to plot if data has more
+            than two dimensions. If None (default), data in the first
+            index (layer) is plotted.
+        return_figure: bool, optional
+            Whether to return the figure (default is False).
+        figure_kwargs : dict, optional
+            Dictionary of keyword arguments passed to
+            :func:`matplotlib.pyplot.subplots`.
+        kwargs
+            Keyword arguments passed to
+            :meth:`matplotlib.axes.Axes.imshow`.
+
+        Returns
+        -------
+        fig : matplotlib.figure.Figure
+            The created figure, returned if `return_figure` is True.
+
+        See Also
+        --------
+        matplotlib.axes.Axes.imshow
+        orix.plot.CrystalMapPlot.plot_map
+        orix.plot.CrystalMapPlot.add_scalebar
+        orix.plot.CrystalMapPlot.add_overlay
+        orix.plot.CrystalMapPlot.add_colorbar
+        """
+        import orix.plot.crystal_map_plot
+
+        fig, ax = plt.subplots(subplot_kw=dict(projection="plot_map"), **figure_kwargs)
+        ax.plot_map(
+            self,
+            value=value,
+            scalebar=scalebar,
+            scalebar_properties=scalebar_properties,
+            legend=legend,
+            legend_properties=legend_properties,
+            **kwargs,
+        )
+        if overlay is not None:
+            ax.add_overlay(self, overlay)
+        if remove_padding:
+            ax.remove_padding()
+        if return_figure:
+            return fig
 
     @staticmethod
     def _step_size_from_coordinates(coordinates):

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -768,15 +768,14 @@ class CrystalMap:
             Whether to add a scalebar (default is True) along the
             horizontal map dimension.
         scalebar_properties : dict
-            Dictionary of keyword arguments passed to
-            :func:`mpl_toolkits.axes_grid1.anchored_artists.AnchoredSizeBar`.
+            Keyword arguments passed to
+            :class:`matplotlib_scalebar.scalebar.ScaleBar`.
         legend : bool, optional
             Whether to add a legend to the plot. This is only
             implemented for a phase plot (in which case default is
             True).
         legend_properties : dict
-            Dictionary of keyword arguments passed to
-            :meth:`matplotlib.axes.legend`.
+            Keyword arguments passed to :meth:`matplotlib.axes.legend`.
         axes : tuple of ints, optional
             Which data axes to plot if data has more than two
             dimensions. The index of data to plot in the final dimension
@@ -789,7 +788,7 @@ class CrystalMap:
         return_figure: bool, optional
             Whether to return the figure (default is False).
         figure_kwargs : dict, optional
-            Dictionary of keyword arguments passed to
+            Keyword arguments passed to
             :func:`matplotlib.pyplot.subplots`.
         kwargs
             Keyword arguments passed to
@@ -808,6 +807,7 @@ class CrystalMap:
         orix.plot.CrystalMapPlot.add_overlay
         orix.plot.CrystalMapPlot.add_colorbar
         """
+        # Register "plot_map" projection with Matplotlib
         import orix.plot.crystal_map_plot
 
         fig, ax = plt.subplots(subplot_kw=dict(projection="plot_map"), **figure_kwargs)

--- a/orix/plot/__init__.py
+++ b/orix/plot/__init__.py
@@ -28,14 +28,13 @@ Example of usage::
     >>> ax.scatter(vector.Vector3d([[0, 0, 1], [1, 0, 1]]))
 """
 
-from orix.plot.crystal_map_plot import convert_unit, CrystalMapPlot
+from orix.plot.crystal_map_plot import CrystalMapPlot
 from orix.plot.rotation_plot import AxAnglePlot, RodriguesPlot, RotationPlot
 from orix.plot.stereographic_plot import StereographicPlot
 
 
 # Lists what will be imported when calling "from orix.plot import *"
 __all__ = [
-    "convert_unit",
     "CrystalMapPlot",
     "AxAnglePlot",
     "RodriguesPlot",

--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -22,7 +22,7 @@ from matplotlib.axes import Axes
 from matplotlib.image import AxesImage
 from matplotlib.projections import register_projection
 from mpl_toolkits.axes_grid1 import make_axes_locatable
-from matplotlib_scalebar.scalebar import ScaleBar
+from matplotlib_scalebar import dimension, scalebar
 import numpy as np
 
 from orix.scalar import Scalar
@@ -238,6 +238,15 @@ class CrystalMapPlot(Axes):
         last_axis = crystal_map.ndim - 1
         horizontal = crystal_map._coordinate_axes[last_axis]
 
+        # Set a reasonable unit dimension
+        scan_unit = crystal_map.scan_unit
+        if scan_unit == "px":
+            dim = "pixel-length"
+        elif scan_unit[-1] == "m":
+            dim = "si-length"  # Default
+        else:
+            dim = dimension._Dimension(scan_unit)
+
         # Set up arguments to AnchoredSizeBar() if not already present in kwargs
         d = dict(
             pad=0.2,
@@ -246,11 +255,12 @@ class CrystalMapPlot(Axes):
             location="lower left",
             box_alpha=0.6,
             font_properties=dict(size=11),
+            dimension=dim,
         )
         [kwargs.setdefault(k, v) for k, v in d.items()]
 
         # Create scalebar
-        bar = ScaleBar(
+        bar = scalebar.ScaleBar(
             dx=crystal_map._step_sizes[horizontal],
             units=crystal_map.scan_unit,
             **kwargs,

--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-import matplotlib.font_manager as fm
 import matplotlib.patches as mpatches
 from matplotlib.axes import Axes
 from matplotlib.image import AxesImage
@@ -38,6 +37,8 @@ class CrystalMapPlot(Axes):
     _data_axes = None
     _data_slices = None
     _data_shape = None
+    colorbar = None
+    scalebar = None
 
     def plot_map(
         self,
@@ -203,7 +204,9 @@ class CrystalMapPlot(Axes):
         return im
 
     def add_scalebar(self, crystal_map, **kwargs):
-        """Add a scalebar to the axes instance.
+        """Add a scalebar to the axes instance and return it.
+
+        The scalebar is also available as an attribute :attr:`scalebar`.
 
         Parameters
         ----------
@@ -254,7 +257,6 @@ class CrystalMapPlot(Axes):
             border_pad=0.5,
             location="lower left",
             box_alpha=0.6,
-            font_properties=dict(size=11),
             dimension=dim,
         )
         [kwargs.setdefault(k, v) for k, v in d.items()]
@@ -266,6 +268,7 @@ class CrystalMapPlot(Axes):
             **kwargs,
         )
         self.axes.add_artist(bar)
+        self.scalebar = bar
 
         return bar
 
@@ -319,7 +322,9 @@ class CrystalMapPlot(Axes):
         image.set_data(image_data)
 
     def add_colorbar(self, label=None, **kwargs):
-        """Add an opinionated colorbar to the figure.
+        """Add an opinionated colorbar to the figure and return it.
+
+        The colorbar is also available as an attribute :attr:`colorbar`.
 
         Parameters
         ----------
@@ -367,6 +372,8 @@ class CrystalMapPlot(Axes):
         # Set label with padding
         cbar.ax.get_yaxis().labelpad = 15
         cbar.ax.set_ylabel(label, rotation=270)
+
+        self.colorbar = cbar
 
         return cbar
 
@@ -458,7 +465,6 @@ class CrystalMapPlot(Axes):
             "handlelength": 0.75,
             "handletextpad": 0.3,
             "framealpha": 0.6,
-            "prop": fm.FontProperties(size=11),
         }
         [kwargs.setdefault(k, v) for k, v in d.items()]
         self.legend(handles=patches, **kwargs)

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -35,15 +35,15 @@ class TestCrystalMapInit:
 
         assert isinstance(rotations, Rotation)
 
-        cm = CrystalMap(rotations=rotations)
+        xmap = CrystalMap(rotations=rotations)
 
-        assert np.allclose(cm.x, np.arange(map_size))
-        assert cm.size == map_size
-        assert cm.shape == (map_size,)
-        assert cm.ndim
-        assert np.allclose(cm.id, np.arange(map_size))
-        assert isinstance(cm.rotations, Rotation)
-        assert np.allclose(cm.rotations.data, rotations.data)
+        assert np.allclose(xmap.x, np.arange(map_size))
+        assert xmap.size == map_size
+        assert xmap.shape == (map_size,)
+        assert xmap.ndim
+        assert np.allclose(xmap.id, np.arange(map_size))
+        assert isinstance(xmap.rotations, Rotation)
+        assert np.allclose(xmap.rotations.data, rotations.data)
 
     @pytest.mark.parametrize("rotation_format", ["array", "list"])
     def test_init_with_invalid_rotations(self, rotations, rotation_format):
@@ -91,20 +91,20 @@ class TestCrystalMapInit:
         expected_step_sizes,
         expected_rotations_per_point,
     ):
-        cm = CrystalMap(**crystal_map_input)
+        xmap = CrystalMap(**crystal_map_input)
         coordinate_arrays = [
             crystal_map_input["z"],
             crystal_map_input["y"],
             crystal_map_input["x"],
         ]
 
-        assert cm.shape == expected_shape
-        assert cm.size == expected_size
-        assert cm._step_sizes == expected_step_sizes
-        assert cm.rotations_per_point == expected_rotations_per_point
+        assert xmap.shape == expected_shape
+        assert xmap.size == expected_size
+        assert xmap._step_sizes == expected_step_sizes
+        assert xmap.rotations_per_point == expected_rotations_per_point
 
         for actual_coords, expected_coords, expected_step_size in zip(
-            cm._coordinates.values(), coordinate_arrays, expected_step_sizes.values()
+            xmap._coordinates.values(), coordinate_arrays, expected_step_sizes.values()
         ):
             print(actual_coords, expected_coords)
             if expected_coords is None:
@@ -115,11 +115,11 @@ class TestCrystalMapInit:
     def test_init_map_with_props(self, crystal_map_input):
         x = crystal_map_input["x"]
         props = {"iq": np.arange(x.size)}
-        cm = CrystalMap(prop=props, **crystal_map_input)
+        xmap = CrystalMap(prop=props, **crystal_map_input)
 
-        assert cm.prop == props
-        assert np.allclose(cm.prop.id, cm.id)
-        assert np.allclose(cm.prop.is_in_data, cm.is_in_data)
+        assert xmap.prop == props
+        assert np.allclose(xmap.prop.id, xmap.id)
+        assert np.allclose(xmap.prop.is_in_data, xmap.is_in_data)
 
     @pytest.mark.parametrize(
         "crystal_map_input",
@@ -131,16 +131,16 @@ class TestCrystalMapInit:
     )
     def test_init_with_phase_id(self, crystal_map_input):
         phase_id = crystal_map_input["phase_id"]
-        cm = CrystalMap(**crystal_map_input)
+        xmap = CrystalMap(**crystal_map_input)
 
-        assert np.allclose(cm.phase_id, phase_id)
+        assert np.allclose(xmap.phase_id, phase_id)
         # Test all_indexed
         if -1 in np.unique(phase_id):
-            assert not cm.all_indexed
-            assert -1 in cm.phases.ids
+            assert not xmap.all_indexed
+            assert -1 in xmap.phases.ids
         else:
-            assert cm.all_indexed
-            assert -1 not in cm.phases.ids
+            assert xmap.all_indexed
+            assert -1 not in xmap.phases.ids
 
     @pytest.mark.parametrize(
         "crystal_map_input",
@@ -154,25 +154,25 @@ class TestCrystalMapInit:
     def test_init_with_phase_list(self, crystal_map_input):
         point_groups = [C2, C3, C4]
         phase_list = PhaseList(point_groups=point_groups)
-        cm = CrystalMap(phase_list=phase_list, **crystal_map_input)
+        xmap = CrystalMap(phase_list=phase_list, **crystal_map_input)
 
         n_point_groups = len(point_groups)
-        n_phase_ids = len(cm.phases.ids)
+        n_phase_ids = len(xmap.phases.ids)
         n_different = n_point_groups - n_phase_ids
         if n_different < 0:
             point_groups += [None] * abs(n_different)
         assert [
-            cm.phases.point_groups[i] == point_groups[i] for i in range(n_phase_ids)
+            xmap.phases.point_groups[i] == point_groups[i] for i in range(n_phase_ids)
         ]
 
         unique_phase_ids = list(np.unique(crystal_map_input["phase_id"]).astype(int))
-        assert cm.phases.ids == unique_phase_ids
+        assert xmap.phases.ids == unique_phase_ids
 
     def test_init_with_single_point_group(self, crystal_map_input):
         point_group = O
         phase_list = PhaseList(point_groups=point_group)
-        cm = CrystalMap(phase_list=phase_list, **crystal_map_input)
-        assert np.allclose(cm.phases.point_groups[0].data, point_group.data)
+        xmap = CrystalMap(phase_list=phase_list, **crystal_map_input)
+        assert np.allclose(xmap.phases.point_groups[0].data, point_group.data)
 
     @pytest.mark.parametrize(
         "crystal_map_input, phase_names, phase_ids, desired_phase_names",
@@ -223,10 +223,10 @@ class TestCrystalMapGetItem:
         indirect=["crystal_map_input"],
     )
     def test_get_by_slice(self, crystal_map_input, slice_tuple, expected_shape):
-        cm = CrystalMap(**crystal_map_input)
+        xmap = CrystalMap(**crystal_map_input)
 
-        cm2 = cm[slice_tuple]
-        assert cm2.shape == expected_shape
+        xmap2 = xmap[slice_tuple]
+        assert xmap2.shape == expected_shape
 
     def test_get_by_phase_name(self, crystal_map_input, phase_list):
         x = crystal_map_input["x"]
@@ -242,27 +242,27 @@ class TestCrystalMapGetItem:
             n_points_per_phase[phase.name] = len(np.where(phase_ids == phase_i)[0])
 
         crystal_map_input.pop("phase_id")
-        cm = CrystalMap(phase_id=phase_ids, **crystal_map_input)
-        cm.phases = phase_list
+        xmap = CrystalMap(phase_id=phase_ids, **crystal_map_input)
+        xmap.phases = phase_list
 
         for (_, phase), (expected_phase_name, n_points) in zip(
             phase_list, n_points_per_phase.items()
         ):
-            cm2 = cm[phase.name]
+            xmap2 = xmap[phase.name]
 
-            assert cm2.size == n_points
-            assert cm2.phases_in_data.names == [expected_phase_name]
+            assert xmap2.size == n_points
+            assert xmap2.phases_in_data.names == [expected_phase_name]
 
     def test_get_by_indexed_not_indexed(self, crystal_map):
-        cm = crystal_map
+        xmap = crystal_map
 
         # Set some points to not_indexed
-        cm[2:4].phase_id = -1
+        xmap[2:4].phase_id = -1
 
-        indexed = cm["indexed"]
-        not_indexed = cm["not_indexed"]
+        indexed = xmap["indexed"]
+        not_indexed = xmap["not_indexed"]
 
-        assert indexed.size + not_indexed.size == cm.size
+        assert indexed.size + not_indexed.size == xmap.size
         assert np.allclose(np.unique(not_indexed.phase_id), np.array([-1]))
         assert np.allclose(np.unique(indexed.phase_id), np.array([0]))
 
@@ -272,33 +272,33 @@ class TestCrystalMapGetItem:
         indirect=["crystal_map_input"],
     )
     def test_get_by_condition(self, crystal_map_input):
-        cm = CrystalMap(**crystal_map_input)
+        xmap = CrystalMap(**crystal_map_input)
 
-        cm.prop["dp"] = np.arange(cm.size)
+        xmap.prop["dp"] = np.arange(xmap.size)
 
         n_points = 2
-        assert cm.shape == (4, 3)  # Test code assumption
-        cm[0, :n_points].dp = -1
-        cm2 = cm[cm.dp < 0]
+        assert xmap.shape == (4, 3)  # Test code assumption
+        xmap[0, :n_points].dp = -1
+        xmap2 = xmap[xmap.dp < 0]
 
-        assert cm2.size == n_points
-        assert np.sum(cm2.dp) == -n_points
+        assert xmap2.size == n_points
+        assert np.sum(xmap2.dp) == -n_points
 
     def test_get_by_multiple_conditions(self, crystal_map, phase_list):
-        cm = crystal_map
+        xmap = crystal_map
 
         assert phase_list.ids == [0, 1, 2]  # Test code assumption
 
-        cm.phases = phase_list
-        cm.prop["dp"] = np.arange(cm.size)
+        xmap.phases = phase_list
+        xmap.prop["dp"] = np.arange(xmap.size)
         a_phase_id = phase_list.ids[0]
-        cm[cm.dp > 3].phase_id = a_phase_id
+        xmap[xmap.dp > 3].phase_id = a_phase_id
 
-        condition1 = cm.dp > 3
-        condition2 = cm.phase_id == a_phase_id
-        cm2 = cm[condition1 & condition2]
-        assert cm2.size == np.sum(condition1 * condition2)
-        assert np.allclose(cm2.is_in_data, condition1 * condition2)
+        condition1 = xmap.dp > 3
+        condition2 = xmap.phase_id == a_phase_id
+        xmap2 = xmap[condition1 & condition2]
+        assert xmap2.size == np.sum(condition1 * condition2)
+        assert np.allclose(xmap2.is_in_data, condition1 * condition2)
 
     @pytest.mark.parametrize(
         "crystal_map_input, integer_slices, expected_id, raises",
@@ -315,13 +315,13 @@ class TestCrystalMapGetItem:
         self, crystal_map_input, integer_slices, expected_id, raises
     ):
         # This also tests `phase_id`
-        cm = CrystalMap(**crystal_map_input)
+        xmap = CrystalMap(**crystal_map_input)
         if raises:
             with pytest.raises(IndexError, match=f".* is out of bounds for"):
-                _ = cm[integer_slices]
+                _ = xmap[integer_slices]
         else:
-            point = cm[integer_slices]
-            expected_point = cm[cm.id == expected_id]
+            point = xmap[integer_slices]
+            expected_point = xmap[xmap.id == expected_id]
 
             assert np.allclose(point.rotations.data, expected_point.rotations.data)
             assert point._coordinates == expected_point._coordinates
@@ -329,26 +329,26 @@ class TestCrystalMapGetItem:
 
 class TestCrystalMapSetAttributes:
     def test_set_scan_unit(self, crystal_map):
-        cm = crystal_map
-        assert cm.scan_unit == "px"
+        xmap = crystal_map
+        assert xmap.scan_unit == "px"
 
         micron = "um"
-        cm.scan_unit = micron
-        assert cm.scan_unit == micron
+        xmap.scan_unit = micron
+        assert xmap.scan_unit == micron
 
     @pytest.mark.parametrize("set_phase_id", [1, -1])
     def test_set_phase_ids(self, crystal_map, set_phase_id):
-        cm = crystal_map
+        xmap = crystal_map
 
-        phase_ids = cm.phase_id
-        condition = cm.x > 1.5
-        cm[condition].phase_id = set_phase_id
+        phase_ids = xmap.phase_id
+        condition = xmap.x > 1.5
+        xmap[condition].phase_id = set_phase_id
         phase_ids[condition] = set_phase_id
 
-        assert np.allclose(cm.phase_id, phase_ids)
+        assert np.allclose(xmap.phase_id, phase_ids)
 
         if set_phase_id == -1:
-            assert "not_indexed" in cm.phases.names
+            assert "not_indexed" in xmap.phases.names
 
     def test_set_phase_ids_raises(self, crystal_map):
         with pytest.raises(ValueError, match="NumPy boolean array indexing assignment"):
@@ -356,43 +356,43 @@ class TestCrystalMapSetAttributes:
 
     @pytest.mark.parametrize("set_phase_id, index_error", [(-1, False), (1, True)])
     def test_set_phase_id_with_unknown_id(self, crystal_map, set_phase_id, index_error):
-        cm = crystal_map
+        xmap = crystal_map
 
-        condition = cm.x > 1.5
-        phase_ids = cm.phases.ids  # Get before adding a new phase
+        condition = xmap.x > 1.5
+        phase_ids = xmap.phases.ids  # Get before adding a new phase
 
         if index_error:
             with pytest.raises(IndexError, match="list index out of range"):
                 # `set_phase_id` ID is not in `self.phases.phase_ids`
-                cm[condition].phase_id = set_phase_id
-                _ = repr(cm)
+                xmap[condition].phase_id = set_phase_id
+                _ = repr(xmap)
 
             # Add unknown ID to phase list to fix `repr(self)`
-            cm.phases.add(Phase("a", point_group=432))  # Add phase with ID 1
+            xmap.phases.add(Phase("a", point_group=432))  # Add phase with ID 1
         else:
-            cm[condition].phase_id = set_phase_id
+            xmap[condition].phase_id = set_phase_id
 
-        _ = repr(cm)
+        _ = repr(xmap)
 
         new_phase_ids = phase_ids + [set_phase_id]
         new_phase_ids.sort()
-        assert cm.phases.ids == new_phase_ids
+        assert xmap.phases.ids == new_phase_ids
 
     def test_phases_in_data(self, crystal_map, phase_list):
-        cm = crystal_map
-        cm.phases = phase_list
+        xmap = crystal_map
+        xmap.phases = phase_list
 
-        assert cm.phases_in_data.names != cm.phases.names
+        assert xmap.phases_in_data.names != xmap.phases.names
 
         ids_not_in_data = np.setdiff1d(
-            np.array(cm.phases.ids), np.array(cm.phases_in_data.ids)
+            np.array(xmap.phases.ids), np.array(xmap.phases_in_data.ids)
         )
-        condition1 = cm.x > 1.5
-        condition2 = cm.y > 1.5
+        condition1 = xmap.x > 1.5
+        condition2 = xmap.y > 1.5
         for new_id, condition in zip(ids_not_in_data, [condition1, condition2]):
-            cm[condition].phase_id = new_id
+            xmap[condition].phase_id = new_id
 
-        assert cm.phases_in_data.names == cm.phases.names
+        assert xmap.phases_in_data.names == xmap.phases.names
 
 
 class TestCrystalMapOrientations:
@@ -405,20 +405,20 @@ class TestCrystalMapOrientations:
             phase_ids[i] = unique_id
 
         crystal_map_input.pop("phase_id")
-        cm = CrystalMap(phase_id=phase_ids, **crystal_map_input)
+        xmap = CrystalMap(phase_id=phase_ids, **crystal_map_input)
 
         # Set phases and make sure all are in data
-        cm.phases = phase_list
-        assert cm.phases_in_data.names == cm.phases.names
+        xmap.phases = phase_list
+        assert xmap.phases_in_data.names == xmap.phases.names
 
         # Ensure all points have a valid orientation
         orientations_size = 0
         for phase_id in phase_list.ids:
-            o = cm[cm.phase_id == phase_id].orientations
+            o = xmap[xmap.phase_id == phase_id].orientations
             assert isinstance(o, Orientation)
             orientations_size += o.size
 
-        assert orientations_size == cm.size
+        assert orientations_size == xmap.size
 
     @pytest.mark.parametrize(
         "point_group, rotation, expected_orientation",
@@ -431,10 +431,10 @@ class TestCrystalMapOrientations:
     )
     def test_orientations_symmetry(self, point_group, rotation, expected_orientation):
         r = Rotation(rotation)
-        cm = CrystalMap(rotations=r, phase_id=np.array([0]))
-        cm.phases = PhaseList(Phase("a", point_group=point_group))
+        xmap = CrystalMap(rotations=r, phase_id=np.array([0]))
+        xmap.phases = PhaseList(Phase("a", point_group=point_group))
 
-        o = cm.orientations
+        o = xmap.orientations
 
         assert np.allclose(
             o.data, Orientation(r).set_symmetry(point_group).data, atol=1e-3
@@ -442,21 +442,21 @@ class TestCrystalMapOrientations:
         assert np.allclose(o.data, expected_orientation, atol=1e-3)
 
     def test_orientations_none_symmetry_raises(self, crystal_map_input):
-        cm = CrystalMap(**crystal_map_input)
+        xmap = CrystalMap(**crystal_map_input)
 
-        assert cm.phases.point_groups == [None]
+        assert xmap.phases.point_groups == [None]
 
         with pytest.raises(TypeError, match="'NoneType' object is not iterable"):
-            _ = cm.orientations
+            _ = xmap.orientations
 
     def test_orientations_multiple_phases_raises(self, crystal_map, phase_list):
-        cm = crystal_map
+        xmap = crystal_map
 
-        cm.phases = phase_list
-        cm[cm.x > 1.5].phase_id = 2
+        xmap.phases = phase_list
+        xmap[xmap.x > 1.5].phase_id = 2
 
         with pytest.raises(ValueError, match="Data has the phases "):
-            _ = cm.orientations
+            _ = xmap.orientations
 
     @pytest.mark.parametrize(
         "crystal_map_input, rotations_per_point",
@@ -466,51 +466,51 @@ class TestCrystalMapOrientations:
     def test_multiple_orientations_per_point(
         self, crystal_map_input, rotations_per_point
     ):
-        cm = CrystalMap(**crystal_map_input)
+        xmap = CrystalMap(**crystal_map_input)
 
-        assert cm.phases.ids == [0]  # Test code assumption
-        cm.phases[0].point_group = "m-3m"
+        assert xmap.phases.ids == [0]  # Test code assumption
+        xmap.phases[0].point_group = "m-3m"
 
-        assert cm.rotations_per_point == rotations_per_point
-        assert cm.orientations.size == cm.size
+        assert xmap.rotations_per_point == rotations_per_point
+        assert xmap.orientations.size == xmap.size
 
 
 class TestCrystalMapProp:
     def test_add_new_crystal_map_property(self, crystal_map):
-        cm = crystal_map
+        xmap = crystal_map
 
         prop_name = "iq"
-        prop_values = np.arange(cm.size)
-        cm.prop[prop_name] = prop_values
+        prop_values = np.arange(xmap.size)
+        xmap.prop[prop_name] = prop_values
 
-        assert np.allclose(cm.prop.get(prop_name), prop_values)
-        assert np.allclose(cm.prop[prop_name], prop_values)
+        assert np.allclose(xmap.prop.get(prop_name), prop_values)
+        assert np.allclose(xmap.prop[prop_name], prop_values)
 
     def test_overwrite_crystal_map_property_values(self, crystal_map):
-        cm = crystal_map
+        xmap = crystal_map
 
         prop_name = "iq"
-        prop_values = np.arange(cm.size)
-        cm.prop[prop_name] = prop_values
+        prop_values = np.arange(xmap.size)
+        xmap.prop[prop_name] = prop_values
 
-        assert np.allclose(cm.prop[prop_name], prop_values)
+        assert np.allclose(xmap.prop[prop_name], prop_values)
 
         new_prop_value = -1
-        cm.__setattr__(prop_name, new_prop_value)
+        xmap.__setattr__(prop_name, new_prop_value)
 
-        assert np.allclose(cm.prop[prop_name], np.ones(cm.size) * new_prop_value)
+        assert np.allclose(xmap.prop[prop_name], np.ones(xmap.size) * new_prop_value)
 
 
 class TestCrystalMapMasking:
     def test_getitem_with_masking(self, crystal_map_input):
         x = crystal_map_input["x"]
         props = {"iq": np.arange(x.size)}
-        cm = CrystalMap(prop=props, **crystal_map_input)
+        xmap = CrystalMap(prop=props, **crystal_map_input)
 
-        cm2 = cm[cm.iq > 1]
+        xmap2 = xmap[xmap.iq > 1]
 
-        assert np.allclose(cm2.prop.id, cm2.id)
-        assert np.allclose(cm2.prop.is_in_data, cm2.is_in_data)
+        assert np.allclose(xmap2.prop.id, xmap2.id)
+        assert np.allclose(xmap2.prop.is_in_data, xmap2.is_in_data)
 
 
 class TestCrystalMapGetMapData:
@@ -536,34 +536,34 @@ class TestCrystalMapGetMapData:
         indirect=["crystal_map_input"],
     )
     def test_get_coordinate_array(self, crystal_map_input, to_get, expected_array):
-        cm = CrystalMap(**crystal_map_input)
+        xmap = CrystalMap(**crystal_map_input)
 
         # Get via string
-        data_via_string = cm.get_map_data(to_get)
+        data_via_string = xmap.get_map_data(to_get)
         assert np.allclose(data_via_string, expected_array)
 
         # Get via numpy array
         if to_get == "x":
-            data_via_array = cm.get_map_data(cm.x)
+            data_via_array = xmap.get_map_data(xmap.x)
         elif to_get == "y":
-            data_via_array = cm.get_map_data(cm.y)
+            data_via_array = xmap.get_map_data(xmap.y)
         else:  # to_get == "z"
-            data_via_array = cm.get_map_data(cm.z)
+            data_via_array = xmap.get_map_data(xmap.z)
         assert np.allclose(data_via_array, expected_array)
 
         # Make sure they are the same
         assert np.allclose(data_via_array, data_via_string)
 
     def test_get_property_array(self, crystal_map):
-        cm = crystal_map
+        xmap = crystal_map
 
-        expected_array = np.arange(cm.size)
+        expected_array = np.arange(xmap.size)
         prop_name = "iq"
-        cm.prop[prop_name] = expected_array
+        xmap.prop[prop_name] = expected_array
 
-        iq = cm.get_map_data(prop_name)
+        iq = xmap.get_map_data(prop_name)
 
-        assert np.allclose(iq, expected_array.reshape(cm.shape))
+        assert np.allclose(iq, expected_array.reshape(xmap.shape))
 
     @pytest.mark.parametrize(
         "crystal_map_input",
@@ -571,48 +571,48 @@ class TestCrystalMapGetMapData:
         indirect=["crystal_map_input"],
     )
     def test_get_orientations_array(self, crystal_map_input, phase_list):
-        cm = CrystalMap(**crystal_map_input)
+        xmap = CrystalMap(**crystal_map_input)
 
-        cm[:2, 0].phase_id = 1
+        xmap[:2, 0].phase_id = 1
         # Test code assumption
         id1 = 0
         id2 = 1
-        assert np.allclose(np.unique(cm.phase_id), np.array([id1, id2]))
-        cm.phases = phase_list
+        assert np.allclose(np.unique(xmap.phase_id), np.array([id1, id2]))
+        xmap.phases = phase_list
 
         # Get all with string
-        o = cm.get_map_data("orientations")
+        o = xmap.get_map_data("orientations")
 
         # Get per phase with string
-        cm1 = cm[cm.phase_id == id1]
-        cm2 = cm[cm.phase_id == id2]
-        o1 = cm1.get_map_data("orientations")
-        o2 = cm2.get_map_data("orientations")
+        xmap1 = xmap[xmap.phase_id == id1]
+        xmap2 = xmap[xmap.phase_id == id2]
+        o1 = xmap1.get_map_data("orientations")
+        o2 = xmap2.get_map_data("orientations")
 
-        expected_o1 = cm1.orientations.to_euler()
+        expected_o1 = xmap1.orientations.to_euler()
         expected_shape = expected_o1.shape
         assert np.allclose(
             o1[~np.isnan(o1)].reshape(expected_shape), expected_o1, atol=1e-3
         )
 
-        expected_o2 = cm2.orientations.to_euler()
+        expected_o2 = xmap2.orientations.to_euler()
         expected_shape = expected_o2.shape
         assert np.allclose(
             o2[~np.isnan(o2)].reshape(expected_shape), expected_o2, atol=1e-3
         )
 
         # Do calculations "manually"
-        data_shape = (cm.size, 3)
+        data_shape = (xmap.size, 3)
         array = np.zeros(data_shape)
 
-        if cm.rotations_per_point > 1:
-            rotations = cm.rotations[:, 0]
+        if xmap.rotations_per_point > 1:
+            rotations = xmap.rotations[:, 0]
         else:
-            rotations = cm.rotations
+            rotations = xmap.rotations
 
-        for i, phase in cm.phases_in_data:
-            phase_mask = cm._phase_id == i
-            phase_mask_in_data = cm.phase_id == i
+        for i, phase in xmap.phases_in_data:
+            phase_mask = xmap._phase_id == i
+            phase_mask_in_data = xmap.phase_id == i
             array[phase_mask] = (
                 Orientation(rotations[phase_mask_in_data])
                 .set_symmetry(phase.point_group)
@@ -627,21 +627,21 @@ class TestCrystalMapGetMapData:
         indirect=["crystal_map_input"],
     )
     def test_get_rotations_array(self, crystal_map_input):
-        cm = CrystalMap(**crystal_map_input)
+        xmap = CrystalMap(**crystal_map_input)
 
         # Get with string
-        r = cm.get_map_data("rotations")
+        r = xmap.get_map_data("rotations")
 
-        new_shape = cm.shape + (3,)
-        if cm.rotations_per_point > 1:
-            expected_array = cm.rotations[:, 0].to_euler().reshape(*new_shape)
+        new_shape = xmap.shape + (3,)
+        if xmap.rotations_per_point > 1:
+            expected_array = xmap.rotations[:, 0].to_euler().reshape(*new_shape)
         else:
-            expected_array = cm.rotations.to_euler().reshape(*new_shape)
+            expected_array = xmap.rotations.to_euler().reshape(*new_shape)
         assert np.allclose(r, expected_array, atol=1e-3)
 
         # Get with array (RGB)
-        new_shape2 = (cm.size, 3)
-        r2 = cm.get_map_data(r.reshape(*new_shape2))
+        new_shape2 = (xmap.size, 3)
+        r2 = xmap.get_map_data(r.reshape(*new_shape2))
         assert np.allclose(r2, expected_array, atol=1e-3)
 
     @pytest.mark.parametrize(
@@ -650,8 +650,8 @@ class TestCrystalMapGetMapData:
         indirect=["crystal_map_input"],
     )
     def test_get_phase_id_array_from_3d_data(self, crystal_map_input):
-        cm = CrystalMap(**crystal_map_input)
-        _ = cm.get_map_data(cm.phase_id)
+        xmap = CrystalMap(**crystal_map_input)
+        _ = xmap.get_map_data(xmap.phase_id)
 
     @pytest.mark.parametrize(
         "crystal_map_input, to_get",
@@ -871,3 +871,9 @@ class TestCrystalMapShape:
     def test_coordinate_axes(self, crystal_map_input, expected_coordinate_axes):
         xmap = CrystalMap(**crystal_map_input)
         assert xmap._coordinate_axes == expected_coordinate_axes
+
+
+class TestCrystalMapPlot:
+    def test_plot(self, crystal_map):
+        xmap = crystal_map
+        xmap.plot()

--- a/orix/tests/test_crystal_map_plot.py
+++ b/orix/tests/test_crystal_map_plot.py
@@ -23,14 +23,10 @@ import matplotlib.pyplot as plt
 import pytest
 
 from orix.plot import CrystalMapPlot
-from orix.plot.crystal_map_plot import convert_unit
 from orix.crystal_map import CrystalMap
 from orix.crystal_map.phase_list import PhaseList
 
 plt.rcParams["backend"] = "TkAgg"
-
-# Warning raised when plot width is too small (this too is tested)
-SCALEBAR_WARNING = "Scalebar width .* is not an integer."
 
 # Can be easily changed in the future
 PLOT_MAP = "plot_map"
@@ -45,7 +41,6 @@ class TestCrystalMapPlot:
         ],
         indirect=["crystal_map_input"],
     )
-    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
     def test_plot_phase(self, crystal_map_input, phase_list, expected_data_shape):
         cm = CrystalMap(**crystal_map_input)
 
@@ -73,7 +68,6 @@ class TestCrystalMapPlot:
 
         plt.close("all")
 
-    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
     def test_plot_property(self, crystal_map):
         cm = crystal_map
 
@@ -89,7 +83,6 @@ class TestCrystalMapPlot:
 
         plt.close("all")
 
-    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
     def test_plot_scalar(self, crystal_map):
         cm = crystal_map
 
@@ -115,7 +108,6 @@ class TestCrystalMapPlot:
         [((2, 9, 3), (1, 1.5, 1.5), 1, [0]), ((2, 10, 5), (1, 0.1, 0.1), 1, [0])],
         indirect=["crystal_map_input"],
     )
-    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
     def test_plot_masked_phase(self, crystal_map_input, phase_list):
         cm = CrystalMap(**crystal_map_input)
 
@@ -143,7 +135,6 @@ class TestCrystalMapPlot:
         [((2, 9, 6), (1, 1.5, 1.5), 2, [0]), ((2, 10, 5), (1, 0.1, 0.1), 1, [0])],
         indirect=["crystal_map_input"],
     )
-    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
     def test_plot_masked_scalar(self, crystal_map_input):
         cm = CrystalMap(**crystal_map_input)
 
@@ -192,7 +183,6 @@ class TestCrystalMapPlotUtilities:
         ],
         indirect=["crystal_map_input"],
     )
-    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
     def test_get_plot_shape(
         self, crystal_map_input, idx_to_change, axes, depth, expected_plot_shape
     ):
@@ -211,7 +201,6 @@ class TestCrystalMapPlotUtilities:
         plt.close("all")
 
     @pytest.mark.parametrize("to_plot", ["scalar", "rgb"])
-    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
     def test_add_overlay(self, crystal_map, to_plot):
         cm = crystal_map
 
@@ -261,7 +250,6 @@ class TestCrystalMapPlotUtilities:
             ),
         ],
     )
-    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
     def test_phase_legend(
         self, crystal_map, phase_names, phase_colors, legend_properties
     ):
@@ -289,7 +277,6 @@ class TestCrystalMapPlotUtilities:
         plt.close("all")
 
     @pytest.mark.parametrize("with_colorbar", [True, False])
-    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
     def test_remove_padding(self, crystal_map, with_colorbar):
         fig = plt.figure()
         ax = fig.add_subplot(projection=PLOT_MAP)
@@ -333,7 +320,6 @@ class TestCrystalMapPlotUtilities:
         plt.close("all")
 
     @pytest.mark.parametrize("cmap", ["viridis", "cividis", "inferno"])
-    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
     def test_set_colormap(self, crystal_map, cmap):
         fig = plt.figure()
         ax = fig.add_subplot(projection=PLOT_MAP)
@@ -347,7 +333,6 @@ class TestCrystalMapPlotUtilities:
         "cmap, label, position",
         [("viridis", "a", "right"), ("cividis", "b", "left"), ("inferno", "c", "top"),],
     )
-    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
     def test_add_colorbar(self, crystal_map, cmap, label, position):
         fig = plt.figure()
         ax = fig.add_subplot(projection=PLOT_MAP)
@@ -368,25 +353,8 @@ class TestCrystalMapPlotUtilities:
 
         plt.close("all")
 
-    @pytest.mark.parametrize(
-        "value, unit, expected_value, expected_unit, expected_factor",
-        [
-            (3.141592 * 1e3, "nm", 3.141592, "um", 1e3),
-            (10.55 * 1e-3, "mm", 10.55, "um", 1e-3),
-            (23.7 * 1e3, "px", 23.7, "px", 1e3),
-        ],
-    )
-    def test_convert_unit(
-        self, value, unit, expected_value, expected_unit, expected_factor
-    ):
-        new_value, new_unit, factor = convert_unit(value, unit)
-        assert np.allclose(new_value, expected_value, atol=1e-6)
-        assert new_unit == expected_unit
-        assert np.allclose(factor, expected_factor)
-
 
 class TestStatusBar:
-    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
     def test_status_bar_call_directly(self, crystal_map):
         fig = plt.figure()
         ax = fig.add_subplot(projection=PLOT_MAP)
@@ -396,7 +364,6 @@ class TestStatusBar:
 
         plt.close("all")
 
-    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
     def test_status_bar_silence_default_format_coord(self, crystal_map):
         fig = plt.figure()
         ax = fig.add_subplot(projection=PLOT_MAP)
@@ -407,7 +374,6 @@ class TestStatusBar:
         plt.close("all")
 
     @pytest.mark.parametrize("to_plot", ["rgb", "scalar"])
-    @pytest.mark.filterwarnings(f"ignore: {SCALEBAR_WARNING}")
     def test_status_bar(self, crystal_map, to_plot):
         fig = plt.figure()
         ax = fig.add_subplot(projection=PLOT_MAP)
@@ -463,125 +429,24 @@ class TestStatusBar:
 
 class TestScalebar:
     @pytest.mark.parametrize(
-        "crystal_map_input, scalebar_properties, artist_attribute",
+        "crystal_map_input, scalebar_properties",
         [
-            (((1, 10, 30), (0, 1, 1), 1, [0]), {}, {}),  # Default
+            (((1, 10, 30), (0, 1, 1), 1, [0]), {}),  # Default
             (
                 ((1, 10, 30), (0, 1, 1), 1, [0]),
-                {"loc": 4, "sep": 6, "size_vertical": 0.2, "alpha": 0.8,},
-                {
-                    "loc": "loc",
-                    "sep": ["_box", "sep"],
-                    "size_vertical": ["size_bar", "_children", 0, "_height"],
-                    "alpha": ["patch", "_alpha"],
-                },
+                {"location": 4, "sep": 6, "box_alpha": 0.8},
             ),
         ],
         indirect=["crystal_map_input"],
     )
-    def test_scalebar_properties(
-        self, crystal_map_input, scalebar_properties, artist_attribute
-    ):
-        cm = CrystalMap(**crystal_map_input)
-        cm.scan_unit = "um"
-
-        fig = plt.figure()
-        ax = fig.add_subplot(projection=PLOT_MAP)
-        _ = ax.plot_map(cm, scalebar=False)
-        sbar = ax.add_scalebar(cm, **scalebar_properties)
-
-        if "alpha" not in scalebar_properties.keys():  # Check default
-            assert sbar.patch._alpha == 0.6
-
-        for (k, v), attr_loc in zip(
-            scalebar_properties.items(), artist_attribute.values()
-        ):
-            if isinstance(attr_loc, list):
-                sbar_attr = sbar.__getattribute__(attr_loc[0])
-                for i in attr_loc[1:]:
-                    if isinstance(i, int):
-                        sbar_attr = sbar_attr[i]
-                    else:
-                        sbar_attr = sbar_attr.__getattribute__(i)
-            else:
-                sbar_attr = sbar.__getattribute__(attr_loc)
-            assert sbar_attr == v
-
-        plt.close("all")
-
-    @pytest.mark.parametrize(
-        (
-            "crystal_map_input, unit, expected_coordinate_axes, expected_width_px, "
-            "expected_width_unit, expected_unit"
-        ),
-        [
-            (((10, 20, 1), (1, 1, 0), 1, [0]), "px", {0: "z", 1: "y"}, 2, 2, "px"),
-            (((1, 10, 30), (0, 1, 1), 1, [0]), "px", {0: "y", 1: "x"}, 2, 2, "px"),
-            (((1, 10, 40), (0, 1, 1), 1, [0]), "px", {0: "y", 1: "x"}, 5, 5, "px"),
-            (((20, 1, 10), (1, 1, 1), 1, [0]), "um", {0: "z", 1: "x"}, 1, 1, "um"),
-            (
-                ((1, 100, 117), (0, 1.5, 1.5), 1, [0]),
-                "nm",
-                {0: "y", 1: "x"},
-                13.33,
-                20,
-                "nm",
-            ),
-        ],
-        indirect=["crystal_map_input"],
-    )
-    def test_scalebar_axis(
-        self,
-        crystal_map_input,
-        unit,
-        expected_coordinate_axes,
-        expected_width_px,
-        expected_width_unit,
-        expected_unit,
-    ):
-        cm = CrystalMap(**crystal_map_input)
-        cm.scan_unit = unit
-
-        assert cm._coordinate_axes == expected_coordinate_axes
-
-        fig = plt.figure()
-        ax = fig.add_subplot(projection=PLOT_MAP)
-        _ = ax.plot_map(cm, scalebar=False)
-        sbar = ax.add_scalebar(cm)
-
-        # Scalebar width (_width attribute of Rectangle artist)
-        assert np.allclose(
-            sbar.size_bar._children[0]._width, expected_width_px, atol=1e-2
-        )
-
-        # Scalebar text
-        if expected_unit == "um":
-            expected_unit = "\u03BC" + "m"
-        assert (
-            sbar.txt_label._children[0]._text
-            == f"{expected_width_unit} {expected_unit}"
-        )
-
-        plt.close("all")
-
-    @pytest.mark.parametrize(
-        "crystal_map_input, warns",
-        [
-            (((1, 10, 20), (0, 1.5, 1.5), 1, [0]), False),
-            (((1, 4, 3), (0, 0.1, 0.1), 1, [0]), True),
-        ],
-        indirect=["crystal_map_input"],
-    )
-    def test_scalebar_warns(self, crystal_map_input, warns):
-        cm = CrystalMap(**crystal_map_input)
-
-        fig = plt.figure()
-        ax = fig.add_subplot(projection=PLOT_MAP)
-
-        if warns:
-            with pytest.warns(UserWarning, match=SCALEBAR_WARNING):
-                _ = ax.plot_map(cm)
-        else:
-            _ = ax.plot_map(cm)
-
+    def test_scalebar_properties(self, crystal_map_input, scalebar_properties):
+        xmap = CrystalMap(**crystal_map_input)
+        units = "um"
+        xmap.scan_unit = units
+        fig = xmap.plot(return_figure=True, scalebar=False)
+        sbar = fig.axes[0].add_scalebar(xmap, **scalebar_properties)
+        assert sbar.units == units
+        assert sbar.dx == xmap.dx
+        for k, v in scalebar_properties.items():
+            assert sbar.__getattribute__(k) == v
         plt.close("all")

--- a/orix/tests/test_crystal_map_plot.py
+++ b/orix/tests/test_crystal_map_plot.py
@@ -26,7 +26,7 @@ from orix.plot import CrystalMapPlot
 from orix.crystal_map import CrystalMap
 from orix.crystal_map.phase_list import PhaseList
 
-plt.rcParams["backend"] = "TkAgg"
+plt.rcParams["backend"] = "Agg"
 
 # Can be easily changed in the future
 PLOT_MAP = "plot_map"
@@ -449,4 +449,10 @@ class TestScalebar:
         assert sbar.dx == xmap.dx
         for k, v in scalebar_properties.items():
             assert sbar.__getattribute__(k) == v
+
+        # Custom scan unit
+        xmap.scan_unit = "parsec"
+        fig2 = xmap.plot(return_figure=True)
+        assert fig2.axes[0].artists[0].units == xmap.scan_unit
+
         plt.close("all")

--- a/orix/tests/test_crystal_map_plot.py
+++ b/orix/tests/test_crystal_map_plot.py
@@ -20,6 +20,8 @@ import copy
 
 import numpy as np
 import matplotlib.pyplot as plt
+import matplotlib.colorbar as mbar
+from matplotlib_scalebar import scalebar
 import pytest
 
 from orix.plot import CrystalMapPlot
@@ -160,6 +162,17 @@ class TestCrystalMapPlot:
 
         plt.close("all")
 
+    def test_properties(self, crystal_map):
+        xmap = crystal_map
+        fig = xmap.plot(return_figure=True, colorbar=True, colorbar_label="score")
+        ax = fig.axes[0]
+
+        assert isinstance(ax.colorbar, mbar.Colorbar)
+        assert ax.colorbar.ax.get_ylabel() == "score"
+        assert isinstance(ax.scalebar, scalebar.ScaleBar)
+
+        plt.close("all")
+
 
 class TestCrystalMapPlotUtilities:
     def test_init_projection(self):
@@ -259,13 +272,16 @@ class TestCrystalMapPlotUtilities:
             names=phase_names, point_groups=[3, 3], colors=phase_colors
         )
 
+        fontsize = 11
+        plt.rcParams["font.size"] = fontsize
+
         fig = plt.figure()
         ax = fig.add_subplot(projection=PLOT_MAP)
         _ = ax.plot_map(cm, legend_properties=legend_properties)
 
         legend = ax.legend_
 
-        assert legend._fontsize == 11.0
+        assert legend._fontsize == fontsize
         assert [i._text for i in legend.texts] == phase_names
 
         frame_alpha = legend_properties.pop("framealpha", 0.6)

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -562,6 +562,7 @@ class Vector3d(Object3d):
             Dictionary of keyword arguments passed to
             :func:`~orix.plot.StereographicPlot.text`, which passes
             these on to :meth:`matplotlib.axes.Axes.text`.
+        %s
         kwargs : dict, optional
             Keyword arguments passed to
             :func:`~orix.plot.StereographicPlot.scatter`, which passes
@@ -570,7 +571,7 @@ class Vector3d(Object3d):
         Returns
         -------
         fig : matplotlib.figure.Figure
-            The created figure.
+            The created figure, returned if `return_figure` is True.
 
         Notes
         -----
@@ -652,6 +653,7 @@ class Vector3d(Object3d):
         %s
         %s
         %s
+        %s
         kwargs
             Keyword arguments passed to
             :meth:`matplotlib.axes.Axes.plot` to alter the circles'
@@ -660,7 +662,7 @@ class Vector3d(Object3d):
         Returns
         -------
         fig : matplotlib.figure.Figure
-            The created figure.
+            The created figure, returned if `return_figure` is True.
 
         Notes
         -----
@@ -814,6 +816,9 @@ PLOT_GRID_RESOLUTION_DOCSTRING = """grid_resolution : tuple, optional
             :class:`~orix.plot.StereographicPlot.azimuth_grid` and
             :class:`~orix.plot.StereographicPlot.polar_grid`.
     """
+PLOT_RETURN_FIGURE_DOCSTRING = """return_figure : bool, optional
+            Whether to return the figure (default is False).
+    """
 PLOT_FIGURE_KWARGS_DOCSTRING = """figure_kwargs : dict, optional
             Dictionary of keyword arguments passed to
             :func:`matplotlib.pyplot.subplots`.
@@ -833,6 +838,7 @@ Vector3d.scatter.__doc__ %= (
     PLOT_GRID_DOCSTRING,
     PLOT_GRID_RESOLUTION_DOCSTRING,
     PLOT_FIGURE_KWARGS_DOCSTRING,
+    PLOT_RETURN_FIGURE_DOCSTRING,
     PLOT_NOT_SO_CUSTOMIZABLE_NOTE_DOCSTRING,
 )
 Vector3d.draw_circle.__doc__ %= (
@@ -844,6 +850,7 @@ Vector3d.draw_circle.__doc__ %= (
     PLOT_GRID_DOCSTRING,
     PLOT_GRID_RESOLUTION_DOCSTRING,
     PLOT_FIGURE_KWARGS_DOCSTRING,
+    PLOT_RETURN_FIGURE_DOCSTRING,
     PLOT_NOT_SO_CUSTOMIZABLE_NOTE_DOCSTRING,
 )
 Vector3d._setup_plot.__doc__ %= (

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         "diffpy.structure >= 3",
         "h5py",
         "matplotlib >= 3.3",
+        "matplotlib-scalebar",
         "numpy",
         "scipy",
         "tqdm",


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
This PR aims to make plotting a CrystalMap simpler.

* Add CrystalMap.plot() method (using `orix.projections.CrystalMapPlot`, similar to `Vector3d.plot()` and `Miller.plot()`)
* Move CrystalMap notebook from orix-demos and improve it
* Use [matplotlib-scalebar](https://github.com/ppinard/matplotlib-scalebar/) instead of directily using Matplotlib's AnchoredSizeBar. This enables us to remove lots of code, and brings easier customization of the scalebar.
* Add attributes `scalebar` and `colorbar` to `CrystalMapPlot` for easy access, which are `None` until `add_scalebar()` and `add_colorbar()`, respectively, are called.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)
- [x] Finish notebook editing
- [x] Finish testing of CrystalMap.plot()

#### Minimal example of the bug fix or new feature
This code

```python
>>> xmap
Phase   Orientations                 Name  Space group  Point group  Proper point group       Color
    1   6043 (51.6%)      ferrite/ferrite         None          432                 432    tab:blue
    2   5657 (48.4%)  austenite/austenite         None          432                 432  tab:orange
Properties: iq, dp
Scan unit: um
>>> fig = xmap.plot(overlay="dp", remove_padding=True, return_figure=True)
>>> fig.savefig("/home/hakon/phase_map_dp.png", bbox_inches="tight", pad_inches=0)
```

produces this phase plot with dot product values in overlay

![phase_map_dp_map](https://user-images.githubusercontent.com/12139781/117182992-50cb3280-add7-11eb-8512-5fcd1c001f48.png)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
