### PR TITLE
Preserve symmetry when creating misorientations or when inverting orientations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,8 @@ Changed
 
 Fixed
 -----
+- Symmetry is preserved when creating a misorientation from orientations or when
+  inverting orientations
 - Reading of properties (scores etc.) from EMsoft h5ebsd files with certain map shapes
 - Reading of crystal symmetry from EMsoft h5ebsd dot product files in CrystalMap plugin
 

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -243,6 +243,30 @@ class Orientation(Misorientation):
     :math:`o_2`, call :code:`o_2 - o_1`.
     """
 
+    def __sub__(self, other):
+        if isinstance(other, Orientation):
+            # Call to Object3d.squeeze() doesn't carry over symmetry
+            misorientation = Misorientation(self * ~other).squeeze()
+            return misorientation.set_symmetry(self.symmetry, other.symmetry)
+        return NotImplemented
+
+    def __repr__(self):
+        """String representation."""
+        cls = self.__class__.__name__
+        shape = str(self.shape)
+        symmetry = self.symmetry.name
+        data = np.array_str(self.data, precision=4, suppress_small=True)
+        rep = f"{cls} {shape} {symmetry}\n{data}"
+        return rep
+
+    def __invert__(self):
+        return super().__invert__().set_symmetry(self.symmetry)
+
+    @property
+    def symmetry(self):
+        """Symmetry."""
+        return self._symmetry[1]
+
     @classmethod
     def from_euler(
         cls, euler, symmetry=None, convention="bunge", direction="crystal2lab"
@@ -302,11 +326,6 @@ class Orientation(Misorientation):
             o = o.set_symmetry(symmetry)
         return o
 
-    @property
-    def symmetry(self):
-        """Symmetry."""
-        return self._symmetry[1]
-
     def set_symmetry(self, symmetry):
         """Assign a symmetry to this orientation.
 
@@ -333,12 +352,3 @@ class Orientation(Misorientation):
         [ 0.      1.      0.      0.    ]]
         """
         return super().set_symmetry(C1, symmetry)
-
-    def __sub__(self, other):
-        if isinstance(other, Orientation):
-            misorientation = Misorientation(self * ~other)
-            m_inside = misorientation.set_symmetry(
-                self.symmetry, other.symmetry
-            ).squeeze()
-            return m_inside
-        return NotImplemented

--- a/orix/tests/test_orientation.py
+++ b/orix/tests/test_orientation.py
@@ -34,112 +34,7 @@ def orientation(request):
     return Orientation(request.param)
 
 
-@pytest.mark.parametrize(
-    "orientation, symmetry, expected",
-    [
-        ([(1, 0, 0, 0)], C1, [(1, 0, 0, 0)]),
-        ([(1, 0, 0, 0)], C4, [(1, 0, 0, 0)]),
-        ([(1, 0, 0, 0)], D3, [(1, 0, 0, 0)]),
-        ([(1, 0, 0, 0)], T, [(1, 0, 0, 0)]),
-        ([(1, 0, 0, 0)], O, [(1, 0, 0, 0)]),
-        # 7pi/12 -C2-> # 7pi/12
-        ([(0.6088, 0, 0, 0.7934)], C2, [(-0.7934, 0, 0, 0.6088)]),
-        # 7pi/12 -C3-> # 7pi/12
-        ([(0.6088, 0, 0, 0.7934)], C3, [(-0.9914, 0, 0, 0.1305)]),
-        # 7pi/12 -C4-> # pi/12
-        ([(0.6088, 0, 0, 0.7934)], C4, [(-0.9914, 0, 0, -0.1305)]),
-        # 7pi/12 -O-> # pi/12
-        ([(0.6088, 0, 0, 0.7934)], O, [(-0.9914, 0, 0, -0.1305)]),
-    ],
-    indirect=["orientation"],
-)
-def test_set_symmetry(orientation, symmetry, expected):
-    o = orientation.set_symmetry(symmetry)
-    assert np.allclose(o.data, expected, atol=1e-3)
-
-
-@pytest.mark.parametrize(
-    "symmetry, vector",
-    [(C1, (1, 2, 3)), (C2, (1, -1, 3)), (C3, (1, 1, 1)), (O, (0, 1, 0))],
-    indirect=["vector"],
-)
-def test_orientation_persistence(symmetry, vector):
-    v = symmetry.outer(vector).flatten()
-    o = Orientation.random()
-    oc = o.set_symmetry(symmetry)
-    v1 = o * v
-    v1 = Vector3d(v1.data.round(4))
-    v2 = oc * v
-    v2 = Vector3d(v2.data.round(4))
-    assert v1._tuples == v2._tuples
-
-
-@pytest.mark.parametrize(
-    "orientation, symmetry, expected",
-    [
-        ((1, 0, 0, 0), C1, [0]),
-        ([(1, 0, 0, 0), (0.7071, 0.7071, 0, 0)], C1, [[0, np.pi / 2], [np.pi / 2, 0]]),
-        ([(1, 0, 0, 0), (0.7071, 0.7071, 0, 0)], C4, [[0, np.pi / 2], [np.pi / 2, 0]]),
-        ([(1, 0, 0, 0), (0.7071, 0, 0, 0.7071)], C4, [[0, 0], [0, 0]]),
-        (
-            [
-                [(1, 0, 0, 0), (0.7071, 0, 0, 0.7071)],
-                [(0, 0, 0, 1), (0.9239, 0, 0, 0.3827)],
-            ],
-            C4,
-            [
-                [[[0, 0], [0, np.pi / 4]], [[0, 0], [0, np.pi / 4]]],
-                [[[0, 0], [0, np.pi / 4]], [[np.pi / 4, np.pi / 4], [np.pi / 4, 0]]],
-            ],
-        ),
-    ],
-    indirect=["orientation"],
-)
-def test_distance(orientation, symmetry, expected):
-    o = orientation.set_symmetry(symmetry)
-    distance = o.distance(verbose=True)
-    assert np.allclose(distance, expected, atol=1e-3)
-
-
-@pytest.mark.parametrize("symmetry", [C1, C2, C4, D2, D6, T, O])
-def test_getitem(orientation, symmetry):
-    o = orientation.set_symmetry(symmetry)
-    assert o[0].symmetry._tuples == symmetry._tuples
-
-
-@pytest.mark.parametrize("Gl", [C4, C2])
-def test_equivalent(Gl):
-    """ Tests that the property Misorientation.equivalent runs without error,
-    use grain_exchange=True as this falls back to grain_exchange=False when
-    Gl!=Gr:
-
-    Gl == C4 is grain exchange
-    Gl == C2 is no grain exchange
-    """
-    m = Misorientation([1, 1, 1, 1])  # any will do
-    m_new = m.set_symmetry(Gl, C4, verbose=True)
-    m_new.symmetry
-    _m = m_new.equivalent(grain_exchange=True)
-
-
-def test_repr():
-    m = Misorientation([1, 1, 1, 1])  # any will do
-    _ = repr(m)
-
-
-def test_sub():
-    m = Orientation([1, 1, 1, 1])  # any will do
-    m.set_symmetry(C4)  # only one as it a O
-    assert np.allclose((m - m).data, [1, 0, 0, 0])
-
-
-def test_sub_orientation_and_other():
-    m = Orientation([1, 1, 1, 1])  # any will do
-    with pytest.raises(TypeError):
-        _ = m - 3
-
-
-class TestOrientationInitialization:
+class TestOrientation:
     def test_from_euler_symmetry(self):
         euler = np.deg2rad([90, 45, 90])
         o1 = Orientation.from_euler(euler)
@@ -178,3 +73,133 @@ class TestOrientationInitialization:
         assert o2.symmetry.name == "m-3m"
         o3 = o1.set_symmetry(Oh)
         assert np.allclose(o3.data, o2.data)
+
+    @pytest.mark.parametrize(
+        "orientation, symmetry, expected",
+        [
+            # fmt: off
+            ((1, 0, 0, 0), C1, (1, 0, 0, 0)),
+            ((1, 0, 0, 0), C4, (1, 0, 0, 0)),
+            ((1, 0, 0, 0), D3, (1, 0, 0, 0)),
+            ((1, 0, 0, 0), T,  (1, 0, 0, 0)),
+            ((1, 0, 0, 0), O,  (1, 0, 0, 0)),
+            # 7pi/12 -C2-> # 7pi/12
+            ((0.6088, 0, 0, 0.7934), C2, (-0.7934, 0, 0,  0.6088)),
+            # 7pi/12 -C3-> # 7pi/12
+            ((0.6088, 0, 0, 0.7934), C3, (-0.9914, 0, 0,  0.1305)),
+            # 7pi/12 -C4-> # pi/12
+            ((0.6088, 0, 0, 0.7934), C4, (-0.9914, 0, 0, -0.1305)),
+            # 7pi/12 -O-> # pi/12
+            ((0.6088, 0, 0, 0.7934), O , (-0.9914, 0, 0, -0.1305)),
+            # fmt: on
+        ],
+        indirect=["orientation"],
+    )
+    def test_set_symmetry(self, orientation, symmetry, expected):
+        o = orientation.set_symmetry(symmetry)
+        assert np.allclose(o.data, expected, atol=1e-3)
+
+    @pytest.mark.parametrize(
+        "symmetry, vector",
+        [(C1, (1, 2, 3)), (C2, (1, -1, 3)), (C3, (1, 1, 1)), (O, (0, 1, 0))],
+        indirect=["vector"],
+    )
+    def test_orientation_persistence(self, symmetry, vector):
+        v = symmetry.outer(vector).flatten()
+        o = Orientation.random()
+        oc = o.set_symmetry(symmetry)
+        v1 = o * v
+        v1 = Vector3d(v1.data.round(4))
+        v2 = oc * v
+        v2 = Vector3d(v2.data.round(4))
+        assert v1._tuples == v2._tuples
+
+    @pytest.mark.parametrize(
+        "orientation, symmetry, expected",
+        [
+            ((1, 0, 0, 0), C1, [0]),
+            (
+                [(1, 0, 0, 0), (0.7071, 0.7071, 0, 0)],
+                C1,
+                [[0, np.pi / 2], [np.pi / 2, 0]],
+            ),
+            (
+                [(1, 0, 0, 0), (0.7071, 0.7071, 0, 0)],
+                C4,
+                [[0, np.pi / 2], [np.pi / 2, 0]],
+            ),
+            ([(1, 0, 0, 0), (0.7071, 0, 0, 0.7071)], C4, [[0, 0], [0, 0]]),
+            (
+                [
+                    [(1, 0, 0, 0), (0.7071, 0, 0, 0.7071)],
+                    [(0, 0, 0, 1), (0.9239, 0, 0, 0.3827)],
+                ],
+                C4,
+                [
+                    [[[0, 0], [0, np.pi / 4]], [[0, 0], [0, np.pi / 4]]],
+                    [
+                        [[0, 0], [0, np.pi / 4]],
+                        [[np.pi / 4, np.pi / 4], [np.pi / 4, 0]],
+                    ],
+                ],
+            ),
+        ],
+        indirect=["orientation"],
+    )
+    def test_distance(self, orientation, symmetry, expected):
+        o = orientation.set_symmetry(symmetry)
+        distance = o.distance(verbose=True)
+        assert np.allclose(distance, expected, atol=1e-3)
+
+    @pytest.mark.parametrize("symmetry", [C1, C2, C4, D2, D6, T, O])
+    def test_getitem(self, orientation, symmetry):
+        o = orientation.set_symmetry(symmetry)
+        assert o[0].symmetry._tuples == symmetry._tuples
+
+    def test_symmetry_is_preserved(self):
+        o = Orientation.identity().set_symmetry(O)
+        o_inv = ~o
+        assert o_inv.symmetry.name == O.name
+        assert np.allclose(o.symmetry.data, o_inv.symmetry.data)
+
+    def test_repr(self):
+        shape = (2, 3)
+        o = Orientation.identity(shape).set_symmetry(O)
+        assert repr(o).split("\n")[0] == f"Orientation {shape} {O.name}"
+
+
+class TestMisorientation:
+    @pytest.mark.parametrize("Gl", [C4, C2])
+    def test_equivalent(self, Gl):
+        """Tests that the property Misorientation.equivalent runs
+        without error, use grain_exchange=True as this falls back to
+        grain_exchange=False when Gl!=Gr:
+            - Gl == C4 is grain exchange
+            - Gl == C2 is no grain exchange
+        """
+        m = Misorientation([1, 1, 1, 1])  # any will do
+        m_new = m.set_symmetry(Gl, C4, verbose=True)
+        assert len(m_new.symmetry) == 2
+        _ = m_new.equivalent(grain_exchange=True)
+
+    def test_sub(self):
+        o = Orientation([1, 1, 1, 1])  # any will do
+        o = o.set_symmetry(C4)  # only one as it a O
+        m = o - o
+        assert np.allclose(m.data, [1, 0, 0, 0])
+
+        # Symmetries are preserved
+        sym = m.symmetry
+        assert sym[0].name == C4.name
+        assert sym[1].name == C4.name
+        assert np.allclose(sym[0].data, C4.data)
+
+    def test_sub_orientation_and_other(self):
+        m = Orientation([1, 1, 1, 1])  # any will do
+        with pytest.raises(TypeError):
+            _ = m - 3
+
+    def test_repr(self):
+        shape = (2, 3)
+        m = Misorientation.identity(shape).set_symmetry(C1, O)
+        assert repr(m).split("\n")[0] == f"Misorientation {shape} {C1.name}, {O.name}"


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
* Fix bug in `Orientation.__sub__()` which returned misorientations without symmetries
* Add `Orientation.__repr__()` to show only `Orientation.symmetry`, and not the identity operation as well (from `Misorientation.__repr__()`)
* Overwrite `Orientation.__invert__()` to maintain symmetry

I'm looking into how to compute misorientation angles in reasonable time and without flooding memory. This PR is part of that work. I plan to push more stuff later today.

I think this is OK to go in for v0.6, but it can wait for v0.7 if we don't find the time to get it in.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> from orix.quaternion import Orientation
>>> from orix.quaternion.symmetry import Oh
>>> o = Orientation((1, 0.5, 0.5, 1)).set_symmetry(Oh)
>>> print(o)
Orientation (1,) m-3m
[[-0.9487  0.      0.3162  0.    ]]
>>> print(~o)
Orientation (1,) m-3m
[[-0.9487  0.     -0.3162 -0.    ]]
>>> print(o - o)
Misorientation (1,) m-3m, m-3m
[[1. 0. 0. 0.]]
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
