### PR TITLE
Change Sphinx documentation theme to Furo

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -61,7 +61,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "sphinx_rtd_theme"
+html_theme = "furo"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,10 @@ from orix import __name__, __version__, __author__, __author_email__, __descript
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
 extra_feature_requirements = {
     "doc": [
+        "furo",
         "ipykernel",  # https://github.com/spatialaudio/nbsphinx/issues/121
         "nbsphinx >= 0.7",
         "sphinx >= 3.0.2",
-        "sphinx-rtd-theme >= 0.4.3",
         "sphinx-gallery >= 0.6",
         "sphinxcontrib-bibtex >= 1.0",
         "scikit-image",


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
I propose we change the Sphinx documentation theme from the Read The Docs (RTD) theme to the Furo theme (https://pradyunsg.me/furo/).

Our documentation with:
* RTD: https://orix.readthedocs.io/en/latest/
* Furo: https://orix--200.org.readthedocs.build/en/200/

Pros:
* Cleaner than RTD, in my opinion
* Right-hand-side table of contents (RHS TOC) enables easier navigation

Cons:
* When navigating a long page in a somewhat narrow (not so narrow that the left side bar isn't visible) browser window, the RHS TOC is *only* expandable from a hamburger icon at the top of the page

I plan to use this for kikuchipy as well.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
