### PR TITLE
add transpose class method

### DIFF
--- a/orix/base/__init__.py
+++ b/orix/base/__init__.py
@@ -54,9 +54,7 @@ class DimensionError(Exception):
 
 
 class Object3d:
-    """Base class for 3d objects.
-
-    """
+    """Base class for 3d objects."""
 
     dim = None
     """int : The number of dimensions for this object."""
@@ -205,6 +203,24 @@ class Object3d:
         obj = self.__class__(self.data.reshape(*shape, self.dim))
         obj._data = self._data.reshape(*shape, -1)
         return obj
+
+    def transpose(self, *order):
+        """Returns a new object containing the same data transposed.
+        If ndim is originally 2, then order may be undefined.
+        In this case the first two dimensions will be transposed."""
+        if not len(order):
+            if len(self.shape) != 2:
+                raise ValueError("order must be defined for more than two dimensions.")
+            else:
+                # swap first two axes
+                order = (1, 0)
+
+        if len(order) != len(self.shape):
+            raise ValueError(
+                f"Number of axes is ill-defined: {tuple(order)} does not fit with {self.shape}."
+            )
+
+        return self.__class__(self.data.transpose(*order, -1))
 
     def get_plot_data(self):
         return self


### PR DESCRIPTION
#### Description of the change
Hi there, thanks for all the work put into Orix! I have found it very useful. I was wondering whether you would be interested in adding a transpose class method given that there is also a reshape method. I have found myself coding this up quite a few times recently and found it to be quite useful when comparing arrays of Orientations, so thought about creating a PR.
Cheers!

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> from orix import Orientation
>>> import numpy as np
>>> ori = Orientation(np.random.rand(5, 3, 4))
>>> oriT = ori.transpose()
>>> ori.shape, oriT.shape

>>> from orix.vector import Vector3d
>>> v = Vector3d(np.random.rand(10, 3, 4, 3))
>>> vT = v.transpose(2, 0, 1)
>>> v.shape, vT.shape
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
