### PR TITLE
Deprecate Object3d.data_dim property in favour of Object3d.ndim

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,11 @@ this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.htm
 Unreleased
 ==========
 
+Added
+-----
+- ndim attribute to Object3d which returns number of navigation dimensions
+- data_dim attribute of Object3d to be deprecated in 0.9.0 with a warning from 0.8.0
+
 
 2021-09-07 - version 0.7.0
 ==========================

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -165,6 +165,27 @@ files by `nbsphinx <https://nbsphinx.readthedocs.io/en/latest/>`_:
 - ``nbsphinx-thumbnail`` tag to a code cell with an image output. The notebook must be
   added to the gallery in the README.rst to be included in the documentation pages.
 
+Deprecations
+============
+
+orix tries to adhere to semantic versioning as best we can. This means that as little,
+ideally no, functionality should break between minor releases. Deprecation warnings
+are raised whenever possible and feasible for functions/methods/properties, so that
+users get a heads-up one (minor) release before something is removed or changes, with a
+possible alternative to be used.
+
+The decorator should be placed right above the object signature to be deprecated, like
+so::
+
+    @deprecate(since=0.8, removal=0.9, alternative="bar")
+    def foo(self, n):
+        return n + 1
+
+    @property
+    @deprecate(since=0.9, removal=0.10, alternative="another", object_type="property")
+    def this_property(self):
+        return 2
+
 Run and write tests
 ===================
 

--- a/orix/base/__init__.py
+++ b/orix/base/__init__.py
@@ -111,12 +111,7 @@ class Object3d:
         return self.data.shape[:-1]
 
     @property
-    @deprecated(
-        "0.8.0",
-        message="The use of 'data_dim' is deprecated.",
-        alternative="ndim",
-        removal="0.9.0",
-    )
+    @deprecated(since="0.8", alternative="ndim", removal="0.9", object_type="property")
     def data_dim(self):
         """int : The dimensions of the data.
 

--- a/orix/base/__init__.py
+++ b/orix/base/__init__.py
@@ -112,15 +112,15 @@ class Object3d:
 
     @property
     @deprecated(
-        "0.7.1",
+        "0.8.0",
         message="The use of 'data_dim' is deprecated.",
         alternative="ndim",
-        removal="0.8.0",
+        removal="0.9.0",
     )
     def data_dim(self):
         """int : The dimensions of the data.
 
-        For example, if `data` has shape (4, 4, 3), `data_dim` is 3.
+        For example, if `data` has shape (4, 5, 6), `data_dim` is 3.
 
         """
         return self.ndim

--- a/orix/base/__init__.py
+++ b/orix/base/__init__.py
@@ -17,6 +17,7 @@
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
+from .._util import deprecated
 
 
 # Lists what will be imported when calling "from orix.base import *"
@@ -110,12 +111,23 @@ class Object3d:
         return self.data.shape[:-1]
 
     @property
+    @deprecated(
+        "0.7.1",
+        message="The use of 'data_dim' is deprecated.",
+        alternative="ndim",
+        removal="0.8.0",
+    )
     def data_dim(self):
         """int : The dimensions of the data.
 
         For example, if `data` has shape (4, 4, 3), `data_dim` is 3.
 
         """
+        return self.ndim
+
+    @property
+    def ndim(self):
+        """int: The number of navigation dimensions of the object."""
         return len(self.shape)
 
     @property

--- a/orix/tests/test_object3d.py
+++ b/orix/tests/test_object3d.py
@@ -158,6 +158,10 @@ def test_data_dim(object3d):
     assert object3d.data_dim == len(object3d.data.shape[:-1])
 
 
+def test_ndim(object3d):
+    assert object3d.ndim == len(object3d.data.shape[:-1])
+
+
 def test_size(object3d):
     assert object3d.size == object3d.data.size / object3d.dim
 

--- a/orix/tests/test_object3d.py
+++ b/orix/tests/test_object3d.py
@@ -205,3 +205,12 @@ def test_get_random_sample(test_object3d):
 
     with pytest.raises(ValueError, match="Cannot draw a sample greater than 20"):
         _ = o3d.get_random_sample(21)
+
+
+@pytest.mark.parametrize("test_object3d", [3], indirect=["test_object3d"])
+def test_deprecation_warning_data_dim(test_object3d):
+    o3d = test_object3d(np.arange(21).reshape((7, 3)))
+    with pytest.warns(
+        np.VisibleDeprecationWarning, match="Property `data_dim` is deprecated and "
+    ):
+        assert o3d.data_dim == 1

--- a/orix/tests/test_object3d.py
+++ b/orix/tests/test_object3d.py
@@ -158,11 +158,6 @@ def test_data_dim(object3d):
     assert object3d.data_dim == len(object3d.data.shape[:-1])
 
 
-def test_data_dim_warns(object3d):
-    with pytest.warns(np.VisibleDeprecationWarning, match="Function "):
-        _ = object3d.data_dim
-
-
 def test_ndim(object3d):
     assert object3d.ndim == len(object3d.data.shape[:-1])
 


### PR DESCRIPTION
As discussed in #227 we will aim for the addition of a the attribute ```ndim``` on the ```Object3d``` class to be more consistent with NumPy. This will lead to the eventual deprecation of ```data_dim```.

The docstring example of ```data_dim``` has been updated for clarity.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> from orix.quaternion import Orientation
>>> v = Orientation.random_vonmises((100, 200))
>>> v.ndim
>>> 2
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
