### PR TITLE
Add symmetry property to Orientation-based classes in favour of set_symmetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ ENV/
 # Visual Studio Code
 *.code-workspace
 .vscode
+
+# MacOS
+.DS_Store

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,12 +33,9 @@ Deprecated
 ----------
 - The `data_dim` attribute of Object3d and all derived classes is deprecated from 0.8
   and will be removed in 0.9. Use `ndim` instead.
-- `set_symmetry` will be deprecated from 0.8 in favour of a `symmetry` property for
-  `Orientation` and `Misorientation` classes. `set_symmetry` will be removed in 0.9.
-  The behaviour of `set_symmetry` can still be achieved by using the following snippet:
-  >>> o = Orientation(data)
-  >>> o.symmetry = symmetry
-  >>> o = o.compute_symmetry_reduced_orientations()
+- Setting (Mis)Orientation symmetry via `set_symmetry()` is deprecated in 0.8, in favour of
+  setting it directly via a `symmetry.setter`, and will be removed in 0.9. Use
+  `assign_smallest_angle()` instead.
 
 Removed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,7 +36,9 @@ Deprecated
 - Setting (Mis)Orientation symmetry via `set_symmetry()` is deprecated in 0.8, in favour of
   setting it directly via a `symmetry.setter`, and will be removed in 0.9. Use
   `assign_smallest_angle()` instead.
-
+- `Orientation` class methods `from_euler`, `from_matrix`, and `from_neo_euler` no longer 
+  return the smallest angle rotation when `symmetry` argument is provided and not None.
+   
 Removed
 -------
 - `StereographicPlot` methods `azimuth_grid()` and `polar_grid()`.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,8 @@ Changed
 - `StereographicPlot` doesn't use Matplotlib's `transforms` framework anymore, and
   (X, Y) replaces (azimuth, polar) as internal coordinates.
 - Renamed `Symmetry` method `fundamental_sector()` to `fundamental_zone()`.
+- `Orientation` class methods `from_euler`, `from_matrix`, and `from_neo_euler` no longer 
+  return the smallest angle rotation when `symmetry` argument is provided and not None.
 
 Deprecated
 ----------
@@ -36,9 +38,7 @@ Deprecated
 - Setting (Mis)Orientation symmetry via `set_symmetry()` is deprecated in 0.8, in favour of
   setting it directly via a `symmetry.setter`, and will be removed in 0.9. Use
   `assign_smallest_angle()` instead.
-- `Orientation` class methods `from_euler`, `from_matrix`, and `from_neo_euler` no longer 
-  return the smallest angle rotation when `symmetry` argument is provided and not None.
-   
+ 
 Removed
 -------
 - `StereographicPlot` methods `azimuth_grid()` and `polar_grid()`.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Added
 - Sampling of vectors in UV mesh on a unit sphere (*S2*).
 - `ndim` attribute to Object3d and derived classes which returns number of navigation
   dimensions.
-- `symmetry` property for `Orientation` and `Misorientation` classes.
+- Setting the symmetry of a (Mis)Orientation via a `symmetry.setter`.
 
 Changed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ Changed
 - Renamed `Symmetry` method `fundamental_sector()` to `fundamental_zone()`.
 - `Orientation` class methods `from_euler`, `from_matrix`, and `from_neo_euler` no longer 
   return the smallest angle rotation when `symmetry` argument is provided and not None.
+- `CrystalMap.orientations` no longer returns smallest angle rotation.
 
 Deprecated
 ----------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Added
 - Sampling of vectors in UV mesh on a unit sphere (*S2*).
 - `ndim` attribute to Object3d and derived classes which returns number of navigation
   dimensions.
+- `symmetry` property for `Orientation` and `Misorientation` classes.
 
 Changed
 -------
@@ -32,6 +33,12 @@ Deprecated
 ----------
 - The `data_dim` attribute of Object3d and all derived classes is deprecated from 0.8
   and will be removed in 0.9. Use `ndim` instead.
+- `set_symmetry` will be deprecated from 0.8 in favour of a `symmetry` property for
+  `Orientation` and `Misorientation` classes. `set_symmetry` will be removed in 0.9.
+  The behaviour of `set_symmetry` can still be achieved by using the following snippet:
+  >>> o = Orientation(data)
+  >>> o.symmetry = symmetry
+  >>> o = o.compute_symmetry_reduced_orientations()
 
 Removed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,7 +38,7 @@ Deprecated
   and will be removed in 0.9. Use `ndim` instead.
 - Setting (Mis)Orientation symmetry via `set_symmetry()` is deprecated in 0.8, in favour of
   setting it directly via a `symmetry.setter`, and will be removed in 0.9. Use
-  `assign_smallest_angle()` instead.
+  `map_into_symmetry_reduced_zone()` instead.
  
 Removed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,8 +29,8 @@ Changed
   (X, Y) replaces (azimuth, polar) as internal coordinates.
 - Renamed `Symmetry` method `fundamental_sector()` to `fundamental_zone()`.
 - `Orientation` class methods `from_euler`, `from_matrix`, and `from_neo_euler` no longer 
-  return the smallest angle rotation when `symmetry` argument is provided and not None.
-- `CrystalMap.orientations` no longer returns smallest angle rotation.
+  return the smallest angle orientation when a `symmetry` is given.
+- `CrystalMap.orientations` no longer returns smallest angle orientation.
 
 Deprecated
 ----------

--- a/orix/base/__init__.py
+++ b/orix/base/__init__.py
@@ -64,10 +64,10 @@ class Object3d:
     """Base class for 3d objects."""
 
     dim = None
-    """int : The number of dimensions for this object."""
+    """int : The number of dimensions for this object."""  # pragma: no cover
 
     _data = None
-    """np.ndarray : Array holding this object's numerical data."""
+    """np.ndarray : Array holding this object's numerical data."""  # pragma: no cover
 
     __array_ufunc__ = None
 

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -331,9 +331,9 @@ class CrystalMap:
                 rotations = self.rotations[:, 0]
             else:
                 rotations = self.rotations
-            o = Orientation(rotations)
-            o.symmetry = phases[:].point_group
-            return o.compute_symmetry_reduced_orientations()
+            orientations = Orientation(rotations)
+            orientations.symmetry = phases[:].point_group
+            return orientations
         else:
             raise ValueError(
                 f"Data has the phases {phases.names}, however, you are executing a "

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -331,7 +331,9 @@ class CrystalMap:
                 rotations = self.rotations[:, 0]
             else:
                 rotations = self.rotations
-            return Orientation(rotations).set_symmetry(phases[:].point_group)
+            o = Orientation(rotations)
+            o.symmetry = phases[:].point_group
+            return o.compute_symmetry_reduced_orientations()
         else:
             raise ValueError(
                 f"Data has the phases {phases.names}, however, you are executing a "

--- a/orix/plot/rotation_plot.py
+++ b/orix/plot/rotation_plot.py
@@ -33,7 +33,7 @@ class RotationPlot(Axes3D):
     def transform(self, xs, fundamental_region=None):
         from orix.quaternion import Rotation, Misorientation, OrientationRegion
 
-        # check whether xs is in fundamental region
+        # Project rotations into fundamental zone if necessary
         if isinstance(xs, Misorientation):
             if fundamental_region is None:
                 if isinstance(xs.symmetry, tuple):

--- a/orix/plot/rotation_plot.py
+++ b/orix/plot/rotation_plot.py
@@ -30,22 +30,22 @@ class RotationPlot(Axes3D):
     name = None
     transformation_class = None
 
-    def transform(self, xs, fundamental_region=None):
+    def transform(self, xs, fundamental_zone=None):
         from orix.quaternion import Rotation, Misorientation, OrientationRegion
 
         # Project rotations into fundamental zone if necessary
         if isinstance(xs, Misorientation):
-            if fundamental_region is None:
+            if fundamental_zone is None:
                 if isinstance(xs.symmetry, tuple):
-                    fundamental_region = OrientationRegion.from_symmetry(
+                    fundamental_zone = OrientationRegion.from_symmetry(
                         xs.symmetry[0], xs.symmetry[1]
                     )
                 else:
-                    fundamental_region = OrientationRegion.from_symmetry(xs.symmetry)
-            # check fundamental_region is properly defined
-            if not isinstance(fundamental_region, OrientationRegion):
-                raise TypeError("Fundamental_region is not OrientationRegion.")
-            region_edge = fundamental_region.get_plot_data().angle.data.max()
+                    fundamental_zone = OrientationRegion.from_symmetry(xs.symmetry)
+            # check fundamental_zone is properly defined
+            if not isinstance(fundamental_zone, OrientationRegion):
+                raise TypeError("Fundamental_zone is not OrientationRegion.")
+            region_edge = fundamental_zone.get_plot_data().angle.data.max()
             # if xs is out of fundamental region, calculate symmetry reduction
             if xs.angle.data.max() > region_edge:
                 xs = xs.map_into_symmetry_reduced_zone()
@@ -57,8 +57,8 @@ class RotationPlot(Axes3D):
         x, y, z = transformed.xyz
         return x, y, z
 
-    def scatter(self, xs, fundamental_region=None, **kwargs):
-        x, y, z = self.transform(xs, fundamental_region=fundamental_region)
+    def scatter(self, xs, fundamental_zone=None, **kwargs):
+        x, y, z = self.transform(xs, fundamental_zone=fundamental_zone)
         return super().scatter(x, y, z, **kwargs)
 
     def plot(self, xs, **kwargs):

--- a/orix/plot/rotation_plot.py
+++ b/orix/plot/rotation_plot.py
@@ -44,9 +44,8 @@ class RotationPlot(Axes3D):
             # check fundamental_zone is properly defined
             if not isinstance(fundamental_zone, OrientationRegion):
                 raise TypeError("Fundamental_zone is not an OrientationRegion object.")
-            region_edge = fundamental_zone.get_plot_data().angle.data.max()
-            # if xs is out of fundamental region, calculate symmetry reduction
-            if xs.angle.data.max() > region_edge:
+            # if any in xs is out of fundamental_zone, calculate symmetry reduction
+            if not (xs < fundamental_zone).all():
                 xs = xs.map_into_symmetry_reduced_zone()
 
         if isinstance(xs, Rotation):

--- a/orix/plot/rotation_plot.py
+++ b/orix/plot/rotation_plot.py
@@ -36,12 +36,11 @@ class RotationPlot(Axes3D):
         # Project rotations into fundamental zone if necessary
         if isinstance(xs, Misorientation):
             if fundamental_zone is None:
-                if isinstance(xs.symmetry, tuple):
-                    fundamental_zone = OrientationRegion.from_symmetry(
-                        xs.symmetry[0], xs.symmetry[1]
-                    )
-                else:
-                    fundamental_zone = OrientationRegion.from_symmetry(xs.symmetry)
+                symmetry = xs.symmetry
+                # Orientation.symmetry returns a Symmetry object not a tuple, so pack
+                if not isinstance(symmetry, tuple):
+                    symmetry = (symmetry,)
+                fundamental_zone = OrientationRegion.from_symmetry(*symmetry)
             # check fundamental_zone is properly defined
             if not isinstance(fundamental_zone, OrientationRegion):
                 raise TypeError("Fundamental_zone is not an OrientationRegion object.")

--- a/orix/plot/rotation_plot.py
+++ b/orix/plot/rotation_plot.py
@@ -44,7 +44,7 @@ class RotationPlot(Axes3D):
                     fundamental_zone = OrientationRegion.from_symmetry(xs.symmetry)
             # check fundamental_zone is properly defined
             if not isinstance(fundamental_zone, OrientationRegion):
-                raise TypeError("Fundamental_zone is not OrientationRegion.")
+                raise TypeError("Fundamental_zone is not an OrientationRegion object.")
             region_edge = fundamental_zone.get_plot_data().angle.data.max()
             # if xs is out of fundamental region, calculate symmetry reduction
             if xs.angle.data.max() > region_edge:

--- a/orix/plot/rotation_plot.py
+++ b/orix/plot/rotation_plot.py
@@ -44,7 +44,7 @@ class RotationPlot(Axes3D):
             # check fundamental_zone is properly defined
             if not isinstance(fundamental_zone, OrientationRegion):
                 raise TypeError("Fundamental_zone is not an OrientationRegion object.")
-            # if any in xs is out of fundamental_zone, calculate symmetry reduction
+            # if any in xs are out of fundamental_zone, calculate symmetry reduction
             if not (xs < fundamental_zone).all():
                 xs = xs.map_into_symmetry_reduced_zone()
 

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -234,7 +234,7 @@ class Misorientation(Rotation):
         return o_inside
 
     def distance(self, verbose=False, split_size=100):
-        """Symmetry reduced distance
+        """Symmetry reduced distance.
 
         Compute the shortest distance between all orientations
         considering symmetries.

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -382,7 +382,7 @@ class Misorientation(Rotation):
             to_plot = self.get_random_sample(size)
         else:
             to_plot = self
-        ax.scatter(to_plot, **kwargs)
+        ax.scatter(to_plot, fundamental_region=fundamental_region, **kwargs)
 
         if return_figure:
             return figure

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -129,11 +129,10 @@ class Misorientation(Rotation):
 
     @symmetry.setter
     def symmetry(self, value):
-        err_message = "Value must be a tuple with two Symmetry instances."
         if not isinstance(value, (list, tuple)):
-            raise TypeError(err_message)
+            raise TypeError("Value must be a 2-tuple of Symmetry objects.")
         if len(value) != 2 or not all(isinstance(s, Symmetry) for s in value):
-            raise ValueError(err_message)
+            raise ValueError("Value must be a 2-tuple of Symmetry objects.")
         self._symmetry = tuple(value)
 
     def __getitem__(self, key):
@@ -382,7 +381,7 @@ class Misorientation(Rotation):
             to_plot = self.get_random_sample(size)
         else:
             to_plot = self
-        ax.scatter(to_plot, fundamental_region=fundamental_region, **kwargs)
+        ax.scatter(to_plot, fundamental_region, **kwargs)
 
         if return_figure:
             return figure

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -164,7 +164,7 @@ class Misorientation(Rotation):
 
     @deprecated(
         since="0.8",
-        alternative="orix.quaternion.Misorientation.assign_smallest_angle",
+        alternative="orix.quaternion.Misorientation.map_into_symmetry_reduced_zone",
         removal="0.9",
     )
     def set_symmetry(self, Gl, Gr, verbose=False):

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -619,7 +619,7 @@ class Orientation(Misorientation):
 
     @deprecated(
         since="0.8",
-        alternative="orix.quaternion.Orientation.assign_smallest_angle",
+        alternative="orix.quaternion.Orientation.map_into_symmetry_reduced_zone",
         removal="0.9",
     )
     def set_symmetry(self, symmetry):

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -128,13 +128,13 @@ class Misorientation(Rotation):
         return self._symmetry
 
     @symmetry.setter
-    def symmetry(self, values):
-        err_message = "Values must be a tuple of two Symmetry objects."
-        if not isinstance(values, (list, tuple)):
+    def symmetry(self, value):
+        err_message = "Value must be a tuple with two Symmetry instances."
+        if not isinstance(value, (list, tuple)):
             raise TypeError(err_message)
-        if len(values) != 2 or not all(isinstance(s, Symmetry) for s in values):
+        if len(value) != 2 or not all(isinstance(s, Symmetry) for s in value):
             raise ValueError(err_message)
-        self._symmetry = tuple(values)
+        self._symmetry = tuple(value)
 
     def __getitem__(self, key):
         m = super().__getitem__(key)

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -360,19 +360,19 @@ class Misorientation(Rotation):
 
         # Plot wireframe
         if isinstance(self.symmetry, tuple):
-            fundamental_region = OrientationRegion.from_symmetry(
+            fundamental_zone = OrientationRegion.from_symmetry(
                 s1=self.symmetry[0], s2=self.symmetry[1]
             )
-            ax.plot_wireframe(fundamental_region, **wireframe_kwargs)
+            ax.plot_wireframe(fundamental_zone, **wireframe_kwargs)
         else:
             # Orientation via inheritance
-            fundamental_region = OrientationRegion.from_symmetry(self.symmetry)
-            ax.plot_wireframe(fundamental_region, **wireframe_kwargs)
+            fundamental_zone = OrientationRegion.from_symmetry(self.symmetry)
+            ax.plot_wireframe(fundamental_zone, **wireframe_kwargs)
 
         # Correct the aspect ratio of the axes according to the extent
         # of the boundaries of the fundamental region, and also restrict
         # the data limits to these boundaries
-        ax._correct_aspect_ratio(fundamental_region, set_limits=True)
+        ax._correct_aspect_ratio(fundamental_zone, set_limits=True)
 
         ax.axis("off")
         figure.subplots_adjust(left=0, right=1, bottom=0, top=1, hspace=0, wspace=0)
@@ -381,7 +381,7 @@ class Misorientation(Rotation):
             to_plot = self.get_random_sample(size)
         else:
             to_plot = self
-        ax.scatter(to_plot, fundamental_region, **kwargs)
+        ax.scatter(to_plot, fundamental_zone=fundamental_zone, **kwargs)
 
         if return_figure:
             return figure

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -194,9 +194,9 @@ class Misorientation(Rotation):
         """
         misori = self.__class__(self.data)
         misori.symmetry = (Gl, Gr)
-        return misori.compute_symmetry_reduced_orientations()
+        return misori.map_into_symmetry_reduced_zone()
 
-    def compute_symmetry_reduced_orientations(self, verbose=False):
+    def map_into_symmetry_reduced_zone(self, verbose=False):
         """Computes equivalent transformations which have the smallest
         angle of rotation and return these as a new Misorientation object.
 
@@ -211,7 +211,7 @@ class Misorientation(Rotation):
         >>> data = np.array([[0.5, 0.5, 0.5, 0.5], [0, 1, 0, 0]])
         >>> m = Misorientation(data)
         >>> m.symmetry = (C4, C2)
-        >>> m.compute_symmetry_reduced_orientations()
+        >>> m.map_into_symmetry_reduced_zone()
         Misorientation (2,) 4, 2
         [[-0.7071  0.7071  0.      0.    ]
         [ 0.      1.      0.      0.    ]]
@@ -260,7 +260,7 @@ class Misorientation(Rotation):
         >>> data = np.array([[0.5, 0.5, 0.5, 0.5], [0, 1, 0, 0]])
         >>> m = Misorientation(data)
         >>> m.symmetry = (C4, C2)
-        >>> m = m.compute_symmetry_reduced_orientations()
+        >>> m = m.map_into_symmetry_reduced_zone()
         >>> m.distance()
         array([[3.14159265, 1.57079633],
                [1.57079633, 0.        ]])
@@ -439,7 +439,7 @@ class Orientation(Misorientation):
             # Call to Object3d.squeeze() doesn't carry over symmetry
             misorientation = Misorientation(self * ~other).squeeze()
             misorientation.symmetry = (self.symmetry, other.symmetry)
-            return misorientation.compute_symmetry_reduced_orientations()
+            return misorientation.map_into_symmetry_reduced_zone()
         return NotImplemented
 
     @classmethod
@@ -649,7 +649,7 @@ class Orientation(Misorientation):
         """
         o = self.__class__(self.data)
         o.symmetry = symmetry
-        return o.compute_symmetry_reduced_orientations()
+        return o.map_into_symmetry_reduced_zone()
 
     def _dot_outer_dask(self, other, chunk_size=20):
         """Symmetry reduced dot product of every orientation in this

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -620,9 +620,9 @@ class Orientation(Misorientation):
         return Scalar(angles)
 
     @deprecated(
-        since="0.7",
-        alternative="orix.quaternion.Orientation.compute_symmetry_reduced_orientations",
-        removal="0.8",
+        since="0.8",
+        alternative="orix.quaternion.Orientation.assign_smallest_angle",
+        removal="0.9",
     )
     def set_symmetry(self, symmetry):
         """Assign a symmetry to this orientation.

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -163,9 +163,9 @@ class Misorientation(Rotation):
         return self.__class__(equivalent).flatten()
 
     @deprecated(
-        since="0.7",
-        alternative="orix.quaternion.Misorientation.compute_symmetry_reduced_orientations",
-        removal="0.8",
+        since="0.8",
+        alternative="orix.quaternion.Misorientation.assign_smallest_angle",
+        removal="0.9",
     )
     def set_symmetry(self, Gl, Gr, verbose=False):
         """Assign symmetries to this misorientation.

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -405,9 +405,7 @@ class Orientation(Misorientation):
     @symmetry.setter
     def symmetry(self, value):
         if not isinstance(value, Symmetry):
-            raise TypeError(
-                "Value must be an instance of orix.quaternion.Symmetry."
-            )
+            raise TypeError("Value must be an instance of orix.quaternion.Symmetry.")
         self._symmetry = (C1, value)
 
     @property

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -406,7 +406,7 @@ class Orientation(Misorientation):
     def symmetry(self, value):
         if not isinstance(value, Symmetry):
             raise TypeError(
-                "Value must be an instance of orix.quaternion.symmetry.Symmetry."
+                "Value must be an instance of orix.quaternion.Symmetry."
             )
         self._symmetry = (C1, value)
 

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -198,7 +198,7 @@ class Misorientation(Rotation):
 
     def compute_symmetry_reduced_orientations(self, verbose=False):
         """Computes equivalent transformations which have the smallest
-        angle of rotation and assigns these in-place.
+        angle of rotation and return these as a new Misorientation object.
 
         Returns
         -------

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -375,7 +375,7 @@ def test_set_symmetry_deprecation_warning_orientation():
     with pytest.warns(
         np.VisibleDeprecationWarning,
         match="Function `set_symmetry()",
-    ):  # can only get this to work properly with one backtick...
+    ):
         _ = o.set_symmetry(C2)
 
 
@@ -384,5 +384,5 @@ def test_set_symmetry_deprecation_warning_misorientation():
     with pytest.warns(
         np.VisibleDeprecationWarning,
         match="Function `set_symmetry()",
-    ):  # can only get this to work properly with one backtick...
+    ):
         _ = o.set_symmetry(C2, C2)

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -181,6 +181,7 @@ class TestOrientationInitialization:
         assert np.allclose(o1.data, [0, -0.3827, 0, -0.9239], atol=1e-4)
         assert o1.symmetry.name == "1"
         o2 = Orientation.from_euler(euler, symmetry=Oh)
+        o2 = o2.compute_symmetry_reduced_orientations()
         assert np.allclose(o2.data, [0.9239, 0, 0.3827, 0], atol=1e-4)
         assert o2.symmetry.name == "m-3m"
         o3 = o1.set_symmetry(Oh)
@@ -196,6 +197,7 @@ class TestOrientationInitialization:
         )
         assert o1.symmetry.name == "1"
         o2 = Orientation.from_matrix(om, symmetry=Oh)
+        o2 = o2.compute_symmetry_reduced_orientations()
         assert np.allclose(
             o2.data, np.array([1, 0, 0, 0] * 2 + [-1, 0, 0, 0] * 2).reshape((4, 4))
         )
@@ -209,6 +211,7 @@ class TestOrientationInitialization:
         assert np.allclose(o1.data, [0.7071, 0, 0, 0.7071])
         assert o1.symmetry.name == "1"
         o2 = Orientation.from_neo_euler(v, symmetry=Oh)
+        o2 = o2.compute_symmetry_reduced_orientations()
         assert np.allclose(o2.data, [-1, 0, 0, 0])
         assert o2.symmetry.name == "m-3m"
         o3 = o1.set_symmetry(Oh)

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -161,7 +161,6 @@ def test_sub_orientation_and_other():
 def test_transpose_2d():
     o1 = Orientation.random_vonmises((11, 3))
     o2 = o1.transpose()
-
     assert o1.shape == o2.shape[::-1]
 
 
@@ -172,7 +171,6 @@ def test_transpose_2d():
 def test_transpose_3d(shape, expected_shape, axes):
     o1 = Orientation.random_vonmises(shape)
     o2 = o1.transpose(*axes)
-
     assert o2.shape == tuple(expected_shape)
 
 
@@ -181,16 +179,13 @@ def test_transpose_symmetry():
     o1.symmetry = Oh
     o1 = o1.map_into_symmetry_reduced_zone()
     o2 = o1.transpose()
-
     assert o1.symmetry == o2.symmetry
 
 
 def test_symmetry_property_orientation():
     o = Orientation.random((3, 2))
-
     sym = Oh
     o.symmetry = sym
-
     assert o.symmetry == sym
     assert o._symmetry == (C1, sym)
 
@@ -200,21 +195,18 @@ def test_symmetry_property_orientation_data():
     o = Orientation.random((3, 2))
     d1 = o.data.copy()
     o.symmetry = Oh
-
     assert np.allclose(o.data, d1)
 
 
 def test_symmetry_property_misorientation():
     o = Misorientation.random((3, 2))
     o.symmetry = (Oh, C3)
-
     assert o.symmetry == (Oh, C3)
     assert o._symmetry == (Oh, C3)
 
 
 def test_symmetry_property_wrong_type_orientation():
     o = Orientation.random((3, 2))
-
     with pytest.raises(TypeError, match="Value must be an instance of"):
         o.symmetry = 1
 
@@ -237,7 +229,6 @@ def test_symmetry_property_wrong_type_misorientation(error_type, value):
 )
 def test_symmetry_property_wrong_number_of_values_misorientation(error_type, value):
     o = Misorientation.random((3, 2))
-
     with pytest.raises(error_type, match="Value must be a tuple"):
         # less than 2 Symmetry
         o.symmetry = value

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -199,10 +199,10 @@ def test_symmetry_property_orientation_data():
 
 
 def test_symmetry_property_misorientation():
-    o = Misorientation.random((3, 2))
-    o.symmetry = (Oh, C3)
-    assert o.symmetry == (Oh, C3)
-    assert o._symmetry == (Oh, C3)
+    m = Misorientation.random((3, 2))
+    m.symmetry = (Oh, C3)
+    assert m.symmetry == (Oh, C3)
+    assert m._symmetry == (Oh, C3)
 
 
 def test_symmetry_property_wrong_type_orientation():

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -219,23 +219,28 @@ def test_symmetry_property_wrong_type_orientation():
         o.symmetry = 1
 
 
-@pytest.mark.parametrize("error_type, value", [(ValueError, (1, 2)), (ValueError, (C1, 2)), (TypeError, 1)])
+@pytest.mark.parametrize(
+    "error_type, value", [(ValueError, (1, 2)), (ValueError, (C1, 2)), (TypeError, 1)]
+)
 def test_symmetry_property_wrong_type_misorientation(error_type, value):
     mori = Misorientation.random((3, 2))
-    with pytest.raises(error_type, match="Values must be a tuple"):
+    with pytest.raises(error_type, match="Value must be a tuple"):
         mori.symmetry = value
 
 
-def test_symmetry_property_too_many_values_misorientation():
+@pytest.mark.parametrize(
+    "error_type, value",
+    [
+        (ValueError, (C1,)),
+        (ValueError, (C1, C2, C1)),
+    ],
+)
+def test_symmetry_property_wrong_number_of_values_misorientation(error_type, value):
     o = Misorientation.random((3, 2))
 
-    with pytest.raises(ValueError, match="Values must be a tuple"):
+    with pytest.raises(error_type, match="Value must be a tuple"):
         # less than 2 Symmetry
-        o.symmetry = (C1,)
-
-    with pytest.raises(ValueError, match="Values must be a tuple"):
-        # more than 2 Symmetry
-        o.symmetry = (C1, C2, C3)
+        o.symmetry = value
 
 
 class TestOrientationInitialization:

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -219,20 +219,11 @@ def test_symmetry_property_wrong_type_orientation():
         o.symmetry = 1
 
 
-def test_symmetry_property_wrong_type_misorientation():
-    o = Misorientation.random((3, 2))
-
-    with pytest.raises(ValueError, match="Values must be a tuple"):
-        # not Symmetry
-        o.symmetry = (1, 2)
-
-    with pytest.raises(ValueError, match="Values must be a tuple"):
-        # not Symmetry
-        o.symmetry = (C1, 2)
-
-    with pytest.raises(TypeError, match="Values must be a tuple"):
-        # not list or tuple
-        o.symmetry = 1
+@pytest.mark.parametrize("error_type, value", [(ValueError, (1, 2)), (ValueError, (C1, 2)), (TypeError, 1)])
+def test_symmetry_property_wrong_type_misorientation(error_type, value):
+    mori = Misorientation.random((3, 2))
+    with pytest.raises(error_type, match="Values must be a tuple"):
+        mori.symmetry = value
 
 
 def test_symmetry_property_too_many_values_misorientation():

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -222,10 +222,7 @@ def test_symmetry_property_wrong_type_misorientation(error_type, value):
 
 @pytest.mark.parametrize(
     "error_type, value",
-    [
-        (ValueError, (C1,)),
-        (ValueError, (C1, C2, C1)),
-    ],
+    [(ValueError, (C1,)), (ValueError, (C1, C2, C1))],
 )
 def test_symmetry_property_wrong_number_of_values_misorientation(error_type, value):
     o = Misorientation.random((3, 2))

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -381,3 +381,21 @@ class TestOrientation:
         orientation.random_vonmises(200).scatter(size=50)
 
         plt.close("all")
+
+
+def test_set_symmetry_deprecation_warning_orientation():
+    o = Orientation.random((3, 2))
+    with pytest.warns(
+        np.VisibleDeprecationWarning,
+        match="Function `set_symmetry()",
+    ):  # can only get this to work properly with one backtick...
+        _ = o.set_symmetry(C2)
+
+
+def test_set_symmetry_deprecation_warning_misorientation():
+    o = Misorientation.random((3, 2))
+    with pytest.warns(
+        np.VisibleDeprecationWarning,
+        match="Function `set_symmetry()",
+    ):  # can only get this to work properly with one backtick...
+        _ = o.set_symmetry(C2, C2)

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -216,7 +216,7 @@ def test_symmetry_property_wrong_type_orientation():
 )
 def test_symmetry_property_wrong_type_misorientation(error_type, value):
     mori = Misorientation.random((3, 2))
-    with pytest.raises(error_type, match="Value must be a tuple"):
+    with pytest.raises(error_type, match="Value must be a 2-tuple"):
         mori.symmetry = value
 
 
@@ -226,7 +226,7 @@ def test_symmetry_property_wrong_type_misorientation(error_type, value):
 )
 def test_symmetry_property_wrong_number_of_values_misorientation(error_type, value):
     o = Misorientation.random((3, 2))
-    with pytest.raises(error_type, match="Value must be a tuple"):
+    with pytest.raises(error_type, match="Value must be a 2-tuple"):
         # less than 2 Symmetry
         o.symmetry = value
 

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -104,7 +104,7 @@ def test_orientation_persistence(symmetry, vector):
 )
 def test_distance(orientation, symmetry, expected):
     orientation.symmetry = symmetry
-    orientation = orientation.map_into_symmetry_reduced_zone()
+    orientation = orientation.map_into_symmetry_reduced_zone(verbose=True)
     distance = orientation.distance(verbose=True)
     assert np.allclose(distance, expected, atol=1e-3)
 

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -57,7 +57,9 @@ def orientation(request):
     indirect=["orientation"],
 )
 def test_set_symmetry(orientation, symmetry, expected):
-    o = orientation.set_symmetry(symmetry)
+    o = Orientation(orientation.data)
+    o.symmetry = symmetry
+    o = o.compute_symmetry_reduced_orientations()
     assert np.allclose(o.data, expected, atol=1e-3)
 
 
@@ -69,7 +71,9 @@ def test_set_symmetry(orientation, symmetry, expected):
 def test_orientation_persistence(symmetry, vector):
     v = symmetry.outer(vector).flatten()
     o = Orientation.random()
-    oc = o.set_symmetry(symmetry)
+    oc = Orientation(o.data)
+    oc.symmetry = symmetry
+    oc = oc.compute_symmetry_reduced_orientations()
     v1 = o * v
     v1 = Vector3d(v1.data.round(4))
     v2 = oc * v
@@ -99,15 +103,16 @@ def test_orientation_persistence(symmetry, vector):
     indirect=["orientation"],
 )
 def test_distance(orientation, symmetry, expected):
-    o = orientation.set_symmetry(symmetry)
-    distance = o.distance(verbose=True)
+    orientation.symmetry = symmetry
+    orientation = orientation.compute_symmetry_reduced_orientations()
+    distance = orientation.distance(verbose=True)
     assert np.allclose(distance, expected, atol=1e-3)
 
 
 @pytest.mark.parametrize("symmetry", [C1, C2, C4, D2, D6, T, O])
 def test_getitem(orientation, symmetry):
-    o = orientation.set_symmetry(symmetry)
-    assert o[0].symmetry._tuples == symmetry._tuples
+    orientation.symmetry = symmetry
+    assert orientation[0].symmetry._tuples == symmetry._tuples
 
 
 @pytest.mark.parametrize("Gl", [C4, C2])
@@ -120,8 +125,9 @@ def test_equivalent(Gl):
     Gl == C2 is no grain exchange
     """
     m = Misorientation([1, 1, 1, 1])  # any will do
-    m_new = m.set_symmetry(Gl, C4, verbose=True)
-    m_new.symmetry
+    m_new = Misorientation(m.data)
+    m_new.symmetry = (Gl, C4)
+    m_new = m_new.compute_symmetry_reduced_orientations()
     _ = m_new.equivalent(grain_exchange=True)
 
 
@@ -132,13 +138,16 @@ def test_repr():
 
 def test_repr_ori():
     shape = (2, 3)
-    o = Orientation.identity(shape).set_symmetry(O)
+    o = Orientation.identity(shape)
+    o.symmetry = O
+    o = o.compute_symmetry_reduced_orientations()
     assert repr(o).split("\n")[0] == f"Orientation {shape} {O.name}"
 
 
 def test_sub():
     o = Orientation([1, 1, 1, 1])  # any will do
-    o = o.set_symmetry(C4)  # only one as it a O
+    o.symmetry = C4  # only one as it a O
+    o = o.compute_symmetry_reduced_orientations()
     m = o - o
     assert np.allclose(m.data, [1, 0, 0, 0])
 
@@ -168,10 +177,74 @@ def test_transpose_3d(shape, expected_shape, axes):
 
 
 def test_transpose_symmetry():
-    o1 = Orientation.random_vonmises((11, 3)).set_symmetry(Oh)
+    o1 = Orientation.random_vonmises((11, 3))
+    o1.symmetry = Oh
+    o1 = o1.compute_symmetry_reduced_orientations()
     o2 = o1.transpose()
 
     assert o1.symmetry == o2.symmetry
+
+
+def test_symmetry_property_orientation():
+    o = Orientation.random((3, 2))
+
+    sym = Oh
+    o.symmetry = sym
+
+    assert o.symmetry == sym
+    assert o._symmetry == (C1, sym)
+
+
+def test_symmetry_property_orientation_data():
+    """Test that data remains unchanged after setting symmetry property."""
+    o = Orientation.random((3, 2))
+    d1 = o.data.copy()
+    o.symmetry = Oh
+
+    assert np.allclose(o.data, d1)
+
+
+def test_symmetry_property_misorientation():
+    o = Misorientation.random((3, 2))
+    o.symmetry = (Oh, C3)
+
+    assert o.symmetry == (Oh, C3)
+    assert o._symmetry == (Oh, C3)
+
+
+def test_symmetry_property_wrong_type_orientation():
+    o = Orientation.random((3, 2))
+
+    with pytest.raises(TypeError, match="Value must be an instance of"):
+        o.symmetry = 1
+
+
+def test_symmetry_property_wrong_type_misorientation():
+    o = Misorientation.random((3, 2))
+
+    with pytest.raises(ValueError, match="Values must be a tuple"):
+        # not Symmetry
+        o.symmetry = (1, 2)
+
+    with pytest.raises(ValueError, match="Values must be a tuple"):
+        # not Symmetry
+        o.symmetry = (C1, 2)
+
+    with pytest.raises(TypeError, match="Values must be a tuple"):
+        # not list or tuple
+        o.symmetry = 1
+
+
+def test_symmetry_property_too_many_values_misorientation():
+    o = Misorientation.random((3, 2))
+
+    with pytest.raises(ValueError, match="Values must be a tuple"):
+        # less than 2 Symmetry
+        o.symmetry = (C1,)
+
+    with pytest.raises(ValueError, match="Values must be a tuple"):
+        # more than 2 Symmetry
+        o.symmetry = (C1, C2, C3)
 
 
 class TestOrientationInitialization:
@@ -184,7 +257,9 @@ class TestOrientationInitialization:
         o2 = o2.compute_symmetry_reduced_orientations()
         assert np.allclose(o2.data, [0.9239, 0, 0.3827, 0], atol=1e-4)
         assert o2.symmetry.name == "m-3m"
-        o3 = o1.set_symmetry(Oh)
+        o3 = Orientation(o1.data)
+        o3.symmetry = Oh
+        o3 = o3.compute_symmetry_reduced_orientations()
         assert np.allclose(o3.data, o2.data)
 
     def test_from_matrix_symmetry(self):
@@ -202,7 +277,9 @@ class TestOrientationInitialization:
             o2.data, np.array([1, 0, 0, 0] * 2 + [-1, 0, 0, 0] * 2).reshape((4, 4))
         )
         assert o2.symmetry.name == "m-3m"
-        o3 = o1.set_symmetry(Oh)
+        o3 = Orientation(o1.data)
+        o3.symmetry = Oh
+        o3 = o3.compute_symmetry_reduced_orientations()
         assert np.allclose(o3.data, o2.data)
 
     def test_from_neo_euler_symmetry(self):
@@ -214,7 +291,9 @@ class TestOrientationInitialization:
         o2 = o2.compute_symmetry_reduced_orientations()
         assert np.allclose(o2.data, [-1, 0, 0, 0])
         assert o2.symmetry.name == "m-3m"
-        o3 = o1.set_symmetry(Oh)
+        o3 = Orientation(o1.data)
+        o3.symmetry = Oh
+        o3 = o3.compute_symmetry_reduced_orientations()
         assert np.allclose(o3.data, o2.data)
 
 
@@ -222,7 +301,9 @@ class TestOrientation:
     @pytest.mark.parametrize("symmetry", [C1, C2, C3, C4, D2, D3, D6, T, O, Oh])
     def test_get_distance_matrix(self, symmetry):
         q = [(0.5, 0.5, 0.5, 0.5), (0.5 ** 0.5, 0, 0, 0.5 ** 0.5)]
-        o = Orientation(q).set_symmetry(symmetry)
+        o = Orientation(q)
+        o.symmetry = symmetry
+        o = o.compute_symmetry_reduced_orientations()
         angles_numpy = o.get_distance_matrix()
         assert isinstance(angles_numpy, Scalar)
         assert angles_numpy.shape == (2, 2)
@@ -248,7 +329,9 @@ class TestOrientation:
     def test_angle_with(self, symmetry):
         q = [(0.5, 0.5, 0.5, 0.5), (0.5 ** 0.5, 0, 0, 0.5 ** 0.5)]
         r = Rotation(q)
-        o = Orientation(q).set_symmetry(symmetry)
+        o = Orientation(q)
+        o.symmetry = symmetry
+        o = o.compute_symmetry_reduced_orientations()
 
         is_equal = np.allclose((~o).angle_with(o).data, (~r).angle_with(r).data)
         if symmetry.name in ["1", "m3m"]:
@@ -257,7 +340,9 @@ class TestOrientation:
             assert not is_equal
 
     def test_negate_orientation(self):
-        o = Orientation.identity().set_symmetry(Oh)
+        o = Orientation.identity()
+        o.symmetry = Oh
+        o = o.compute_symmetry_reduced_orientations()
         on = -o
         assert on.symmetry.name == o.symmetry.name
 
@@ -265,7 +350,8 @@ class TestOrientation:
     def test_scatter(self, orientation, pure_misorientation):
         if pure_misorientation:
             orientation = Misorientation(orientation)
-            orientation = orientation.set_symmetry(C2, D6)
+            orientation.symmetry = (C2, D6)
+            orientation = orientation.compute_symmetry_reduced_orientations()
         fig_axangle = orientation.scatter(return_figure=True)
         assert isinstance(fig_axangle.axes[0], AxAnglePlot)
         fig_rodrigues = orientation.scatter(projection="rodrigues", return_figure=True)

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -658,15 +658,13 @@ class TestCrystalMapGetMapData:
         o1 = xmap1.get_map_data("orientations")
         o2 = xmap2.get_map_data("orientations")
 
-        expected_o1 = xmap1.orientations
-        expected_o1 = expected_o1.to_euler()
+        expected_o1 = xmap1.orientations.to_euler()
         expected_shape = expected_o1.shape
         assert np.allclose(
             o1[~np.isnan(o1)].reshape(expected_shape), expected_o1, atol=1e-3
         )
 
-        expected_o2 = xmap2.orientations
-        expected_o2 = expected_o2.to_euler()
+        expected_o2 = xmap2.orientations.to_euler()
         expected_shape = expected_o2.shape
         assert np.allclose(
             o2[~np.isnan(o2)].reshape(expected_shape), expected_o2, atol=1e-3

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -501,11 +501,11 @@ class TestCrystalMapOrientations:
         xmap.phases = PhaseList(Phase("a", point_group=point_group))
 
         o = xmap.orientations
-        o = o.compute_symmetry_reduced_orientations()
+        o = o.map_into_symmetry_reduced_zone()
 
         o1 = Orientation(r)
         o1.symmetry = point_group
-        o1 = o1.compute_symmetry_reduced_orientations()
+        o1 = o1.map_into_symmetry_reduced_zone()
 
         assert np.allclose(o.data, o1.data, atol=1e-3)
         assert np.allclose(o.data, expected_orientation, atol=1e-3)

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -501,6 +501,7 @@ class TestCrystalMapOrientations:
         xmap.phases = PhaseList(Phase("a", point_group=point_group))
 
         o = xmap.orientations
+        o = o.compute_symmetry_reduced_orientations()
 
         o1 = Orientation(r)
         o1.symmetry = point_group
@@ -657,13 +658,15 @@ class TestCrystalMapGetMapData:
         o1 = xmap1.get_map_data("orientations")
         o2 = xmap2.get_map_data("orientations")
 
-        expected_o1 = xmap1.orientations.to_euler()
+        expected_o1 = xmap1.orientations
+        expected_o1 = expected_o1.to_euler()
         expected_shape = expected_o1.shape
         assert np.allclose(
             o1[~np.isnan(o1)].reshape(expected_shape), expected_o1, atol=1e-3
         )
 
-        expected_o2 = xmap2.orientations.to_euler()
+        expected_o2 = xmap2.orientations
+        expected_o2 = expected_o2.to_euler()
         expected_shape = expected_o2.shape
         assert np.allclose(
             o2[~np.isnan(o2)].reshape(expected_shape), expected_o2, atol=1e-3
@@ -683,7 +686,6 @@ class TestCrystalMapGetMapData:
             phase_mask_in_data = xmap.phase_id == i
             oi = Orientation(rotations[phase_mask_in_data])
             oi.symmetry = phase.point_group
-            oi = oi.compute_symmetry_reduced_orientations()
             array[phase_mask] = oi.to_euler()
 
         assert np.allclose(o, array.reshape(o.shape), atol=1e-3)

--- a/orix/tests/test_miller.py
+++ b/orix/tests/test_miller.py
@@ -222,7 +222,6 @@ class TestMiller:
     def test_multiply_orientation(self):
         o = Orientation.from_euler(np.deg2rad([45, 0, 0]))
         o.symmetry = CUBIC_PHASE.point_group
-        o = o.compute_symmetry_reduced_orientations()
         m = Miller(hkl=[[1, 1, 1], [2, 0, 0]], phase=CUBIC_PHASE)
         m2 = o * m
         assert isinstance(m2, Miller)

--- a/orix/tests/test_miller.py
+++ b/orix/tests/test_miller.py
@@ -221,7 +221,8 @@ class TestMiller:
 
     def test_multiply_orientation(self):
         o = Orientation.from_euler(np.deg2rad([45, 0, 0]))
-        o = o.set_symmetry(CUBIC_PHASE.point_group)
+        o.symmetry = CUBIC_PHASE.point_group
+        o = o.compute_symmetry_reduced_orientations()
         m = Miller(hkl=[[1, 1, 1], [2, 0, 0]], phase=CUBIC_PHASE)
         m2 = o * m
         assert isinstance(m2, Miller)

--- a/orix/tests/test_rotation_plot.py
+++ b/orix/tests/test_rotation_plot.py
@@ -21,8 +21,9 @@ from packaging import version
 from matplotlib import __version__ as _MPL_VERSION
 from matplotlib import pyplot as plt
 import numpy as np
+import pytest
 
-from orix.plot import RodriguesPlot, AxAnglePlot
+from orix.plot import RodriguesPlot, AxAnglePlot, RotationPlot
 from orix.quaternion import Misorientation, Orientation, OrientationRegion
 from orix.quaternion.symmetry import C1, D6
 
@@ -50,10 +51,13 @@ def test_init_axangle_plot():
 def test_RotationPlot_methods():
     """This code is lifted from demo-3-v0.1."""
     misori = Misorientation([1, 1, 1, 1])  # any will do
+    ori = Orientation.random()
     fig = plt.figure()
     ax = fig.add_subplot(projection="axangle", proj_type="ortho", **_SUBPLOT_KWARGS)
     ax.scatter(misori)
+    ax.scatter(ori)
     ax.plot(misori)
+    ax.plot(ori)
     ax.plot_wireframe(OrientationRegion.from_symmetry(D6, D6))
     plt.close("all")
 
@@ -64,6 +68,13 @@ def test_RotationPlot_methods():
 def test_full_region_plot():
     empty = OrientationRegion.from_symmetry(C1, C1)
     _ = empty.get_plot_data()
+
+
+def test_RotationPlot_transform_fundamental_region_raises():
+    fig = plt.figure()
+    rp = RotationPlot(fig)
+    with pytest.raises(TypeError, match="Fundamental_region is not OrientationRegion."):
+        rp.transform(Orientation.random(), fundamental_region=1)
 
 
 def test_correct_aspect_ratio():

--- a/orix/tests/test_rotation_plot.py
+++ b/orix/tests/test_rotation_plot.py
@@ -74,7 +74,7 @@ def test_RotationPlot_transform_fundamental_zone_raises():
     fig = plt.figure()
     rp = RotationPlot(fig)
     with pytest.raises(
-        TypeError, match="Fundamental_zone is not an OrientationRegion object"
+        TypeError, match="fundamental_zone is not an OrientationRegion object"
     ):
         rp.transform(Orientation.random(), fundamental_zone=1)
 

--- a/orix/tests/test_rotation_plot.py
+++ b/orix/tests/test_rotation_plot.py
@@ -70,11 +70,13 @@ def test_full_region_plot():
     _ = empty.get_plot_data()
 
 
-def test_RotationPlot_transform_fundamental_region_raises():
+def test_RotationPlot_transform_fundamental_zone_raises():
     fig = plt.figure()
     rp = RotationPlot(fig)
-    with pytest.raises(TypeError, match="Fundamental_region is not OrientationRegion."):
-        rp.transform(Orientation.random(), fundamental_region=1)
+    with pytest.raises(
+        TypeError, match="Fundamental_zone is not an OrientationRegion object"
+    ):
+        rp.transform(Orientation.random(), fundamental_zone=1)
 
 
 def test_correct_aspect_ratio():

--- a/orix/tests/test_rotation_plot.py
+++ b/orix/tests/test_rotation_plot.py
@@ -79,6 +79,23 @@ def test_RotationPlot_transform_fundamental_zone_raises():
         rp.transform(Orientation.random(), fundamental_zone=1)
 
 
+def test_RotationPlot_map_into_symmetry_reduced_zone():
+    # orientations are (in, out) of D6 fundamental zone
+    ori = Orientation(((1, 0, 0, 0), (0.5, 0.5, 0.5, 0.5)))
+    ori.symmetry = D6
+    fz = OrientationRegion.from_symmetry(ori.symmetry)
+    assert np.allclose(ori < fz, (True, False))
+    # test map_into_symmetry_reduced_zone in RotationPlot.transform
+    fig = ori.scatter(return_figure=True)
+    xyz_symmetry = fig.axes[0].collections[1]._offsets3d
+    # compute same plot again but with C1 symmetry where both orientations are in C1 FZ
+    ori.symmetry = C1
+    fig2 = ori.scatter(return_figure=True)
+    xyz = fig2.axes[0].collections[1]._offsets3d
+    # test that the plotted points are not the same
+    assert not np.allclose(xyz_symmetry, xyz)
+
+
 def test_correct_aspect_ratio():
     # Set up figure the "old" way
     fig = plt.figure()

--- a/orix/tests/test_stereographic_plot.py
+++ b/orix/tests/test_stereographic_plot.py
@@ -105,10 +105,10 @@ class TestStereographicPlot:
 
     def test_set_labels(self):
         _, ax = plt.subplots(subplot_kw=dict(projection=PROJ_NAME))
-        assert ax.texts == []
+        assert len(ax.texts) == 0
 
         ax.set_labels(None, None, None)
-        assert ax.texts == []
+        assert len(ax.texts) == 0
 
         ax.set_labels("X", None, None)
         assert len(ax.texts) == 1
@@ -197,7 +197,7 @@ class TestStereographicPlot:
         # Not plotted since the vector isn't visible in this hemisphere
         ax.scatter(v)
         ax.text(v, s="1")
-        assert ax.texts == []
+        assert len(ax.texts) == 0
 
         plt.close("all")
 


### PR DESCRIPTION
#### Description of the change
As discussed in #235 the use of ```set_symmetry``` produces behaviour which may be undesired in certain circumstances. As such a ```symmetry``` property has been introduced for ```Orientation``` and ```Misorientation``` classes which sets the instances ```_symmetry``` attribute without further calculations.

These extra calculations, in the case of the ```Orientation``` class, take the form of finding the symmetry component with the smallest angular distance to the ```C1``` symmetry, which is the identity orientation. In this PR no calculations are automatically performed when the ```symmetry``` property is set. A new function currently named ```compute_symmetry_reduced_orientations``` performs the calculations previously defined within ```set_symmetry```. In this case, the old functionality afforded by ```set_symmetry```:
```python
o = Orientation.random((5, 3))
o.set_symmetry(Oh)
```
can still be achieved as:

```python
o = Orientation.random((5, 3))
o.symmetry = Oh
o = o.compute_symmetry_reduced_orientations()
```

This would be in favour of possibly deprecating ```set_symmetry``` in a future release.

The tests have been updated to use the new syntax above and are passing.


#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
from orix.quaternion import Orientation
o = Orientation.random((5, 3))
o.symmetry = Oh
o.symmetry
>>> Symmetry (48,) m-3m
    [[ 1.      0.      0.      0.    ]
    ...
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
