### PR TITLE
Add new classmethods from_axes_angles() to Rotation and Orientation classes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,8 @@ Added
   sample direction.
 - Inverse pole figure colouring of orientations given a Laue symmetry and sample
   direction.
+- `from_axes_angles()` method to `Rotation` and `Orientation` as a shortcut to
+  `from_neo_euler()` for axis/angle pairs.
 
 Changed
 -------

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -328,6 +328,7 @@ Orientation
     distance
     dot
     dot_outer
+    from_axes_angles
     from_euler
     from_matrix
     from_neo_euler
@@ -381,6 +382,7 @@ Rotation
     angle_with
     dot_outer
     flatten
+    from_axes_angles
     from_euler
     from_matrix
     from_neo_euler

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -51,6 +51,7 @@ from orix.quaternion.orientation_region import OrientationRegion
 from orix.quaternion.rotation import Rotation
 from orix.quaternion.symmetry import C1, Symmetry
 from orix.scalar import Scalar
+from orix.vector import AxAngle
 from orix._util import deprecated
 
 
@@ -254,11 +255,10 @@ class Misorientation(Rotation):
         Examples
         --------
         >>> import numpy as np
-        >>> from orix.quaternion.symmetry import C4, C2
-        >>> from orix.quaternion.orientation import Misorientation
+        >>> from orix.quaternion import Misorientation, symmetry
         >>> data = np.array([[0.5, 0.5, 0.5, 0.5], [0, 1, 0, 0]])
         >>> m = Misorientation(data)
-        >>> m.symmetry = (C4, C2)
+        >>> m.symmetry = (symmetry.C4, symmetry.C2)
         >>> m = m.map_into_symmetry_reduced_zone()
         >>> m.distance()
         array([[3.14159265, 1.57079633],
@@ -271,12 +271,12 @@ class Misorientation(Rotation):
         """Returns a new Misorientation containing the same data
         transposed.
 
-        If ndim is originally 2, then order may be undefined. In this
+        If `ndim` is originally 2, then order may be undefined. In this
         case the first two dimensions will be transposed.
 
         Parameters
         ----------
-        axes: int, optional
+        axes : int, optional
             The transposed axes order. Only navigation axes need to be
             defined. May be undefined if self only contains two
             navigation dimensions.
@@ -504,8 +504,42 @@ class Orientation(Misorientation):
             o.symmetry = symmetry
         return o
 
+    @classmethod
+    def from_axes_angles(cls, axes, angles, symmetry=None):
+        """Creates orientation(s) from axis-angle pair(s).
+
+        Parameters
+        ----------
+        axes : Vector3d or array_like
+            The axis of rotation.
+        angles : array_like
+            The angle of rotation, in radians.
+        symmetry : Symmetry, optional
+            Symmetry of orientation(s). If None (default), no symmetry
+            is set.
+
+        Returns
+        -------
+        Orientation
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from orix.quaternion import Orientation, symmetry
+        >>> ori = Orientation.from_axes_angles((0, 0, -1), np.pi / 2, symmetry.Oh)
+        >>> ori
+        Orientation (1,) m-3m
+        [[ 0.7071  0.      0.     -0.7071]]
+
+        See Also
+        --------
+        from_neo_euler
+        """
+        axangle = AxAngle.from_axes_angles(axes, angles)
+        return cls.from_neo_euler(axangle, symmetry)
+
     def angle_with(self, other):
-        """The symmetry reduced smallest angle of rotation transforming
+        """The smallest symmetry reduced angle of rotation transforming
         this orientation to the other.
 
         Parameters

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -198,12 +198,12 @@ class Quaternion(Object3d):
         return Scalar(dots)
 
     def mean(self):
-        """Calculates the mean quarternion with unitary weights.
+        """Calculates the mean quaternion with unitary weights.
 
         Notes
         -----
         The method used here corresponds to Equation (13) in
-        http://www.acsu.buffalo.edu/~johnc/ave_quat07.pdf.
+        https://arc.aiaa.org/doi/pdf/10.2514/1.28949.
         """
         q = self.flatten().data.T
         qq = q.dot(q.T)

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -46,7 +46,7 @@ import numpy as np
 from scipy.special import hyp0f1
 
 from orix.quaternion import Quaternion
-from orix.vector import Vector3d
+from orix.vector import AxAngle, Vector3d
 from orix.scalar import Scalar
 
 # Used to round values below 1e-16 to zero
@@ -62,11 +62,11 @@ class Rotation(Quaternion):
     - Inversion.
     - Multiplication with other rotations and vectors.
 
-    Rotations inherit all methods from :class:`Quaternion` although behaviour is
-    different in some cases.
+    Rotations inherit all methods from :class:`Quaternion` although
+    behaviour is different in some cases.
 
-    Rotations can be converted to other parametrizations, notably the neo-Euler
-    representations. See :class:`NeoEuler`.
+    Rotations can be converted to other parametrizations, notably the
+    neo-Euler representations. See :class:`NeoEuler`.
     """
 
     def __init__(self, data):
@@ -210,8 +210,8 @@ class Rotation(Quaternion):
         return angles
 
     def outer(self, other, **kwargs):
-        """Compute the outer product of this rotation and the other object."""
-        r = super().outer(other, **kwargs)
+        """Compute the outer product of this rotation and the other."""
+        r = super().outer(other)
         if isinstance(r, Rotation):
             r.improper = np.logical_xor.outer(self.improper, other.improper)
         if isinstance(r, Vector3d):
@@ -260,6 +260,37 @@ class Rotation(Quaternion):
         d = s * neo_euler.axis.z.data
         r = cls(np.stack([a, b, c, d], axis=-1))
         return r
+
+    @classmethod
+    def from_axes_angles(cls, axes, angles):
+        """Creates rotation(s) from axis-angle pair(s).
+
+        Parameters
+        ----------
+        axes : Vector3d or array_like
+            The axis of rotation.
+        angles : array_like
+            The angle of rotation, in radians.
+
+        Returns
+        -------
+        Rotation
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from orix.quaternion import Rotation
+        >>> rot = Rotation.from_axes_angles((0, 0, -1), np.pi / 2)
+        >>> rot
+        Rotation (1,)
+        [[ 0.7071  0.      0.     -0.7071]]
+
+        See Also
+        --------
+        from_neo_euler
+        """
+        axangle = AxAngle.from_axes_angles(axes, angles)
+        return cls.from_neo_euler(axangle)
 
     def to_euler(self, convention="bunge"):
         """Rotations as Euler angles.

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -209,7 +209,7 @@ class Rotation(Quaternion):
         angles = Scalar(np.nan_to_num(np.arccos(2 * dp ** 2 - 1)))
         return angles
 
-    def outer(self, other, **kwargs):
+    def outer(self, other):
         """Compute the outer product of this rotation and the other."""
         r = super().outer(other)
         if isinstance(r, Rotation):

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -146,7 +146,7 @@ def test_repr_ori():
 
 def test_sub():
     o = Orientation([1, 1, 1, 1])  # any will do
-    o.symmetry = C4  # only one as it a O
+    o.symmetry = C4
     o = o.map_into_symmetry_reduced_zone()
     m = o - o
     assert np.allclose(m.data, [1, 0, 0, 0])
@@ -279,6 +279,17 @@ class TestOrientationInitialization:
         o3.symmetry = Oh
         o3 = o3.map_into_symmetry_reduced_zone()
         assert np.allclose(o3.data, o2.data)
+
+    def test_from_axes_angles(self, rotations):
+        axis = Vector3d.xvector() - Vector3d.yvector()
+        angle = np.pi / 2
+        axangle = AxAngle.from_axes_angles(axis, angle)
+        ori = Orientation.from_neo_euler(axangle, Oh)
+        ori2 = Orientation.from_axes_angles(axis, angle, Oh)
+        assert np.allclose(ori.to_euler(), (3 * np.pi / 4, np.pi / 2, -3 * np.pi / 4))
+        assert np.allclose(ori.data, ori2.data)
+        assert ori.symmetry.name == ori2.symmetry.name == "m-3m"
+        assert np.allclose(ori.symmetry.data, ori2.symmetry.data)
 
 
 class TestOrientation:

--- a/orix/tests/quaternion/test_rotation.py
+++ b/orix/tests/quaternion/test_rotation.py
@@ -16,14 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-from diffpy.structure.spacegroups import sg225
 from math import cos, sin, tan, pi
+
+from diffpy.structure.spacegroups import sg225
 import numpy as np
 import pytest
 
-from orix.quaternion import Quaternion
-from orix.quaternion.rotation import Rotation
-from orix.vector import Vector3d
+from orix.quaternion import Quaternion, Rotation
+from orix.vector import AxAngle, Vector3d
+
 
 rotations = [
     (0.707, 0.0, 0.0, 0.707),
@@ -527,3 +528,13 @@ class TestFromToMatrix:
         """
         r = Rotation.from_matrix([i.R for i in sg225.symop_list])
         assert not np.isnan(r.data).any()
+
+
+class TestFromAxesAngles:
+    """These tests address Rotation.from_axes_angles()."""
+
+    def test_from_axes_angles(self, rotations):
+        axangle = AxAngle.from_rotation(rotations)
+        rotations2 = Rotation.from_neo_euler(axangle)
+        rotations3 = Rotation.from_axes_angles(axangle.axis.data, axangle.angle.data)
+        assert np.allclose(rotations2.data, rotations3.data)


### PR DESCRIPTION
#### Description of the change
* Add new classmethods `from_axes_angles()` to `Rotation` and `Orientation`, accepting two arguments `axes` and `angles`. `Orientation` also accepts `symmetry=None`. This method is a shortcut for instatiating an `AxAngle` instance and passing this to `from_neo_euler()`.

Closes #250.

I haven't updated any user guides to use these methods. I anticipate to do that once we have the current PRs with user guide changes in so that we can restructure the guide into topics, as suggested in #248.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> import numpy as np
>>> from orix.quaternion import Orientation, symmetry
>>> from orix.vector import Vector3d
>>> axis = Vector3d((1, 1, 0))
>>> angles = np.linspace(0, np.radians(54.74), 100)
>>> ori = Orientation.from_axes_angles(-axis, angles, symmetry.Oh)
>>> directions = Vector3d(((1, 0, 0), (0, 1, 0), (0, 0, 1)))
>>> ori.scatter("ipf", c=angles, direction=directions)  # IPF
>>> ori.scatter("rodrigues", c=angles)  # Rodrigues Fundamental Zone
>>> fig = (~ori * directions[2]).scatter(c=angles, grid=True, axes_labels=["x", "y", None], return_figure=True)  # [001] PF
>>> fig.axes[0].draw_circle(axis.perpendicular)
```

![ipfs](https://user-images.githubusercontent.com/12139781/146176345-1e4cf3d2-aed4-40f8-8f2f-5e34559b43bc.png)

![rfz](https://user-images.githubusercontent.com/12139781/146176259-0b31b060-b1ce-47e9-bb81-ffef490a6130.png)

![pf](https://user-images.githubusercontent.com/12139781/146176266-94396218-15b0-4458-afb0-c55495161b33.png)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
