### PR TITLE
Ensure Rotation.to_euler() doesn't divide by zero to suppress warning

### DIFF
--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -338,20 +338,28 @@ class Rotation(Quaternion):
             e[..., 2] = np.where(cond, 0, e[..., 2])
 
         if np.sum(chi != 0) > 0:
-            not_zero = chi != 0
+            not_zero = ~np.isclose(chi, 0)
             alpha = np.arctan2(
-                np.divide(b * d - a * c, chi, where=not_zero, out=np.zeros_like(chi)),
-                np.divide(-a * b - c * d, chi, where=not_zero, out=np.zeros_like(chi)),
+                np.divide(
+                    b * d - a * c, chi, where=not_zero, out=np.full_like(chi, np.inf)
+                ),
+                np.divide(
+                    -a * b - c * d, chi, where=not_zero, out=np.full_like(chi, np.inf)
+                ),
             )
             beta = np.arctan2(2 * chi, q_zero_three - q_one_two)
             gamma = np.arctan2(
-                np.divide(a * c + b * d, chi, where=not_zero, out=np.zeros_like(chi)),
-                np.divide(c * d - a * b, chi, where=not_zero, out=np.zeros_like(chi)),
+                np.divide(
+                    a * c + b * d, chi, where=not_zero, out=np.full_like(chi, np.inf)
+                ),
+                np.divide(
+                    c * d - a * b, chi, where=not_zero, out=np.full_like(chi, np.inf)
+                ),
             )
 
-            e[..., 0] = np.where(chi != 0, alpha, e[..., 0])
-            e[..., 1] = np.where(chi != 0, beta, e[..., 1])
-            e[..., 2] = np.where(chi != 0, gamma, e[..., 2])
+            e[..., 0] = np.where(not_zero, alpha, e[..., 0])
+            e[..., 1] = np.where(not_zero, beta, e[..., 1])
+            e[..., 2] = np.where(not_zero, gamma, e[..., 2])
 
         return e
 

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -338,12 +338,15 @@ class Rotation(Quaternion):
             e[..., 2] = np.where(cond, 0, e[..., 2])
 
         if np.sum(chi != 0) > 0:
+            not_zero = chi != 0
             alpha = np.arctan2(
-                np.divide(b * d - a * c, chi), np.divide(-a * b - c * d, chi)
+                np.divide(b * d - a * c, chi, where=not_zero, out=np.zeros_like(chi)),
+                np.divide(-a * b - c * d, chi, where=not_zero, out=np.zeros_like(chi)),
             )
             beta = np.arctan2(2 * chi, q_zero_three - q_one_two)
             gamma = np.arctan2(
-                np.divide(a * c + b * d, chi), np.divide(c * d - a * b, chi)
+                np.divide(a * c + b * d, chi, where=not_zero, out=np.zeros_like(chi)),
+                np.divide(c * d - a * b, chi, where=not_zero, out=np.zeros_like(chi)),
             )
 
             e[..., 0] = np.where(chi != 0, alpha, e[..., 0])

--- a/orix/tests/quaternion/test_rotation.py
+++ b/orix/tests/quaternion/test_rotation.py
@@ -538,3 +538,10 @@ class TestFromAxesAngles:
         rotations2 = Rotation.from_neo_euler(axangle)
         rotations3 = Rotation.from_axes_angles(axangle.axis.data, axangle.angle.data)
         assert np.allclose(rotations2.data, rotations3.data)
+
+
+def test_to_euler_not_warning():
+    rot = Rotation(((0, 1, 0, 0), (1, 0, 0, 0), (1, 1, 0, 0)))
+    with pytest.warns(None) as record:
+        _ = rot.to_euler()
+    assert len(record) == 0


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
* Ensure Rotation.to_euler() doesn't divide by zero to suppress warning
* Add test to ensure this

Closes #231.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [n/a] New functions are imported in corresponding `__init__.py`.
- [n/a] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
