### PR TITLE
Don't round array values in CrystalMap.get_map_data() by default, change in CrystalMap.plot()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,10 @@ Changed
 - The methods `flatten`, `reshape`, and `squeeze` have been overridden in
   `Misorientation` based classes to maintain the initial symmetry of the returned
   instance.
+- `CrystalMap.get_map_data()` doesn't round values by default anymore. Passing
+  `decimals=3` retains the old behaviour.
+- `CrystalMap.plot()` doesn't override the Matplotlib status bar by default anymore.
+  Passing `override_status_bar=True` retains the old behaviour.
 
 Deprecated
 ----------
@@ -55,6 +59,11 @@ Removed
 -------
 - `StereographicPlot` methods `azimuth_grid()` and `polar_grid()`.
   Use `stereographic_grid()` instead.
+
+Fixed
+-----
+- `CrystalMap.get_map_data()` can return an array of shape (3,) if there are that many
+  points in the map.
 
 2021-09-07 - version 0.7.0
 ==========================

--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -50,6 +50,7 @@ class CrystalMapPlot(Axes):
         legend_properties=None,
         axes=None,
         depth=None,
+        override_status_bar=False,
         **kwargs,
     ) -> AxesImage:
         r"""Plot a 2D map with any CrystalMap attribute as map values.
@@ -71,20 +72,25 @@ class CrystalMapPlot(Axes):
             Dictionary of keyword arguments passed to
             :func:`mpl_toolkits.axes_grid1.anchored_artists.AnchoredSizeBar`.
         legend : bool, optional
-            Whether to add a legend to the plot. This is only implemented
-            for a phase plot (in which case default is True).
+            Whether to add a legend to the plot. This is only
+            implemented for a phase plot (in which case default is
+            True).
         legend_properties : dict
             Dictionary of keyword arguments passed to
             :meth:`matplotlib.axes.legend`.
         axes : tuple of ints, optional
-            Which data axes to plot if data has more than two dimensions.
-            The index of data to plot in the final dimension is determined
-            by `depth`. If None (default), data along the two last axes is
-            plotted.
+            Which data axes to plot if data has more than two
+            dimensions. The index of data to plot in the final dimension
+            is determined by `depth`. If None (default), data along the
+            two last axes is plotted.
         depth : int, optional
-            Which layer along the third axis to plot if data has more than
-            two dimensions. If None (default), data in the first index
-            (layer) is plotted.
+            Which layer along the third axis to plot if data has more
+            than two dimensions. If None (default), data in the first
+            index (layer) is plotted.
+        override_status_bar : bool, optional
+            Whether to display Euler angles and any overlay values in
+            the status bar when hovering over the map (default is
+            False).
         kwargs
             Keyword arguments passed to
             :meth:`matplotlib.axes.Axes.imshow`.
@@ -110,23 +116,23 @@ class CrystalMapPlot(Axes):
 
         Import a crystal map
 
-        >>> cm = load("/some/directory/data.ang")
+        >>> xmap = load("/some/directory/data.ang")
 
         Plot a phase map
 
         >>> fig = plt.figure()  # Get figure
         >>> ax = fig.add_subplot(projection="plot_map")  # Get axes
-        >>> im = ax.plot_map(cm)  # Get image
+        >>> im = ax.plot_map(xmap)  # Get image
 
         Add an overlay
 
-        >>> ax.add_overlay(cm, cm.iq)
+        >>> ax.add_overlay(xmap, xmap.iq)
 
         Plot an arbitrary map property, also changing scalebar location
 
         >>> ax = plt.subplot(projection="plot_map")
         >>> ax.plot_map(
-        ...     cm, cm.dp, cmap="cividis", scalebar_properties={"loc": 4}
+        ...     xmap, xmap.dp, cmap="cividis", scalebar_properties={"loc": 4}
         ... )
 
         Add a colorbar
@@ -135,11 +141,11 @@ class CrystalMapPlot(Axes):
 
         Plot orientation angle in degrees of one phase
 
-        >>> cm2 = cm["austenite"]
-        >>> austenite_angles = cm2.orientations.angle.data * 180 / np.pi
+        >>> xmap2 = xmap["austenite"]
+        >>> austenite_angles = xmap2.orientations.angle.data * 180 / np.pi
         >>> fig = plt.figure()
         >>> ax = fig.add_subplot(projection="plot_map")
-        >>> im = ax.plot_map(cm2, austenite_angles)
+        >>> im = ax.plot_map(xmap2, austenite_angles)
         >>> ax.add_colorbar("Orientation angle [$^{\circ}$]")
 
         Remove all figure and axes padding
@@ -199,7 +205,8 @@ class CrystalMapPlot(Axes):
             _ = self.add_scalebar(crystal_map, **scalebar_properties)
 
         im = self.imshow(X=data, **kwargs)
-        im = self._override_status_bar(im, crystal_map)
+        if override_status_bar:
+            im = self._override_status_bar(im, crystal_map)
 
         return im
 
@@ -288,7 +295,7 @@ class CrystalMapPlot(Axes):
 
         Examples
         --------
-        >>> cm
+        >>> xmap
         Phase  Orientations   Name       Symmetry  Color
         1      5657 (48.4%)   austenite  432       tab:blue
         2      6043 (51.6%)   ferrite    432       tab:orange
@@ -299,8 +306,8 @@ class CrystalMapPlot(Axes):
 
         >>> fig = plt.figure()
         >>> ax = fig.add_subplot(projection="plot_map")
-        >>> im = ax.plot_map(cm)
-        >>> ax.add_overlay(cm, cm.dp)
+        >>> im = ax.plot_map(xmap)
+        >>> ax.add_overlay(xmap, xmap.dp)
 
         """
         image = self.images[0]
@@ -341,7 +348,7 @@ class CrystalMapPlot(Axes):
 
         Examples
         --------
-        >>> cm
+        >>> xmap
         Phase  Orientations   Name       Symmetry  Color
         1      5657 (48.4%)   austenite  432       tab:blue
         2      6043 (51.6%)   ferrite    432       tab:orange
@@ -352,7 +359,7 @@ class CrystalMapPlot(Axes):
 
         >>> fig = plt.figure()
         >>> ax = fig.add_subplot(projection="plot_map")
-        >>> im = ax.plot_map(cm, cm.dp, cmap="inferno")
+        >>> im = ax.plot_map(xmap, xmap.dp, cmap="inferno")
         >>> cbar = ax.add_colorbar("Dot product")
 
         If the default options are not satisfactory, the colorbar can be
@@ -382,7 +389,7 @@ class CrystalMapPlot(Axes):
 
         Examples
         --------
-        >>> cm
+        >>> xmap
         Phase  Orientations   Name       Symmetry  Color
         1      5657 (48.4%)   austenite  432       tab:blue
         2      6043 (51.6%)   ferrite    432       tab:orange
@@ -393,7 +400,7 @@ class CrystalMapPlot(Axes):
 
         >>> fig = plt.figure()
         >>> ax = fig.add_subplot(projection="plot_map")
-        >>> ax.plot_map(cm)
+        >>> ax.plot_map(xmap)
         >>> ax.remove_padding()
         """
         self.set_axis_off()

--- a/orix/tests/plot/test_crystal_map_plot.py
+++ b/orix/tests/plot/test_crystal_map_plot.py
@@ -25,8 +25,7 @@ from matplotlib_scalebar import scalebar
 import pytest
 
 from orix.plot import CrystalMapPlot
-from orix.crystal_map import CrystalMap
-from orix.crystal_map.phase_list import PhaseList
+from orix.crystal_map import CrystalMap, PhaseList
 
 plt.rcParams["backend"] = "Agg"
 
@@ -384,7 +383,11 @@ class TestStatusBar:
         fig = plt.figure()
         ax = fig.add_subplot(projection=PLOT_MAP)
         _ = ax.plot_map(crystal_map)
+        assert ax.format_coord(0, 0) == "x=0 y=0"
 
+        fig = plt.figure()
+        ax = fig.add_subplot(projection=PLOT_MAP)
+        _ = ax.plot_map(crystal_map, override_status_bar=True)
         assert ax.format_coord(0, 0) == ""
 
         plt.close("all")
@@ -399,9 +402,9 @@ class TestStatusBar:
         f.canvas.flush_events()
 
         if to_plot == "rgb":
-            im = ax.plot_map(crystal_map)
+            im = ax.plot_map(crystal_map, override_status_bar=True)
         else:  # scalar
-            im = ax.plot_map(crystal_map, crystal_map.id)
+            im = ax.plot_map(crystal_map, crystal_map.id, override_status_bar=True)
 
         # Get figure canvas (x, y) from transformation from data (x, y)
         data_idx = (2, 2)


### PR DESCRIPTION
#### Description of the change
* Don't round array values in `CrystalMap.get_map_data()` to three decimals by default. Previous behaviour can be retained by passing `decimals=3`. Solves #204.
* Don't override the Matplotlib status bar in `CrystalMap.plot()` by default. Previous behaviour can be retained by using the new parameter `override_status_bar=True` (default is False). Solves #205.
* #220 is fixed.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> import numpy as np
>>> from orix.crystal_map import CrystalMap
>>> xmap = CrystalMap.empty((3,))
>>> xmap.prop["iq"] = np.random.random(3)
>>> xmap.iq
array([0.29770224, 0.9273115 , 0.78679572])
>>> xmap.get_map_data("iq")
array([0.29770224, 0.9273115 , 0.78679572])
>>> xmap.get_map_data("iq", decimals=3)  # Old behaviour
array([0.298, 0.927, 0.787])
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.