### PR TITLE
Fix reading of point groups with "-" sign in EMsoft h5ebsd files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,10 @@ Removed
 - `StereographicPlot` methods `azimuth_grid()` and `polar_grid()`.
   Use `stereographic_grid()` instead.
 
+Fixed
+-----
+- Reading of point groups with "-" sign, like -43m, from EMsoft h5ebsd files.
+
 2021-09-07 - version 0.7.0
 ==========================
 

--- a/orix/io/plugins/emsoft_h5ebsd.py
+++ b/orix/io/plugins/emsoft_h5ebsd.py
@@ -220,7 +220,7 @@ def dict2phase(dictionary):
     Phase
     """
     name = re.search(r"([A-z0-9]+)", dictionary["MaterialName"]).group(1)
-    point_group = re.search(r"\[([A-z0-9/]+)\]", dictionary["Point Group"]).group(1)
+    point_group = re.search(r"\[([A-z0-9/-]+)]", dictionary["Point Group"]).group(1)
     lattice = Lattice(
         *tuple(
             dictionary[f"Lattice Constant {i}"]


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
Solves #159.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
