### PR TITLE
Remove deprecated import convention "Krakow_Hielscher" in from_euler()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -61,7 +61,7 @@ Removed
 -------
 - `StereographicPlot` methods `azimuth_grid()` and `polar_grid()`.
   Use `stereographic_grid()` instead.
-- `fromo_euler()' no longer accepts "Krakow_Hielscher" as a convention, use "MTEX" instead.
+- `from_euler()` no longer accepts "Krakow_Hielscher" as a convention, use "MTEX" instead.
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -61,6 +61,7 @@ Removed
 -------
 - `StereographicPlot` methods `azimuth_grid()` and `polar_grid()`.
   Use `stereographic_grid()` instead.
+- `fromo_euler()' no longer accepts "Krakow_Hielscher" as a convention, use "MTEX" instead.
 
 Fixed
 -----

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -389,14 +389,6 @@ class Rotation(Quaternion):
 
         convention = convention.lower()
 
-        if convention == "krakow_hielscher":
-            # To be applied to the data found at:
-            # https://www.repository.cam.ac.uk/handle/1810/263510
-            warnings.warn(
-                "This method is deprecated and will be removed in v0.8 use 'MTEX' instead"
-            )
-            convention = "mtex"
-
         if convention not in conventions:
             raise ValueError(
                 f"The chosen convention is not one of the allowed options {conventions}"

--- a/orix/tests/quaternion/test_rotation.py
+++ b/orix/tests/quaternion/test_rotation.py
@@ -222,10 +222,10 @@ class TestToFromEuler:
         r = Rotation.from_euler(e)
         e2 = r.to_euler()
         assert np.allclose(e, e2.data)
-    
+
     def test_mtex(self, e):
         _ = Rotation.from_euler(e, convention="mtex")
-      
+
     def test_direction_kwarg(self, e):
         _ = Rotation.from_euler(e, direction="lab2crystal")
 

--- a/orix/tests/quaternion/test_rotation.py
+++ b/orix/tests/quaternion/test_rotation.py
@@ -222,7 +222,10 @@ class TestToFromEuler:
         r = Rotation.from_euler(e)
         e2 = r.to_euler()
         assert np.allclose(e, e2.data)
-
+    
+    def test_mtex(self, e):
+        _ = Rotation.from_euler(e, convention="mtex")
+      
     def test_direction_kwarg(self, e):
         _ = Rotation.from_euler(e, direction="lab2crystal")
 

--- a/orix/tests/quaternion/test_rotation.py
+++ b/orix/tests/quaternion/test_rotation.py
@@ -226,9 +226,6 @@ class TestToFromEuler:
     def test_direction_kwarg(self, e):
         _ = Rotation.from_euler(e, direction="lab2crystal")
 
-    def test_Krakow_Hielscher(self, e):
-        _ = Rotation.from_euler(e, convention="Krakow_Hielscher")
-
     def test_direction_kwarg_dumb(self, e):
         with pytest.raises(ValueError, match="The chosen direction is not one of "):
             _ = Rotation.from_euler(e, direction="dumb_direction")


### PR DESCRIPTION
#### Description of the change
Removing a deprecation in advance of 0.8, see #230. Will let the CI find the tests that need removing.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [n/a] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
