### PR TITLE
Correct azimuthal angle within fundamental sectors (IPFs)

### DIFF
--- a/orix/plot/direction_color_keys/_util.py
+++ b/orix/plot/direction_color_keys/_util.py
@@ -212,6 +212,8 @@ def _correct_azimuth(azimuth, sector, rx):
     if vertices.size == 3:
         angle = _calculate_azimuth(center, rx, vertices)
         azimuth3 = np.round(m * np.sort(angle) / (2 * np.pi)).astype(int)
+        if azimuth3[0] < 10:
+            azimuth3 = np.delete(azimuth3, 0)
         idx = np.arange(azimuth3[0])
         polar[idx] /= np.sum(polar[idx]) / 3
         idx = np.arange(azimuth3[0], azimuth3[1])

--- a/orix/plot/direction_color_keys/_util.py
+++ b/orix/plot/direction_color_keys/_util.py
@@ -212,8 +212,6 @@ def _correct_azimuth(azimuth, sector, rx):
     if vertices.size == 3:
         angle = _calculate_azimuth(center, rx, vertices)
         azimuth3 = np.round(m * np.sort(angle) / (2 * np.pi)).astype(int)
-        if azimuth3[0] < 10:
-            azimuth3 = np.delete(azimuth3, 0)
         idx = np.arange(azimuth3[0])
         polar[idx] /= np.sum(polar[idx]) / 3
         idx = np.arange(azimuth3[0], azimuth3[1])

--- a/orix/tests/plot/test_orientation_color_keys.py
+++ b/orix/tests/plot/test_orientation_color_keys.py
@@ -56,6 +56,16 @@ class TestIPFColorKeyTSL:
         rgb_c2h = ckey_c2h.orientation2color(ori2)
         assert np.allclose(rgb_c2h, ((1, 0, 0), (0, 1, 0.23), (0, 0.23, 1)), atol=0.2)
 
+        # Color vertices of D3d IPF red, green and blue
+        pg_d3d = symmetry.D3d  # -3m
+        ori3 = Orientation.from_euler(
+            np.radians(((0, 0, 0), (0, -90, 60), (0, 90, 60))),
+            symmetry=pg_d3d,
+        )
+        ckey_d3d = IPFColorKeyTSL(pg_d3d)
+        rgb_d3d = ckey_d3d.orientation2color(ori3)
+        assert np.allclose(rgb_d3d, ((1, 0, 0), (0, 1, 0), (0, 0, 1)), atol=1e-2)
+
     def test_triclinic(self):
         # Complete circle, three vectors on equator 120 degrees apart
         pg_c1 = symmetry.C1

--- a/orix/tests/plot/test_orientation_color_keys.py
+++ b/orix/tests/plot/test_orientation_color_keys.py
@@ -25,7 +25,7 @@ from orix.vector import Vector3d
 
 class TestIPFColorKeyTSL:
     def test_orientation2color(self):
-        # Color vertices of Oh IPF red, green and close to blue
+        # Color vertices of Oh IPF red, green and blue
         pg_o = symmetry.O  # 432
         pg_oh = pg_o.laue  # m-3m
         ori = Orientation.from_euler(
@@ -40,13 +40,13 @@ class TestIPFColorKeyTSL:
         ax_o = fig_o.axes[0]
         assert ax_o._symmetry.name == pg_oh.name
         rgb_oh = ckey_oh.orientation2color(ori)
-        assert np.allclose(rgb_oh, ((1, 0, 0), (0, 1, 0), (0, 1 / 3, 1)), atol=0.1)
+        assert np.allclose(rgb_oh, ((1, 0, 0), (0, 1, 0), (0, 0, 1)), atol=0.1)
 
         # Color [001] and "diagonals" of 2/m IPF red, green and blue
         pg_c2 = symmetry.C2  # 2
         pg_c2h = pg_c2.laue  # 2/m
         ori2 = Orientation.from_euler(
-            np.radians(((-90, -90, 0), (0, 90, -45), (0, 90, 45))),
+            np.radians(((-90, -90, 0), (0, 90, -55), (0, 90, 55))),
             symmetry=pg_c2h,
         )
         ckey_c2h = IPFColorKeyTSL(pg_c2, Vector3d.xvector())
@@ -54,7 +54,7 @@ class TestIPFColorKeyTSL:
         assert np.allclose(ckey_c2h.direction.data, (1, 0, 0))
         assert repr(ckey_c2h) == "IPFColorKeyTSL, symmetry: 2/m, direction: [1 0 0]"
         rgb_c2h = ckey_c2h.orientation2color(ori2)
-        assert np.allclose(rgb_c2h, ((1, 0, 0), (0, 1, 0), (0, 0, 1)), atol=0.1)
+        assert np.allclose(rgb_c2h, ((1, 0, 0), (0, 1, 0.23), (0, 0.23, 1)), atol=0.2)
 
     def test_triclinic(self):
         # Complete circle, three vectors on equator 120 degrees apart


### PR DESCRIPTION
#### Description of the change
This ensures for example that the entirely blue part of the m-3m sector is in the [111] direction, and not in the direction corresponding to the sector position perpendicular to the [001]-[101] line (straight north from the barycenter).

Procedure is taken from MTEX, which the docstrings reflect.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [n/a] New functions are imported in corresponding `__init__.py`.
- [n/a] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
