### PR TITLE
Update year in license to 2018-2022

### DIFF
--- a/orix/_util.py
+++ b/orix/_util.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/base/__init__.py
+++ b/orix/base/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/crystal_map/__init__.py
+++ b/orix/crystal_map/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/crystal_map/crystal_map_properties.py
+++ b/orix/crystal_map/crystal_map_properties.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/io/__init__.py
+++ b/orix/io/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/io/plugins/__init__.py
+++ b/orix/io/plugins/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/io/plugins/_h5ebsd.py
+++ b/orix/io/plugins/_h5ebsd.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/io/plugins/ang.py
+++ b/orix/io/plugins/ang.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/io/plugins/bruker_h5ebsd.py
+++ b/orix/io/plugins/bruker_h5ebsd.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/io/plugins/emsoft_h5ebsd.py
+++ b/orix/io/plugins/emsoft_h5ebsd.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/io/plugins/orix_hdf5.py
+++ b/orix/io/plugins/orix_hdf5.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/plot/__init__.py
+++ b/orix/plot/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/plot/_symmetry_marker.py
+++ b/orix/plot/_symmetry_marker.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/plot/_util.py
+++ b/orix/plot/_util.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/plot/direction_color_keys/__init__.py
+++ b/orix/plot/direction_color_keys/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/plot/direction_color_keys/_util.py
+++ b/orix/plot/direction_color_keys/_util.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/plot/direction_color_keys/direction_color_key.py
+++ b/orix/plot/direction_color_keys/direction_color_key.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/plot/direction_color_keys/direction_color_key_tsl.py
+++ b/orix/plot/direction_color_keys/direction_color_key_tsl.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/plot/inverse_pole_figure_plot.py
+++ b/orix/plot/inverse_pole_figure_plot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/plot/orientation_color_keys/__init__.py
+++ b/orix/plot/orientation_color_keys/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/plot/orientation_color_keys/euler_color_key.py
+++ b/orix/plot/orientation_color_keys/euler_color_key.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/plot/orientation_color_keys/ipf_color_key.py
+++ b/orix/plot/orientation_color_keys/ipf_color_key.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/plot/orientation_color_keys/ipf_color_key_tsl.py
+++ b/orix/plot/orientation_color_keys/ipf_color_key_tsl.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/plot/rotation_plot.py
+++ b/orix/plot/rotation_plot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/plot/stereographic_plot.py
+++ b/orix/plot/stereographic_plot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/plot/unit_cell_plot.py
+++ b/orix/plot/unit_cell_plot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/projections/__init__.py
+++ b/orix/projections/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/projections/stereographic.py
+++ b/orix/projections/stereographic.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/quaternion/__init__.py
+++ b/orix/quaternion/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/quaternion/_conversions.py
+++ b/orix/quaternion/_conversions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/quaternion/orientation_region.py
+++ b/orix/quaternion/orientation_region.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/quaternion/symmetry.py
+++ b/orix/quaternion/symmetry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/sampling/S2_sampling.py
+++ b/orix/sampling/S2_sampling.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/sampling/SO3_sampling.py
+++ b/orix/sampling/SO3_sampling.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/sampling/__init__.py
+++ b/orix/sampling/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/sampling/_cubochoric_sampling.py
+++ b/orix/sampling/_cubochoric_sampling.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/sampling/sample_generators.py
+++ b/orix/sampling/sample_generators.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/scalar/__init__.py
+++ b/orix/scalar/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/io/__init__.py
+++ b/orix/tests/io/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/io/test_ang.py
+++ b/orix/tests/io/test_ang.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/io/test_bruker_h5ebsd.py
+++ b/orix/tests/io/test_bruker_h5ebsd.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/io/test_emsoft_h5ebsd.py
+++ b/orix/tests/io/test_emsoft_h5ebsd.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/io/test_h5ebsd.py
+++ b/orix/tests/io/test_h5ebsd.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/io/test_io.py
+++ b/orix/tests/io/test_io.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/io/test_orix_hdf5.py
+++ b/orix/tests/io/test_orix_hdf5.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/plot/__init__.py
+++ b/orix/tests/plot/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/plot/test_crystal_map_plot.py
+++ b/orix/tests/plot/test_crystal_map_plot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/plot/test_direction_color_keys.py
+++ b/orix/tests/plot/test_direction_color_keys.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/plot/test_inverse_pole_figure_plot.py
+++ b/orix/tests/plot/test_inverse_pole_figure_plot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/plot/test_orientation_color_keys.py
+++ b/orix/tests/plot/test_orientation_color_keys.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/plot/test_rotation_plot.py
+++ b/orix/tests/plot/test_rotation_plot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/plot/test_stereographic_plot.py
+++ b/orix/tests/plot/test_stereographic_plot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/plot/test_unit_cell_plot.py
+++ b/orix/tests/plot/test_unit_cell_plot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/quaternion/__init__.py
+++ b/orix/tests/quaternion/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/quaternion/test_conversions.py
+++ b/orix/tests/quaternion/test_conversions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/quaternion/test_orientation_region.py
+++ b/orix/tests/quaternion/test_orientation_region.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/quaternion/test_quaternion.py
+++ b/orix/tests/quaternion/test_quaternion.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/quaternion/test_rotation.py
+++ b/orix/tests/quaternion/test_rotation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/quaternion/test_symmetry.py
+++ b/orix/tests/quaternion/test_symmetry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/sampling/__init__.py
+++ b/orix/tests/sampling/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/sampling/test_cubochoric_sampling.py
+++ b/orix/tests/sampling/test_cubochoric_sampling.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/sampling/test_s2_sampling.py
+++ b/orix/tests/sampling/test_s2_sampling.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/sampling/test_sampling.py
+++ b/orix/tests/sampling/test_sampling.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/test_axangle.py
+++ b/orix/tests/test_axangle.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/test_crystal_map_properties.py
+++ b/orix/tests/test_crystal_map_properties.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/test_fundamental_sector.py
+++ b/orix/tests/test_fundamental_sector.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/test_miller.py
+++ b/orix/tests/test_miller.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/test_neoeuler.py
+++ b/orix/tests/test_neoeuler.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/test_object3d.py
+++ b/orix/tests/test_object3d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/test_phase_list.py
+++ b/orix/tests/test_phase_list.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/test_scalar.py
+++ b/orix/tests/test_scalar.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/test_stereographic_projection.py
+++ b/orix/tests/test_stereographic_projection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/test_util.py
+++ b/orix/tests/test_util.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/tests/test_vector3d.py
+++ b/orix/tests/test_vector3d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/vector/__init__.py
+++ b/orix/vector/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/vector/fundamental_sector.py
+++ b/orix/vector/fundamental_sector.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/vector/miller.py
+++ b/orix/vector/miller.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/vector/neo_euler.py
+++ b/orix/vector/neo_euler.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/vector/spherical_region.py
+++ b/orix/vector/spherical_region.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 the orix developers
+# Copyright 2018-2022 the orix developers
 #
 # This file is part of orix.
 #


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
Update year in license to 2018-2022 using `licenseheaders`. In `orix/`, I ran `licenseheaders -y 2018-2022`.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [n/a] New functions are imported in corresponding `__init__.py`.
- [n/a] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
