### PR TITLE
State support for Python 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         run: python setup.py manifix
 
   build-with-pip:
-    name: ${{ matrix.os }}/py${{ matrix.python-version }}/pip
+    name: ${{ matrix.os }}-py${{ matrix.python-version }}${{ matrix.LABEL }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     env:
@@ -32,20 +32,20 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.9, '3.10']
         include:
-          # Oldest supported version of main dependencies on Python 3.6
           - os: ubuntu-latest
             python-version: 3.6
             OLDEST_SUPPORTED_VERSION: true
             DEPENDENCIES: diffpy.structure==3  matplotlib==3.3
+            LABEL: -oldest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Display versions
+      - name: Display Python and pip versions
         run: python -V; pip -V
       - name: Install depedencies and package
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,8 @@ jobs:
       - name: Install oldest supported version
         if: ${{ matrix.OLDEST_SUPPORTED_VERSION }}
         run: pip install ${{ matrix.DEPENDENCIES }}
+      - name: Display package versions
+        run: pip list
       - name: Run tests
         run: pytest --cov=orix --pyargs orix
       - name: Generate line coverage

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.htm
 Unreleased
 ==========
 
+Added
+-----
+- Python 3.10 support.
+
 2021-12-21 - version 0.8.0
 ==========================
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -10,8 +10,8 @@ We recommend you install it in a `conda environment
 <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_
 with the `Miniconda distribution`_::
 
-   $ conda create --name orix-env python=3.8
-   $ conda activate orix-env
+    conda create --name orix-env python=3.10
+    conda activate orix-env
 
 If you prefer a graphical interface to manage packages and environments, install the
 `Anaconda distribution`_ instead.
@@ -27,11 +27,11 @@ Anaconda
 Anaconda provides the easiest installation. In the Anaconda Prompt, terminal or Command
 Prompt, install with::
 
-    $ conda install orix --channel conda-forge
+    conda install orix --channel conda-forge
 
 If you at a later time need to update the package::
 
-    $ conda update orix
+    conda update orix
 
 .. _install-with-pip:
 
@@ -41,11 +41,11 @@ Pip
 To install with ``pip``, run the following in the Anaconda Prompt, terminal or Command
 Prompt::
 
-    $ pip install orix
+    pip install orix
 
 If you at a later time need to update the package::
 
-    $ pip install --upgrade orix
+    pip install --upgrade orix
 
 .. _install-from-source:
 
@@ -55,9 +55,9 @@ Install from source
 To install orix from source, clone the repository from `GitHub
 <https://github.com/pyxem/orix>`_::
 
-    $ git clone https://github.com/pyxem/orix.git
-    $ cd orix
-    $ pip install --editable .
+    git clone https://github.com/pyxem/orix.git
+    cd orix
+    pip install --editable .
 
 See the :ref:`contributing guidelines <set-up-a-development-installation>`
 for how to set up a development installation.

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
@@ -49,9 +50,9 @@ setup(
     # fmt: off
     install_requires=[
         "dask[array]",
-        "diffpy.structure >= 3",
+        "diffpy.structure       >= 3",
         "h5py",
-        "matplotlib >= 3.3",
+        "matplotlib             >= 3.3",
         "matplotlib-scalebar",
         "numba",
         "numpy",


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
* State support for Python 3.10.
* CI build matrix is moved from 3.8 and 3.9 to 3.9 and 3.10, with minimal versions of dependencies still tested on 3.6.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
