### PR TITLE
Fix misorientation calculation in Orientation methods angle_with(), dot() and dot_outer()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Added
 
 Fixed
 -----
-- Orientation disorientation angles and dot products returned from `angle_with()` and
+- `Orientation` disorientation angles and dot products returned from `angle_with()` and
   `dot()` and `dot_outer()`, which now calculates the misorientation as other * ~self.
 
 2021-12-21 - version 0.8.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Added
 -----
 - Python 3.10 support.
 
+Fixed
+-----
+- Orientation disorientation angles and dot products returned from `angle_with()` and
+  `dot()` and `dot_outer()`, which now calculates the misorientation as other * ~self.
+
 2021-12-21 - version 0.8.0
 ==========================
 
@@ -78,7 +83,6 @@ Fixed
 - `CrystalMap.get_map_data()` can return an array of shape (3,) if there are that many
   points in the map.
 - Reading of point groups with "-" sign, like -43m, from EMsoft h5ebsd files.
-
 
 2021-09-07 - version 0.7.0
 ==========================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,8 @@ Added
 Fixed
 -----
 - `Orientation` disorientation angles and dot products returned from `angle_with()` and
-  `dot()` and `dot_outer()`, which now calculates the misorientation as other * ~self.
+  `dot()` and `dot_outer()`, which now calculates the misorientation as `other * ~self`.
+  Disorientation angles `(o2 - o1).angle` and `o1.angle_with(o2)` are now the same.
 
 2021-12-21 - version 0.8.0
 ==========================

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -562,7 +562,7 @@ class Orientation(Misorientation):
         dot_outer
         """
         symmetry = self.symmetry.outer(other.symmetry).unique()
-        misorientation = (~self) * other
+        misorientation = other * ~self
         all_dot_products = Rotation(misorientation).dot_outer(symmetry).data
         highest_dot_product = np.max(all_dot_products, axis=-1)
         return Scalar(highest_dot_product)
@@ -577,7 +577,7 @@ class Orientation(Misorientation):
         dot
         """
         symmetry = self.symmetry.outer(other.symmetry).unique()
-        misorientation = (~self).outer(other)
+        misorientation = other.outer(~self)
         all_dot_products = Rotation(misorientation).dot_outer(symmetry).data
         highest_dot_product = np.max(all_dot_products, axis=-1)
         return Scalar(highest_dot_product)

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -905,7 +905,7 @@ class Orientation(Misorientation):
         `dp = dparr.compute()`.
         """
         symmetry = self.symmetry.outer(other.symmetry).unique()
-        misorientation = (~self)._outer_dask(other, chunk_size=chunk_size)
+        misorientation = other._outer_dask(~self, chunk_size=chunk_size)
 
         # Summation subscripts
         str1 = "abcdefghijklmnopqrstuvwxy"[: misorientation.ndim]

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -523,17 +523,19 @@ def test_set_symmetry_deprecation_warning_misorientation():
         _ = o.set_symmetry(C2, C2)
 
 
-class TestOrientationMultiplication:
-    def test_get_identity(self):
-        o1 = Orientation([0.4884, 0.1728, 0.2661, 0.8129])
-        o2 = Orientation([0.8171, -0.2734, 0.161, -0.4813])
+def test_get_identity():
+    """Get the identity orientation via two alternative routes."""
+    o1 = Orientation([0.4884, 0.1728, 0.2661, 0.8129])
+    o2 = Orientation([0.8171, -0.2734, 0.161, -0.4813])
 
-        m12_1 = o2 - o1
-        o3_1 = (m12_1 * o1) * ~o2
+    # Route 1 from a Misorientation instance
+    m12_1 = o2 - o1
+    o3_1 = (m12_1 * o1) * ~o2
 
-        m12_2 = o2 * ~o1
-        o3_2 = (m12_2 * o1) * ~o2
+    # Route 2 from a third Orientation instance
+    m12_2 = o2 * ~o1
+    o3_2 = (m12_2 * o1) * ~o2
 
-        assert np.allclose(m12_1.data, m12_2.data)
-        assert np.allclose(o3_1.data, o3_2.data)
-        assert np.allclose(o3_1.data, [1, 0, 0, 0])
+    assert np.allclose(m12_1.data, m12_2.data)
+    assert np.allclose(o3_1.data, o3_2.data)
+    assert np.allclose(o3_1.data, [1, 0, 0, 0])

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -397,7 +397,6 @@ class TestOrientation:
         q = [(0.5, 0.5, 0.5, 0.5), (0.5**0.5, 0, 0, 0.5**0.5)]
         r = Rotation(q)
         o = Orientation(q, symmetry=symmetry)
-        o = o.map_into_symmetry_reduced_zone()
 
         is_equal = np.allclose((~o).angle_with(o).data, (~r).angle_with(r).data)
         if symmetry.name in ["1", "m3m"]:
@@ -522,3 +521,19 @@ def test_set_symmetry_deprecation_warning_misorientation():
     o = Misorientation.random((3, 2))
     with pytest.warns(np.VisibleDeprecationWarning, match="Function `set_symmetry()"):
         _ = o.set_symmetry(C2, C2)
+
+
+class TestOrientationMultiplication:
+    def test_get_identity(self):
+        o1 = Orientation([0.4884, 0.1728, 0.2661, 0.8129])
+        o2 = Orientation([0.8171, -0.2734, 0.161, -0.4813])
+
+        m12_1 = o2 - o1
+        o3_1 = (m12_1 * o1) * ~o2
+
+        m12_2 = o2 * ~o1
+        o3_2 = (m12_2 * o1) * ~o2
+
+        assert np.allclose(m12_1.data, m12_2.data)
+        assert np.allclose(o3_1.data, o3_2.data)
+        assert np.allclose(o3_1.data, [1, 0, 0, 0])


### PR DESCRIPTION
#### Description of the change
Orientation disorientation angles and dot products returned from `angle_with()` and `dot()` and `dot_outer()`, now calculates the misorientation as other * ~self instead of (~self) * other.

With this change the two routes to obtain a misorientation angle, notably `(o1 - o2).angle` and `o1.angle_with(o2)` (which calls `dot()` and `dot_outer()` internally to get the disorientation angle [symmetry reduced misorientation angle]) return the same results, which was the concern of @soupmongoose in #276. Will close #276.

All tests passed without modifications after making this change. I've added a test to ensure that getting the misorientation from two orientations and and doing the inverse operation results in the identity orientation. Also removed a now unnecessary call to `o1.map_into_symmetry_reduced_zone()`.

Thanks to @harripj for spotting this bug and @soupmongoose for reporting the issue that led to this fix!

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
See https://github.com/pyxem/orix/issues/276#issuecomment-1033700249.

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [n/a] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
