### PR TITLE
Add figure kwargs to plot methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Unreleased
 Added
 -----
 - Python 3.10 support.
+- Option to pass figure initialization keyword arguments Matplotlib in plotting methods.
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,8 @@ Unreleased
 Added
 -----
 - Python 3.10 support.
-- Option to pass figure initialization keyword arguments Matplotlib in plotting methods.
+- Option to pass figure initialization keyword arguments to Matplotlib via plotting
+  methods.
 
 Fixed
 -----

--- a/orix/plot/inverse_pole_figure_plot.py
+++ b/orix/plot/inverse_pole_figure_plot.py
@@ -228,7 +228,12 @@ class InversePoleFigurePlot(StereographicPlot):
 mprojections.register_projection(InversePoleFigurePlot)
 
 
-def _setup_inverse_pole_figure_plot(symmetry, direction=None, hemisphere=None):
+def _setup_inverse_pole_figure_plot(
+    symmetry,
+    direction=None,
+    hemisphere=None,
+    figure_kwargs=None,
+):
     """Set up an inverse pole figure plot.
 
     Parameters
@@ -242,6 +247,9 @@ def _setup_inverse_pole_figure_plot(symmetry, direction=None, hemisphere=None):
         Which hemisphere(s) to plot the vectors in. If not given,
         "upper" is used. Options are "upper", "lower", and "both", which
         plots two projections side by side.
+    figure_kwargs : dict, optional
+        Dictionary of keyword arguments passed to
+        :func:`matplotlib.pyplot.figure`.
 
     Returns
     -------
@@ -273,7 +281,9 @@ def _setup_inverse_pole_figure_plot(symmetry, direction=None, hemisphere=None):
         ncols = 3
         nrows = int(np.ceil(n_plots / 3))
 
-    figure = plt.figure()
+    if figure_kwargs is None:
+        figure_kwargs = dict()
+    figure = plt.figure(**figure_kwargs)
     axes = []
     subplot_kw = dict(projection="ipf", symmetry=symmetry)
     for i in range(n_plots):

--- a/orix/plot/rotation_plot.py
+++ b/orix/plot/rotation_plot.py
@@ -151,8 +151,7 @@ def _setup_rotation_plot(
         for further details. Default is (1, 1, 1).
     figure_kwargs : dict, optional
         Dictionary of keyword arguments passed to
-        :func:`matplotlib.pyplot.figure` if `figure` is not given, else
-        :func:`matplotlib.pyplot.subplots`.
+        :func:`matplotlib.pyplot.figure` if `figure` is not given.
 
     Returns
     -------

--- a/orix/plot/rotation_plot.py
+++ b/orix/plot/rotation_plot.py
@@ -122,7 +122,12 @@ projections.register_projection(RodriguesPlot)
 projections.register_projection(AxAnglePlot)
 
 
-def _setup_rotation_plot(figure=None, projection="axangle", position=None):
+def _setup_rotation_plot(
+    figure=None,
+    projection="axangle",
+    position=None,
+    figure_kwargs=None,
+):
     """Return a figure and rotation plot axis of the correct type.
 
     This is a convenience method used in e.g.
@@ -144,6 +149,10 @@ def _setup_rotation_plot(figure=None, projection="axangle", position=None):
         in the first of two positions in a grid of 1 row and 2
         columns. See :meth:`matplotlib.figure.Figure.add_subplot`
         for further details. Default is (1, 1, 1).
+    figure_kwargs : dict, optional
+        Dictionary of keyword arguments passed to
+        :func:`matplotlib.pyplot.figure` if `figure` is not given, else
+        :func:`matplotlib.pyplot.subplots`.
 
     Returns
     -------
@@ -153,7 +162,9 @@ def _setup_rotation_plot(figure=None, projection="axangle", position=None):
     """
     # Create figure if not already created, then add axis to figure
     if figure is None:
-        figure = plt.figure()
+        if figure_kwargs is None:
+            figure_kwargs = dict()
+        figure = plt.figure(**figure_kwargs)
 
     subplot_kwds = dict(projection=projection, proj_type="ortho")
 

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -345,8 +345,7 @@ class Misorientation(Rotation):
             plotted.
         figure_kwargs : dict, optional
             Dictionary of keyword arguments passed to
-            :func:`matplotlib.pyplot.figure` if `figure` is not given,
-            else :func:`matplotlib.pyplot.subplots`.
+            :func:`matplotlib.pyplot.figure` if `figure` is not given.
         kwargs
             Keyword arguments passed to
             :meth:`orix.plot.AxAnglePlot.scatter` or

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -311,6 +311,7 @@ class Misorientation(Rotation):
         return_figure=False,
         wireframe_kwargs=None,
         size=None,
+        figure_kwargs=None,
         **kwargs,
     ):
         """Plot misorientations in axis-angle space or the Rodrigues
@@ -342,6 +343,10 @@ class Misorientation(Rotation):
             If not given, all misorientations are plotted. If given, a
             random sample of this `size` of the misorientations is
             plotted.
+        figure_kwargs : dict, optional
+            Dictionary of keyword arguments passed to
+            :func:`matplotlib.pyplot.figure` if `figure` is not given,
+            else :func:`matplotlib.pyplot.subplots`.
         kwargs
             Keyword arguments passed to
             :meth:`orix.plot.AxAnglePlot.scatter` or
@@ -359,7 +364,10 @@ class Misorientation(Rotation):
         from orix.plot.rotation_plot import _setup_rotation_plot
 
         figure, ax = _setup_rotation_plot(
-            figure=figure, projection=projection, position=position
+            figure=figure,
+            projection=projection,
+            position=position,
+            figure_kwargs=figure_kwargs,
         )
 
         # Plot wireframe
@@ -792,6 +800,7 @@ class Orientation(Misorientation):
         wireframe_kwargs=None,
         size=None,
         direction=None,
+        figure_kwargs=None,
         **kwargs,
     ):
         """Plot orientations in axis-angle space, the Rodrigues
@@ -828,6 +837,9 @@ class Orientation(Misorientation):
             Sample direction to plot with respect to crystal directions.
             If not given, the out of plane direction, sample Z, is used.
             Only used when plotting IPF(s).
+        figure_kwargs : dict, optional
+            Dictionary of keyword arguments passed to
+            :func:`matplotlib.pyplot.figure` if `figure` is not given.
         kwargs
             Keyword arguments passed to
             :meth:`orix.plot.AxAnglePlot.scatter`,
@@ -852,6 +864,7 @@ class Orientation(Misorientation):
                 return_figure=return_figure,
                 wireframe_kwargs=wireframe_kwargs,
                 size=size,
+                figure_kwargs=figure_kwargs,
                 **kwargs,
             )
         else:
@@ -869,7 +882,10 @@ class Orientation(Misorientation):
                     hemisphere = "upper"
 
                 figure, axes = _setup_inverse_pole_figure_plot(
-                    symmetry=symmetry, direction=direction, hemisphere=hemisphere
+                    symmetry=symmetry,
+                    direction=direction,
+                    hemisphere=hemisphere,
+                    figure_kwargs=figure_kwargs,
                 )
             else:
                 axes = np.asarray(figure.axes)

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -15,7 +15,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
-import sysconfig
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
+import sysconfig
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -417,7 +418,11 @@ class TestOrientation:
             orientation = Misorientation(orientation)
             orientation.symmetry = (C2, D6)
             orientation = orientation.map_into_symmetry_reduced_zone()
-        fig_axangle = orientation.scatter(return_figure=True)
+        fig_size = (5, 5)
+        fig_axangle = orientation.scatter(
+            return_figure=True, figure_kwargs=dict(figsize=fig_size)
+        )
+        assert (fig_axangle.get_size_inches() == fig_size).all()
         assert isinstance(fig_axangle.axes[0], AxAnglePlot)
         fig_rodrigues = orientation.scatter(projection="rodrigues", return_figure=True)
         assert isinstance(fig_rodrigues.axes[0], RodriguesPlot)
@@ -456,7 +461,11 @@ class TestOrientation:
         ori = Orientation.from_euler(np.radians((325, 48, 163)), symmetry=Oh)
 
         # Returned figure has the expected default properties
-        fig = ori.scatter("ipf", return_figure=True)
+        fig_size = (5, 5)
+        fig = ori.scatter(
+            "ipf", return_figure=True, figure_kwargs=dict(figsize=fig_size)
+        )
+        assert (fig.get_size_inches() == fig_size).all()
         axes = fig.axes[0]
         assert isinstance(axes, InversePoleFigurePlot)
         assert len(fig.axes) == 1


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
Allow passing keyword arguments to Matplotlib's `plt.figure()` and/or `plt.subplots()` via `Orientation.scatter()` and `Misorientation.scatter()` (and upstream private functions). An example is `figsize`, which is quite useful. This was possible with `Vector3d.scatter()` and `draw_circle()`, but not the orientation methods.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> from orix.quaternion import Orientation
>>> ori = Orientation.random(10)
>>> ori.scatter(figure_kwargs=dict(figsize=(5, 5)))
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
