### PR TITLE
Allow manual triggering of publish action

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,6 +6,8 @@ name: Upload Python Package
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    workflow: "*"
 
 jobs:
   deploy:


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

See https://github.com/pyxem/orix/issues/275#issuecomment-1039180994. Without this change, the publish action can only be triggered by creating a new tag. With this change, it can be triggered via GitHub.

Will merge myself.