### PR TITLE
Implement rounding consistently to 12 decimal places in orix, eg. in `unique()` functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Changed
 Fixed
 -----
 - `Miller.in_fundamental_sector()` doesn't raise errors.
-- `Miller.unique` now correctly returns unique vectors due to implemented rounding.
+- `Miller.unique()` now correctly returns unique vectors due to implemented rounding.
 
 2022-02-14 - version 0.8.1
 ==========================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,15 @@ this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.htm
 Unreleased
 ==========
 
+Changed
+-------
+- Rounding in functions is now set consistently at 12 dp, eg. `Object3d.unique` and 
+  `Rotation.unique`.
+
+Fixed
+-----
+- `Miller.unique` now correctly returns unique vectors due to implemented rounding.
+
 2022-02-14 - version 0.8.1
 ==========================
 

--- a/orix/base/__init__.py
+++ b/orix/base/__init__.py
@@ -182,11 +182,9 @@ class Object3d:
             The indices of the (flattened) data in the unique array.
 
         """
-        data = self.flatten()._data.round(9)
+        data = self.flatten()._data.round(12)
         data = data[~np.all(np.isclose(data, 0), axis=1)]  # Remove zeros
-        _, idx, inv = np.unique(
-            data.round(4), axis=0, return_index=True, return_inverse=True
-        )
+        _, idx, inv = np.unique(data, axis=0, return_index=True, return_inverse=True)
         obj = self.__class__(data[np.sort(idx), : self.dim])
         obj._data = data[np.sort(idx)]
         if return_index and return_inverse:

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -156,7 +156,7 @@ class Rotation(Quaternion):
                     rotation.improper,
                 ],
                 axis=-1,
-            ).round(6)
+            ).round(12)
         _, idx, inv = np.unique(abcd, axis=0, return_index=True, return_inverse=True)
         idx_argsort = np.argsort(idx)
         idx_sort = idx[idx_argsort]
@@ -196,7 +196,7 @@ class Rotation(Quaternion):
                 i,
             ),
             axis=-1,
-        ).round(6)
+        ).round(12)
         return abcd
 
     def angle_with(self, other):

--- a/orix/sampling/S2_sampling.py
+++ b/orix/sampling/S2_sampling.py
@@ -80,13 +80,14 @@ def sample_S2_cube_mesh(resolution, grid_type="spherified_corner"):
 
     res = np.radians(resolution)
 
+    grid_type = grid_type.lower()
     grid_types = ["normalized", "spherified_edge", "spherified_corner"]
     if grid_type == grid_types[0]:
         grid_length = np.tan(res)
         steps = np.ceil(max_distance / grid_length)
         i = np.arange(-steps, steps) / steps
     elif grid_type == grid_types[1]:
-        steps = np.ceil(max_angle / res)
+        steps = np.ceil((max_angle / res).round(1))
         k = np.arange(-steps, steps)
         theta = np.arctan(max_distance) / steps
         i = np.tan(k * theta)

--- a/orix/sampling/S2_sampling.py
+++ b/orix/sampling/S2_sampling.py
@@ -87,7 +87,7 @@ def sample_S2_cube_mesh(resolution, grid_type="spherified_corner"):
         steps = np.ceil(max_distance / grid_length)
         i = np.arange(-steps, steps) / steps
     elif grid_type == grid_types[1]:
-        steps = np.ceil((max_angle / res).round(1))
+        steps = np.ceil((max_angle / res).round(2))
         k = np.arange(-steps, steps)
         theta = np.arctan(max_distance) / steps
         i = np.tan(k * theta)

--- a/orix/tests/sampling/test_s2_sampling.py
+++ b/orix/tests/sampling/test_s2_sampling.py
@@ -35,7 +35,7 @@ class TestS2Sampling:
         [
             ("spherified_corner", 3, 8666),
             ("normalized", 4, 5402),
-            ("spherified_edge", 5, 2402),
+            ("spherified_edge", 5, 1946),
         ],
     )
     def test_cube_mesh(self, grid_type, resolution, size):

--- a/orix/tests/test_miller.py
+++ b/orix/tests/test_miller.py
@@ -215,9 +215,9 @@ class TestMiller:
         m2 = m.unique(use_symmetry=True)
         assert m2.size == 285
         m3, idx = m2.unit.unique(return_index=True)
-        assert m3.size == 345
+        assert m3.size == 205
         assert isinstance(m3, Miller)
-        assert np.allclose(idx[:10], [74, 448, 434, 409, 374, 330, 278, 447, 412, 432])
+        assert np.allclose(idx[:10], [65, 283, 278, 269, 255, 235, 208, 282, 272, 276])
 
     def test_multiply_orientation(self):
         o = Orientation.from_euler(np.deg2rad([45, 0, 0]))

--- a/orix/tests/test_miller.py
+++ b/orix/tests/test_miller.py
@@ -213,7 +213,7 @@ class TestMiller:
         m = Miller.from_highest_indices(phase=diamond, uvw=[10, 10, 10])
         assert m.size == 9260
         m2 = m.unique(use_symmetry=True)
-        assert m2.size == 450
+        assert m2.size == 285
         m3, idx = m2.unit.unique(return_index=True)
         assert m3.size == 345
         assert isinstance(m3, Miller)

--- a/orix/vector/miller.py
+++ b/orix/vector/miller.py
@@ -671,7 +671,7 @@ class Miller(Vector3d):
             operations = self.phase.point_group
             n_v = v.size
             v2 = operations.outer(v).flatten().reshape(*(n_v, operations.size))
-            data = v2.data
+            data = v2.data.round(12)
             data_sorted = np.zeros_like(data)
             for i in range(n_v):
                 a = data[i]

--- a/orix/vector/miller.py
+++ b/orix/vector/miller.py
@@ -670,7 +670,6 @@ class Miller(Vector3d):
         if use_symmetry:
             operations = self.phase.point_group
             n_v = v.size
-            v2 = operations.outer(v).flatten()
             v2 = operations.outer(v).flatten().reshape(*(n_v, operations.size))
             data = v2.data
             data_sorted = np.zeros_like(data)

--- a/orix/vector/miller.py
+++ b/orix/vector/miller.py
@@ -542,7 +542,7 @@ class Miller(Vector3d):
             cosines = self.dot_outer(other2).data / (
                 self.norm.data[..., np.newaxis] * other2.norm.data[np.newaxis, ...]
             )
-            cosines = np.round(cosines, 9)
+            cosines = np.round(cosines, 12)
             angles = np.min(np.arccos(cosines), axis=-1)
             return Scalar(angles)
         else:

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -411,7 +411,7 @@ class Vector3d(Object3d):
         Scalar
             The angle between the vectors, in radians.
         """
-        cosines = np.round(self.dot(other).data / self.norm.data / other.norm.data, 9)
+        cosines = np.round(self.dot(other).data / self.norm.data / other.norm.data, 12)
         return Scalar(np.arccos(cosines))
 
     def rotate(self, axis=None, angle=0):


### PR DESCRIPTION
#### Description of the change
A discussed in #281 there appears to be a bug in `Miller.unique` which subsequently causes a failing test in that PR. As As @hakonanes has confirmed in that PR, this appears to be a floating point bug, and rounding, even to a large precision (14 dp), corrects the bug.

So whilst implementing #281 has shown the bug and corrects it, I am not sure whether we should rely completely on this or whether we should manually implement some rounding in `unique` to be sure we always get the expected behaviour.

Some thoughts on this would be great.

This PR also corrects the test and removes an unneeded line as discussed in #281.

Update:
Rounding, for example in `unique` functions, has been consistently fixed to 12 dp for the repository.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

### Example code
From @hakonanes in #281
https://github.com/pyxem/orix/pull/281#issuecomment-1043086981

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [n/a] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
