### PR TITLE
Handle symmetry correctly in Miller.in_fundamental_sector()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.htm
 Unreleased
 ==========
 
+Fixed
+-----
+- `Miller.in_fundamental_sector()` doesn't raise errors.
+
 2022-02-14 - version 0.8.1
 ==========================
 

--- a/orix/tests/test_miller.py
+++ b/orix/tests/test_miller.py
@@ -21,17 +21,17 @@ import numpy as np
 import pytest
 
 from orix.crystal_map import Phase
-from orix.quaternion import Orientation
+from orix.quaternion import Orientation, symmetry
 from orix.vector import Miller
 from orix.vector.miller import _round_indices, _uvw2UVTW, _UVTW2uvw
 
 
+TRIGONAL_PHASE = Phase(
+    point_group="321", structure=Structure(lattice=Lattice(4.9, 4.9, 5.4, 90, 90, 120))
+)
 TETRAGONAL_LATTICE = Lattice(0.5, 0.5, 1, 90, 90, 90)
 TETRAGONAL_PHASE = Phase(
     point_group="4", structure=Structure(lattice=TETRAGONAL_LATTICE)
-)
-TRIGONAL_PHASE = Phase(
-    point_group="321", structure=Structure(lattice=Lattice(4.9, 4.9, 5.4, 90, 90, 120))
 )
 CUBIC_PHASE = Phase(point_group="m-3m")
 
@@ -47,7 +47,7 @@ class TestMiller:
 
     def test_repr(self):
         m = Miller(hkil=[1, 1, -2, 0], phase=TRIGONAL_PHASE)
-        assert repr(m) == ("Miller (1,), point group 321, hkil\n" "[[ 1.  1. -2.  0.]]")
+        assert repr(m) == "Miller (1,), point group 321, hkil\n" "[[ 1.  1. -2.  0.]]"
 
     def test_coordinate_format_raises(self):
         m = Miller(hkl=[1, 1, 1], phase=TETRAGONAL_PHASE)
@@ -330,6 +330,31 @@ class TestMiller:
         m2 = m1.transpose(1, 0, 2)
         assert m2.shape == (5, 11, 4)
         assert m1.phase == m2.phase
+
+    def test_in_fundamental_sector(self):
+        """Ensure projecting Miller indices to a fundamental sector
+        retains type and coordinate format, gives the correct indices,
+        and that it's possible to project to a different point group's
+        sector.
+        """
+        h = Miller(uvw=(-1, 1, 0), phase=Phase())
+        with pytest.raises(ValueError, match="`symmetry` must be passed or "):
+            _ = h.in_fundamental_sector()
+
+        h.phase = CUBIC_PHASE
+
+        h2 = h.in_fundamental_sector()
+        assert isinstance(h2, Miller)
+        assert np.allclose(h2.phase.point_group.data, h.phase.point_group.data)
+        assert h2.coordinate_format == h.coordinate_format
+
+        h3 = h.in_fundamental_sector(CUBIC_PHASE.point_group)
+        assert np.allclose((h2.data, h3.data), (1, 0, 1))
+        assert h2 <= h.phase.point_group.fundamental_sector
+
+        h4 = h.in_fundamental_sector(symmetry.D6h)
+        assert np.allclose(h4.phase.point_group.data, h.phase.point_group.data)
+        assert np.allclose(h4.data, (1.366, 0.366, 0), atol=1e-3)
 
 
 class TestMillerBravais:

--- a/orix/vector/miller.py
+++ b/orix/vector/miller.py
@@ -514,7 +514,7 @@ class Miller(Vector3d):
         else:
             return compatible
 
-    # ------------- Overwritten Vector3d/Object3d methods- ----------- #
+    # ------------- Overwritten Vector3d/Object3d methods ------------ #
 
     def angle_with(self, other, use_symmetry=False):
         """Calculate angles between vectors in `self` and `other`,
@@ -522,7 +522,7 @@ class Miller(Vector3d):
         smallest angle under symmetry.
 
         Vectors must have compatible shapes, and be in the same space
-        (direct or recprocal) and crystal reference frames.
+        (direct or reciprocal) and crystal reference frames.
 
         Parameters
         ----------
@@ -554,7 +554,7 @@ class Miller(Vector3d):
         vectors.
 
         Vectors must have compatible shapes, and be in the same space
-        (direct or recprocal) and crystal reference frames.
+        (direct or reciprocal) and crystal reference frames.
 
         Returns
         -------
@@ -572,7 +572,7 @@ class Miller(Vector3d):
         """Dot product of a vector with another vector.
 
         Vectors must have compatible shapes, and be in the same space
-        (direct or recprocal) and crystal reference frames.
+        (direct or reciprocal) and crystal reference frames.
 
         Returns
         -------
@@ -584,7 +584,7 @@ class Miller(Vector3d):
     def dot_outer(self, other):
         """Outer dot product of a vector with another vector.
 
-        Vectors must be in the same space (direct or recprocal) and
+        Vectors must be in the same space (direct or reciprocal) and
         crystal reference frames.
 
         The dot product for every combination of vectors in `self` and
@@ -603,22 +603,23 @@ class Miller(Vector3d):
         return m
 
     def transpose(self, *axes):
-        """Returns a new Miller object containing the same data transposed.
+        """Returns a new Miller object containing the same data
+        transposed.
 
-        If ndim is originally 2, then order may be undefined.
-        In this case the first two dimensions will be transposed.
+        If `self.ndim` is originally 2, then order may be undefined. In
+        this case the first two dimensions will be transposed.
 
         Parameters
         ----------
         axes : int, optional
-            The transposed axes order. Only navigation axes need to be defined.
-            May be undefined if self only contains two navigation dimensions.
+            The transposed axes order. Only navigation axes need to be
+            defined. May be undefined if self only contains two
+            navigation dimensions.
 
         Returns
         -------
-        Miller :
-            A transposed Miller instance of the object.
-
+        Miller
+            New transposed Miller instance of the original instance.
         """
         m = self.__class__(xyz=super().transpose(*axes).data, phase=self.phase)
         m.coordinate_format = self.coordinate_format
@@ -687,6 +688,50 @@ class Miller(Vector3d):
             return m, idx
         else:
             return m
+
+    def in_fundamental_sector(self, symmetry=None):
+        """Project Miller indices to a symmetry's fundamental sector
+        (inverse pole figure).
+
+        This projection is taken from MTEX'
+        :code:`project2FundamentalRegion`.
+
+        Parameters
+        ----------
+        symmetry : ~orix.quaternion.Symmetry, optional
+            Symmetry with a fundamental sector, possibly not equal to
+            `self.phase.point_group`. If not given,
+            `self.phase.point_group` is used if valid, otherwise an
+            error is raised.
+
+        Returns
+        -------
+        Miller
+
+        Examples
+        --------
+        >>> from orix.crystal_map import Phase
+        >>> from orix.quaternion.symmetry import D6h
+        >>> from orix.vector import Miller
+        >>> h = Miller(uvw=(-1, 1, 0), phase=Phase(point_group="m-3m"))
+        >>> h.in_fundamental_sector()
+        Miller (1,), point group m-3m, uvw
+        [[1. 0. 1.]]
+        >>> h.in_fundamental_sector(D6h)
+        Miller (1,), point group m-3m, uvw
+        [[1.366 0.366 0.   ]]
+        """
+        if symmetry is None:
+            symmetry = self.phase.point_group
+            if symmetry is None:
+                raise ValueError(
+                    "`symmetry` must be passed or `self.phase.point_group` must be a "
+                    "`Symmetry` with a `Symmetry.fundamental_sector`"
+                )
+        v = Vector3d(self.data).in_fundamental_sector(symmetry)
+        m = self.__class__(xyz=v.data, phase=self.phase)
+        m.coordinate_format = self.coordinate_format
+        return m
 
 
 def _uvw2xyz(uvw, lattice):

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -294,8 +294,8 @@ class Vector3d(Object3d):
     def dot_outer(self, other):
         """The outer dot product of a vector with another vector.
 
-        The dot product for every combination of vectors in `self` and `other`
-        is computed.
+        The dot product for every combination of vectors in `self` and
+        `other` is computed.
 
         Returns
         -------
@@ -501,7 +501,7 @@ class Vector3d(Object3d):
         pole figure).
 
         This projection is taken from MTEX'
-        :code:`project2fundamentalRegion`.
+        :code:`project2FundamentalRegion`.
 
         Parameters
         ----------
@@ -511,6 +511,18 @@ class Vector3d(Object3d):
         Returns
         -------
         Vector3d
+
+        Examples
+        --------
+        >>> from orix.quaternion.symmetry import D6h, Oh
+        >>> from orix.vector import Vector3d
+        >>> v = Vector3d((-1, 1, 0))
+        >>> v.in_fundamental_sector(Oh)
+        Vector3d (1,)
+        [[1. 0. 1.]]
+        >>> v.in_fundamental_sector(D6h)
+        Vector3d (1,)
+        [[1.366 0.366 0.   ]]
         """
         fs = symmetry.fundamental_sector
         v = deepcopy(self)


### PR DESCRIPTION
#### Description of the change
Overwrite `Vector3d.in_fundamental_sector()` in `Miller.in_fundamental_sector()` with proper handling of the `symmetry` parameter. Fix #287.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> from orix.crystal_map import Phase
>>> from orix.quaternion.symmetry import D6h
>>> from orix.vector import Miller
>>> phase_m3m = Phase(point_group="m-3m")
>>> h = Miller(uvw=(-1, 1, 0), phase=phase_m3m)
>>> fig = h.scatter(return_figure=True, c="b", grid=True)
# Draw fundamental sectors
>>> fig.axes[0].plot(pg_6mmm.fundamental_sector.edges, color="r")
>>> fig.axes[0].plot(h.phase.point_group.fundamental_sector.edges, color="g")
# This doesn't throw errors anymore
>>> h2 = h.in_fundamental_sector()  # Don't pass symmetry
>>> h2
Miller (1,), point group m-3m, uvw
[[1. 0. 1.]]
>>> h2.scatter(figure=fig, c="y")
>>> h3 = h.in_fundamental_sector(phase_m3m.point_group)  # Pass symmetry
>>> h3.scatter(figure=fig, c="c", s=100, zorder=-1)
>>> h4 = h.in_fundamental_sector(D6h)  # Pass another symmetry
>>> h4  # But symmetry stays the same as before!
Miller (1,), point group m-3m, uvw
[[1.366 0.366 0.   ]]
>>> h4.scatter(figure=fig, c="m")
```

![pf](https://user-images.githubusercontent.com/12139781/154670343-96b436fc-af79-4967-a235-88188efe6eee.png)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
