### PR TITLE
Prepare 0.8.2 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,14 +7,15 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_, and
 this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
-Unreleased
-==========
+2022-02-21 - version 0.8.2
+==========================
 
 Changed
 -------
-- `orix.quaternion.Quaternion` now relies on `numpy-quaternion <https://quaternion.readthedocs.io/en/latest/>`_
-  for quaternion conjugation, quaternion-quaternion and quaternion-vector multiplication,
-  and quaternion-quaternion and quaternion-vector outer products.
+- `orix.quaternion.Quaternion` now relies on `numpy-quaternion
+  <https://quaternion.readthedocs.io/en/latest/>`_ for quaternion conjugation,
+  quaternion-quaternion and quaternion-vector multiplication, and quaternion-quaternion
+  and quaternion-vector outer products.
 - Rounding in functions is now set consistently at 12 dp, eg. `Object3d.unique` and 
   `Rotation.unique`.
 
@@ -74,8 +75,8 @@ Changed
 - `StereographicPlot` doesn't use Matplotlib's `transforms` framework anymore, and
   (X, Y) replaces (azimuth, polar) as internal coordinates.
 - Renamed `Symmetry` method `fundamental_sector()` to `fundamental_zone()`.
-- `Orientation` class methods `from_euler`, `from_matrix`, and `from_neo_euler` no longer 
-  return the smallest angle orientation when a `symmetry` is given.
+- `Orientation` class methods `from_euler`, `from_matrix`, and `from_neo_euler` no
+  longer  return the smallest angle orientation when a `symmetry` is given.
 - `CrystalMap.orientations` no longer returns smallest angle orientation.
 - The methods `flatten`, `reshape`, and `squeeze` have been overridden in
   `Misorientation` based classes to maintain the initial symmetry of the returned
@@ -90,8 +91,8 @@ Deprecated
 ----------
 - The `data_dim` attribute of Object3d and all derived classes is deprecated from 0.8
   and will be removed in 0.9. Use `ndim` instead.
-- Setting (Mis)Orientation symmetry via `set_symmetry()` is deprecated in 0.8, in favour of
-  setting it directly via a `symmetry.setter`, and will be removed in 0.9. Use
+- Setting (Mis)Orientation symmetry via `set_symmetry()` is deprecated in 0.8, in favour
+  of setting it directly via a `symmetry.setter`, and will be removed in 0.9. Use
   `map_into_symmetry_reduced_zone()` instead.
  
 Removed
@@ -102,7 +103,6 @@ Removed
 
 Fixed
 -----
-
 - `CrystalMap.get_map_data()` can return an array of shape (3,) if there are that many
   points in the map.
 - Reading of point groups with "-" sign, like -43m, from EMsoft h5ebsd files.

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -1,5 +1,5 @@
 __name__ = "orix"
-__version__ = "0.9.dev0"
+__version__ = "0.8.2"
 __author__ = "orix developers"
 __author_email__ = "pyxem.team@gmail.com"
 __description__ = "orix is an open-source python library for handling crystal orientation mapping data."


### PR DESCRIPTION
#### Description of the change
Update version and changelog in preparation for a patch release 0.8.2, which I plan to release the coming Monday Feb. 21.

I suggest the following release draft:

> 
> orix 0.8.2 is a patch release of orix, an open-source Python library for handling orientations, rotations and crystal symmetry.
> 
> See [the changelog](https://orix.readthedocs.io/en/stable/changelog.html) or https://github.com/pyxem/orix/compare/v0.8.1...v0.8.2 for a complete list of changes.

Feel free to suggest changes.

Unless someone objects, I consider it OK to merge this myself on Monday once the PR is approved by at least one maintainer.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
