### PR TITLE
Post 0.8.2 release updates

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,7 +1,15 @@
-# This workflows will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# This workflows runs when a tagged release is created or it is triggered manually.
+# For more information see:
+# - Python docs: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+# - GitHub action: https://github.com/marketplace/actions/pypi-publish
+# - GitHub docs: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+# The source distribution (sdist) is built with the `build` package
+# (https://pypa-build.readthedocs.io/en/stable/index.html).
+# The sdist is uploaded to:
+# - TestPyPI whenever the workflow is run
+# - PyPI when the current commit is tagged
 
-name: Upload Python Package
+name: Upload to PyPI
 
 on:
   release:
@@ -11,9 +19,7 @@ on:
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -23,11 +29,19 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        pip install build
+    - name: Build package
       run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+        python -m build
+    - name: Publish package to TestPyPI
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish package to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_, and
 this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+Unreleased
+==========
+
 2022-02-21 - version 0.8.2
 ==========================
 
@@ -16,8 +19,8 @@ Changed
   <https://quaternion.readthedocs.io/en/latest/>`_ for quaternion conjugation,
   quaternion-quaternion and quaternion-vector multiplication, and quaternion-quaternion
   and quaternion-vector outer products.
-- Rounding in functions is now set consistently at 12 dp, eg. `Object3d.unique` and 
-  `Rotation.unique`.
+- Rounding in functions, e.g. `Object3d.unique()` and `Rotation.unique()`, is now set
+  consistently at 12 dp.
 
 Fixed
 -----

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,4 +9,4 @@ include setup.cfg
 include setup.py
 
 recursive-include doc Makefile make.bat *.rst *.py *.ipynb *.bib
-recursive-include doc/_static *.png *.svg *.css
+recursive-include doc/_static *.png *.svg

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,13 +1,15 @@
 How to make a new release of ``orix``
 =====================================
 
-Create a PR to the `master` branch and go through the following steps.
+Create a PR to the ``master`` branch and go through the following steps.
 
 Preparation
 -----------
-- Bump ``__version__`` in `orix/__init__.py`, for example "0.8.2".
-- Update the changelog `CHANGELOG.rst`.
-- Let the PR collect comments for a day to ensure that other maintainers are 
+- Review the contributor list ``__credits__`` in ``orix/__init__.py`` to ensure all
+  contributors are included and sorted correctly.
+- Bump ``__version__`` in ``orix/__init__.py``, for example to "0.8.2".
+- Update the changelog ``CHANGELOG.rst``.
+- Let the PR collect comments for a day to ensure that other maintainers are
   comfortable with releasing. Merge.
 
 Release (and tag)
@@ -20,10 +22,9 @@ Release (and tag)
 
 Post-release action
 -------------------
-- Monitor the documentation build at
-  https://readthedocs.org/projects/orix/builds to make sure the new stable
-  documentation is successfully built from the release.
+- Monitor the `documentation build <https://readthedocs.org/projects/orix/builds>`_ to
+  ensure that the new stable documentation is successfully built from the release.
 - Make a post-release PR to ``master`` with ``__version__`` updated (or 
   reverted), e.g. to "0.9.dev0", and any updates to this guide if necessary.
-- Tidy up and close corresponding milestone.
+- Tidy up GitHub issues and close the corresponding milestone.
 - A PR to the conda-forge feedstock will be created by the conda-forge bot.

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -1,8 +1,8 @@
 __name__ = "orix"
-__version__ = "0.8.2"
+__version__ = "0.9.dev0"
 __author__ = "orix developers"
 __author_email__ = "pyxem.team@gmail.com"
-__description__ = "orix is an open-source python library for handling crystal orientation mapping data."
+__description__ = "orix is an open-source Python library for handling crystal orientation mapping data."
 # Initial committer first, then sorted by line contributions
 __credits__ = [
     "Ben Martineau",

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     name=__name__,
     version=str(__version__),
     license="GPLv3",
+    url="https://orix.readthedocs.io",
     author=__author__,
     author_email=__author_email__,
     description=__description__,


### PR DESCRIPTION
#### Description of the change
Typical post-release actions:
* Revert version from 0.8.2 to 0.9.dev0.
* Add URL pointing to Read the Docs documentation in setup.py and remove reference to non-existing *.css files in MANIFEST.in file. These two changes were recommended by the [build check](https://github.com/pyxem/orix/runs/5272913196?check_suite_focus=true#step:5:1) before the package was uploaded to PyPI.
* Add "Unreleased" to changelog

Updates to the PyPI publish action:
Use [PyPA action](https://github.com/marketplace/actions/pypi-publish) and [PyPA `build`](https://pypa-build.readthedocs.io/en/stable/index.html) package. Most importantly, these changes replace the PyPI username/password secrets with a repo specific PyPI API token secret (already generated by me and added to the orix GitHub repo secrets). I've added the possibility to upload to TestPyPI, but this can be removed if we find we don't need it. From the PyPA docs:

> it’ll publish any push to TestPyPI which is useful for providing test builds to your alpha users as well as making sure that your release pipeline remains healthy!

I've added a TestPyPI API token secret specific to my TestPyPI account which we can replace only after orix is uploaded to TestPyPI for the first.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
