### PR TITLE
Add angle_with_outer function

### DIFF
--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -559,6 +559,111 @@ class Orientation(Misorientation):
         angles = np.nan_to_num(np.arccos(2 * dot_products**2 - 1))
         return Scalar(angles)
 
+    def angle_with_outer(self, other, lazy=False, chunk_size=20, progressbar=True):
+        r"""The symmetry reduced smallest angle of rotation transforming
+        every orientation in this instance to every orientation in
+        another instance.
+
+        This is an alternative implementation of
+        :meth:`~orix.quaternion.Misorientation.distance` for
+        a single :class:`Orientation` instance, using :mod:`dask`.
+
+        Parameters
+        ----------
+        lazy : bool, optional
+            Whether to perform the computation lazily with Dask. Default
+            is False.
+        chunk_size : int, optional
+            Number of orientations per axis to include in each iteration
+            of the computation. Default is 20. Only applies when `lazy`
+            is True.
+        progressbar : bool, optional
+            Whether to show a progressbar during computation if `lazy`
+            is True. Default is True.
+
+        Returns
+        -------
+        Scalar
+
+        Notes
+        -----
+        Given two orientations :math:`g_i` and :math:`g_j`, the smallest
+        angle is considered as the geodesic distance
+
+        .. math::
+
+            d(g_i, g_j) = \arccos(2(g_i \cdot g_j)^2 - 1),
+
+        where :math:`(g_i \cdot g_j)` is the highest dot product between
+        symmetrically equivalent orientations to :math:`g_{i,j}`.
+        """
+        ori = self.unit
+        if lazy:
+            dot_products = ori._dot_outer_dask(other, chunk_size=chunk_size)
+
+            # Round because some dot products are slightly above 1
+            n_decimals = np.finfo(dot_products.dtype).precision
+            dot_products = da.round(dot_products, n_decimals)
+
+            angles_dask = da.arccos(2 * dot_products**2 - 1)
+            angles_dask = da.nan_to_num(angles_dask)
+
+            # Create array in memory and overwrite, chunk by chunk
+            angles = np.zeros(angles_dask.shape)
+            if progressbar:
+                with ProgressBar():
+                    da.store(sources=angles_dask, targets=angles)
+            else:
+                da.store(sources=angles_dask, targets=angles)
+        else:
+            dot_products = ori.dot_outer(ori).data
+            angles = np.arccos(2 * dot_products**2 - 1)
+            angles = np.nan_to_num(angles)
+
+        return Scalar(angles)
+
+    def get_distance_matrix(self, lazy=False, chunk_size=20, progressbar=True):
+        r"""The symmetry reduced smallest angle of rotation transforming
+        every orientation in this instance to every other orientation.
+
+        This is an alternative implementation of
+        :meth:`~orix.quaternion.Misorientation.distance` for
+        a single :class:`Orientation` instance, using :mod:`dask`.
+
+        Parameters
+        ----------
+        lazy : bool, optional
+            Whether to perform the computation lazily with Dask. Default
+            is False.
+        chunk_size : int, optional
+            Number of orientations per axis to include in each iteration
+            of the computation. Default is 20. Only applies when `lazy`
+            is True.
+        progressbar : bool, optional
+            Whether to show a progressbar during computation if `lazy`
+            is True. Default is True.
+
+        Returns
+        -------
+        Scalar
+
+        Notes
+        -----
+        Given two orientations :math:`g_i` and :math:`g_j`, the smallest
+        angle is considered as the geodesic distance
+
+        .. math::
+
+            d(g_i, g_j) = \arccos(2(g_i \cdot g_j)^2 - 1),
+
+        where :math:`(g_i \cdot g_j)` is the highest dot product between
+        symmetrically equivalent orientations to :math:`g_{i,j}`.
+        """
+        angles = self.angle_with_outer(
+            self, lazy=lazy, chunk_size=chunk_size, progressbar=progressbar
+        )
+        return angles
+
     def dot(self, other):
         """Symmetry reduced dot product of orientations in this instance
         to orientations in another instance, returned as
@@ -596,68 +701,6 @@ class Orientation(Misorientation):
     )
     def distance(self, verbose=False, split_size=100):
         return super().distance(verbose=verbose, split_size=split_size)
-
-    def get_distance_matrix(self, lazy=False, chunk_size=20, progressbar=True):
-        r"""The symmetry reduced smallest angle of rotation transforming
-        each orientation in this instance to every other orientation.
-
-        This is an alternative implementation of
-        :meth:`~orix.quaternion.Misorientation.distance` for
-        a single :class:`Orientation` instance, using :mod:`dask`.
-
-        Parameters
-        ----------
-        lazy : bool, optional
-            Whether to perform the computation lazily with Dask. Default
-            is False.
-        chunk_size : int, optional
-            Number of orientations per axis to include in each iteration
-            of the computation. Default is 20. Only applies when `lazy`
-            is True.
-        progressbar : bool, optional
-            Whether to show a progressbar during computation if `lazy`
-            is True. Default is True.
-
-        Returns
-        -------
-        Scalar
-
-        Notes
-        -----
-        Given two orientations :math:`g_i` and :math:`g_j`, the smallest
-        angle is considered as the geodesic distance
-
-        .. math::
-
-            d(g_i, g_j) = \arccos(2(g_i \cdot g_j)^2 - 1),
-
-        where :math:`(g_i \cdot g_j)` is the highest dot product between
-        symmetrically equivalent orientations to :math:`g_{i,j}`.
-        """
-        ori = self.unit
-        if lazy:
-            dot_products = ori._dot_outer_dask(ori, chunk_size=chunk_size)
-
-            # Round because some dot products are slightly above 1
-            n_decimals = np.finfo(dot_products.dtype).precision
-            dot_products = da.round(dot_products, n_decimals)
-
-            angles_dask = da.arccos(2 * dot_products**2 - 1)
-            angles_dask = da.nan_to_num(angles_dask)
-
-            # Create array in memory and overwrite, chunk by chunk
-            angles = np.zeros(angles_dask.shape)
-            if progressbar:
-                with ProgressBar():
-                    da.store(sources=angles_dask, targets=angles)
-            else:
-                da.store(sources=angles_dask, targets=angles)
-        else:
-            dot_products = ori.dot_outer(ori).data
-            angles = np.arccos(2 * dot_products**2 - 1)
-            angles = np.nan_to_num(angles)
-
-        return Scalar(angles)
 
     def plot_unit_cell(
         self,


### PR DESCRIPTION
#### Description of the change
Add a function `angle_with_outer` which computes the angles of the outer products between two sets of `Orientation`, `self` and `other`. `Orientation.get_distance_matrix` is essentially a specific case of this function and is already written. As such the general function `angle_with_outer(self, other...)` has been written using the code in `get_distance_matrix()`and `get_distance_matrix()` is a specific call to the former function with the argument `other` as `self`.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> from orix.quaternion import Orientation
>>> o = Orientation.random((3,))
>>> dist = o.get_distance_matrix()
>>> dist.shape
(3, 3)

>>> dist1 = o.angle_with_outer(o)
>>> np.allclose(dist.data, dist1.data)
True

>>> dist2 = o.angle_with_outer(~o)
>>> np.allclose(np.diag(dist2.data), 0)
True
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
