### PR TITLE
Silence warnings when `convention` argument is not passed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,8 +23,9 @@ Changed
 
 Deprecated
 ----------
-- The `convention` parameter in `from_euler()` methods has been deprecated in favour of
-  `direction`. This parameter will be removed in release 1.0.
+- The `convention` parameter in `from_euler()` and `to_euler()` methods has been
+  deprecated, in favour of `direction` in the former. This parameter will be removed in
+  release 1.0.
 
 2022-02-21 - version 0.8.2
 ==========================

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -345,6 +345,7 @@ Orientation
     in_euler_fundamental_region
     scatter
     set_symmetry
+    to_euler
     transpose
 .. autoclass:: orix.quaternion.Orientation
     :show-inheritance:

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -450,10 +450,9 @@ class Orientation(Misorientation):
             return misorientation.map_into_symmetry_reduced_zone()
         return NotImplemented
 
+    # TODO: Remove use of **kwargs in 1.0
     @classmethod
-    def from_euler(
-        cls, euler, symmetry=None, convention="bunge", direction="lab2crystal"
-    ):
+    def from_euler(cls, euler, symmetry=None, direction="lab2crystal", **kwargs):
         """Creates orientation(s) from an array of Euler angles.
 
         Parameters
@@ -463,14 +462,12 @@ class Orientation(Misorientation):
         symmetry : Symmetry, optional
             Symmetry of orientation(s). If None (default), no symmetry
             is set.
-        convention : str
-            Deprecated, please use "direction" argument instead.
         direction : str
             "lab2crystal" (default) or "crystal2lab". "lab2crystal"
             is the Bunge convention. If "MTEX" is provided then the
             direction is "crystal2lab".
         """
-        o = super().from_euler(euler=euler, convention=convention, direction=direction)
+        o = super().from_euler(euler=euler, direction=direction, **kwargs)
         if symmetry:
             o.symmetry = symmetry
         return o

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -48,7 +48,7 @@ from scipy.special import hyp0f1
 from orix.quaternion import Quaternion
 from orix.vector import AxAngle, Vector3d
 from orix.scalar import Scalar
-from orix._util import deprecated
+from orix._util import deprecated_argument
 
 # Used to round values below 1e-16 to zero
 _FLOAT_EPS = np.finfo(float).eps
@@ -308,7 +308,9 @@ class Rotation(Quaternion):
         axangle = AxAngle.from_axes_angles(axes, angles)
         return cls.from_neo_euler(axangle)
 
-    def to_euler(self):
+    # TODO: Remove decorator and **kwargs in 1.0
+    @deprecated_argument("convention", since="0.9", removal="1.0")
+    def to_euler(self, **kwargs):
         r"""Rotations as Euler angles in the Bunge convention
         :cite:`rowenhorst2015consistent`.
 
@@ -374,38 +376,28 @@ class Rotation(Quaternion):
 
         return e
 
+    # TODO: Remove decorator, **kwargs, and use of "convention" in 1.0
     @classmethod
-    @deprecated("0.9", "direction", "1.0", "argument", "convention")
-    def from_euler(cls, euler, convention="bunge", direction="lab2crystal"):
+    @deprecated_argument("convention", "0.9", "1.0", "direction")
+    def from_euler(cls, euler, direction="lab2crystal", **kwargs):
         """Creates a rotation from an array of Euler angles in radians.
 
         Parameters
         ----------
         euler : array-like
             Euler angles in radians in the Bunge convention.
-        convention : str
-            Deprecated, please use "direction" argument instead.
         direction : str
             "lab2crystal" (default) or "crystal2lab". "lab2crystal"
             is the Bunge convention. If "MTEX" is provided then the
             direction is "crystal2lab".
         """
         direction = direction.lower()
-        conventions = ["bunge", "mtex"]
-
-        # processing the convention chosen
-        convention = convention.lower()
-        if convention not in conventions:
-            raise ValueError(
-                f"The chosen convention is not one of the allowed options {conventions}"
-            )
-        if convention == "mtex":
+        if direction == "mtex" or (
+            "convention" in kwargs and kwargs["convention"] == "mtex"
+        ):
             # MTEX uses bunge but with lab2crystal referencing:
             # see - https://mtex-toolbox.github.io/MTEXvsBungeConvention.html
             # and orix issue #215
-            direction = "mtex"
-
-        if direction == "mtex":
             direction = "crystal2lab"
 
         directions = ["lab2crystal", "crystal2lab"]

--- a/orix/tests/quaternion/test_rotation.py
+++ b/orix/tests/quaternion/test_rotation.py
@@ -242,23 +242,6 @@ class TestToFromEuler:
         with pytest.raises(ValueError, match="The chosen direction is not one of "):
             _ = Rotation.from_euler(e, direction="dumb_direction")
 
-    def test_unsupported_conv_to_raises(self, e):
-        r = Rotation.from_euler(e)
-        with pytest.raises(TypeError, match=r"to_euler\(\) got an unexpected keyword "):
-            _ = r.to_euler(convention="bunge")
-
-    def test_unsupported_conv_from_raises(self, e):
-        with pytest.raises(ValueError, match="The chosen convention is not one of "):
-            _ = Rotation.from_euler(e, convention="unsupported")
-
-    # TODO: remove in 1.0
-    def test_conv_from_warns(self, e):
-        with pytest.warns(
-            np.VisibleDeprecationWarning,
-            match=r"Argument `convention` is deprecated and",
-        ):
-            _ = Rotation.from_euler(e)
-
     def test_edge_cases_to_euler(self):
         x = np.sqrt(1 / 2)
         q = Rotation(np.asarray([x, 0, 0, x]))
@@ -270,6 +253,54 @@ class TestToFromEuler:
         with pytest.warns(UserWarning, match="Angles are assumed to be in radians, "):
             r = Rotation.from_euler([90, 0, 0])
             assert np.allclose(r.data, [0.5253, 0, 0, -0.8509], atol=1e-4)
+
+    # TODO: Remove in 1.0
+    def test_from_euler_warns(self, e):
+        """Rotation.from_euler() warns only when "convention" argument
+        is passed.
+        """
+        with pytest.warns(None) as record:
+            _ = Rotation.from_euler(e)
+        assert len(record) == 0
+
+        msg = (
+            r"Argument `convention` is deprecated and will be removed in version 1.0. "
+            r"To avoid this warning, please do not use `convention`. "
+            r"Use `direction` instead. See the documentation of `from_euler\(\)` for "
+            "more details."
+        )
+        with pytest.warns(np.VisibleDeprecationWarning, match=msg):
+            _ = Rotation.from_euler(e, convention="whatever")
+
+    # TODO: Remove in 1.0
+    def test_from_euler_convention_mtex(self, e):
+        """Passing convention="mtex" to Rotation.from_euler() works but
+        warns.
+        """
+        rot1 = Rotation.from_euler(e, direction="crystal2lab")
+        with pytest.warns(np.VisibleDeprecationWarning, match=r"Argument `convention`"):
+            rot2 = Rotation.from_euler(e, convention="mtex")
+        assert np.allclose(rot1.data, rot2.data)
+
+    # TODO: Remove in 1.0
+    def test_to_euler_convention_warns(self, e):
+        """Rotation.to_euler() warns only when "convention" argument is
+        passed.
+        """
+        rot1 = Rotation.from_euler(e)
+
+        with pytest.warns(None) as record:
+            rot2 = rot1.to_euler()
+        assert len(record) == 0
+
+        msg = (
+            r"Argument `convention` is deprecated and will be removed in version 1.0. "
+            r"To avoid this warning, please do not use `convention`. "
+            r"See the documentation of `to_euler\(\)` for more details."
+        )
+        with pytest.warns(np.VisibleDeprecationWarning, match=msg):
+            rot3 = rot1.to_euler(convention="whatever")
+        assert np.allclose(rot2, rot3)
 
 
 @pytest.mark.parametrize(
@@ -562,10 +593,3 @@ class TestFromAxesAngles:
         rotations2 = Rotation.from_neo_euler(axangle)
         rotations3 = Rotation.from_axes_angles(axangle.axis.data, axangle.angle.data)
         assert np.allclose(rotations2.data, rotations3.data)
-
-
-def test_to_euler_not_warning():
-    rot = Rotation(((0, 1, 0, 0), (1, 0, 0, 0), (1, 1, 0, 0)))
-    with pytest.warns(None) as record:
-        _ = rot.to_euler()
-    assert len(record) == 0

--- a/orix/tests/test_util.py
+++ b/orix/tests/test_util.py
@@ -106,20 +106,11 @@ class TestDeprecateArgument:
         """
 
         class Foo:
-            @deprecated_argument(
-                name="a",
-                since="1.3",
-                removal="1.4",
-            )
+            @deprecated_argument(name="a", since="1.3", removal="1.4")
             def bar_arg(self, **kwargs):
                 return kwargs
 
-            @deprecated_argument(
-                name="a",
-                since="1.3",
-                removal="1.4",
-                alternative="b",
-            )
+            @deprecated_argument(name="a", since="1.3", removal="1.4", alternative="b")
             def bar_arg_alt(self, **kwargs):
                 return kwargs
 


### PR DESCRIPTION
#### Description of the change
This PR is a result of me not being as thorough in my review of #294 as I should be.

* Still allow passing the `convention` argument to `Rotation` and `Orientation` methods `from_euler()` and `to_euler()` via accepting `**kwargs`. Still used in `from_euler()` if `convention="mtex"`.
* Only emit warning if `convention` is passed to `from_euler()` or `to_euler()`, and only once if it is passed to `Orientation` methods (emitted from `Rotation` methods). The methods does not emit warnings if `convention` is not passed.
* Move argument deprecation to its own decorator `orix._util.deprecate_argument` to simplify the `deprecated` class. The `@deprecated` decorator alters the function's docstring so that it looks like the whole function (or property) is deprecated, see [Rotation.from_euler()](https://orix.readthedocs.io/en/latest/reference.html#orix.quaternion.Rotation.from_euler) in the "latest" docs. This alteration is clearly not desirable for this method. Instead of adding some extra logic to `@depreacted`, I opted for creating `@deprecate_argument` instead, which does not alter the docstring.
* Clearly stated all code and tests which should be removed before releasing 1.0.

I made these changes mainly because it is undesirable for calls to `Rotation.from_euler()` to raise a warning regarding the `convention` argument, even though it is not passed. This is exemplified by inspecting all the warnings emitted from the test suite, many places where `convention` is not used:

```python
>>> pytest
[...]
orix/tests/test_miller.py: 1 warning
orix/tests/io/test_ang.py: 23 warnings
orix/tests/io/test_bruker_h5ebsd.py: 7 warnings
orix/tests/io/test_emsoft_h5ebsd.py: 3 warnings
orix/tests/io/test_io.py: 3 warnings
orix/tests/io/test_orix_hdf5.py: 7 warnings
orix/tests/plot/test_inverse_pole_figure_plot.py: 1 warning
orix/tests/plot/test_orientation_color_keys.py: 4 warnings
orix/tests/quaternion/test_conversions.py: 1 warning
orix/tests/quaternion/test_orientation.py: 6 warnings
orix/tests/quaternion/test_rotation.py: 11 warnings
orix/tests/sampling/test_sampling.py: 9 warnings
  /home/hakon/kode/orix/orix/quaternion/rotation.py:378: VisibleDeprecationWarning: Argument `convention` is
deprecated and will be removed in version 1.0. Use `direction` instead.
    @deprecated("0.9", "direction", "1.0", "argument", "convention")
```

This would also mean that whenever `Rotation.from_euler()` is called in downstream packages, like kikuchipy, this warning would be emitted. With this PR, this is not the case unless `convention` is passed.

I opted to remove `convention` from the docstring parameters entirely. This could be added if you think it best.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> import numpy as np
>>> from orix.quaternion import Orientation, Rotation

# No warning
>>> rot1 = Rotation.from_euler((0.1, 0.2, 0.3), direction="crystal2lab")

# Warns with alternative
>>> Rotation.from_euler((0.1, 0.2, 0.3), convention="whatever")
/home/hakon/kode/orix/orix/quaternion/rotation.py:381: VisibleDeprecationWarning: Argument `convention` is
deprecated and will be removed in version 1.0. To avoid this warning, please do not use `convention`. Use
`direction` instead. See the  documentation of `from_euler()` for more details.
  @deprecated_argument("convention", "0.9", "1.0", "direction")

# Warns with alternative, but still uses `convention`
>>> rot2 = Rotation.from_euler((0.1, 0.2, 0.3), convention="mtex")
/home/hakon/kode/orix/orix/quaternion/rotation.py:381: VisibleDeprecationWarning: Argument `convention` is
deprecated and will be removed in version 1.0. To avoid this warning, please do not use `convention`. Use
`direction` instead. See the  documentation of `from_euler()` for more details.
  @deprecated_argument("convention", "0.9", "1.0", "direction")
>>> np.allclose(rot1.data, rot2.data)
True
>>> rot1.to_euler()  # No warning
array([[2.84159265, 0.2       , 3.04159265]])

# Warns without alternative, `convention` is not used
>>> rot1.to_euler(convention="whatever")
/home/hakon/kode/orix/orix/quaternion/rotation.py:313: VisibleDeprecationWarning: Argument `convention` is
deprecated and will be removed in version 1.0. To avoid this warning, please do not use `convention`. See
the documentation of `to_euler()` for more details.
  def to_euler(self, **kwargs):
array([[2.84159265, 0.2       , 3.04159265]])

# Warning from Rotation emitted
>>> _ = Orientation.from_euler((0.1, 0.2, 0.3), convention="roe")
/home/hakon/kode/orix/orix/quaternion/rotation.py:381: VisibleDeprecationWarning: Argument `convention` is
deprecated and will be removed in version 1.0. To avoid this warning, please do not use `convention`. Use
`direction` instead. See the documentation of `from_euler()` for more details.
  @deprecated_argument("convention", "0.9", "1.0", "direction")
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
