### PR TITLE
Add `Vector3d.scatter()` reproject onto hemisphere functionality

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ Unreleased
 
 Added
 -----
+- Add `reproject` argument to `Vector3d.scatter()` which reprojects vectors located on
+  the hidden hemisphere to the visible hemisphere.
 - `Rotation` objects can now be checked for equality. Equality is determined by
   comparing their shape, data, and whether the rotations are improper.
 - `angle_with_outer()` has been added to both  `Rotation` and `Orientation` classes

--- a/doc/stereographic_projection.ipynb
+++ b/doc/stereographic_projection.ipynb
@@ -216,6 +216,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a8732363",
+   "metadata": {},
+   "source": [
+    "When `reproject=True`, vectors impinging on the opposite hemisphere are reprojected onto the visible hemisphere after reflection in the projection plane."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e7c076d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reproject_scatter_kwargs = dict(marker=\"o\", fc=\"None\", ec=\"r\", s=150)\n",
+    "v2.scatter(axes_labels=labels, show_hemisphere_label=True, figure_kwargs=fig_kwargs, reproject=True, reproject_scatter_kwargs=reproject_scatter_kwargs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "e9c8c664",
    "metadata": {},
    "source": [

--- a/orix/plot/stereographic_plot.py
+++ b/orix/plot/stereographic_plot.py
@@ -607,6 +607,9 @@ class StereographicPlot(maxes.Axes):
         new_kwargs : dict
             Any default keyword arguments to be passed to the inherited
             method.
+        sort : bool, optional
+            Whether to sort vectors before passing them to Matplotlib.
+            Default is False.
 
         Returns
         -------
@@ -632,6 +635,9 @@ class StereographicPlot(maxes.Axes):
             spherical coordinates are given, they are assumed to
             describe unit vectors. Vectors will be made into unit
             vectors if they aren't already.
+        sort : bool, optional
+            Whether to sort vectors before passing them to Matplotlib.
+            Default is False.
 
         Returns
         -------

--- a/orix/plot/stereographic_plot.py
+++ b/orix/plot/stereographic_plot.py
@@ -639,6 +639,8 @@ class StereographicPlot(maxes.Axes):
             Stereographic x coordinates of unit vectors.
         y : numpy.ndarray
             Stereographic y coordinates of unit vectors.
+        visible : numpy.ndarray
+            Whether these values are visible on the axes.
         """
         pole = self.pole
         if len(values) == 2:

--- a/orix/tests/test_vector3d.py
+++ b/orix/tests/test_vector3d.py
@@ -562,14 +562,19 @@ class TestPlotting:
     def test_scatter_reproject(self):
         o = Orientation.from_axes_angles((-1, 8, 1), np.deg2rad(65))
         v = (symmetry.Oh * o) * Vector3d.zvector()
+        # normal scatter: half of the vectors are shown
         fig1 = v.scatter(hemisphere="upper", reproject=False, return_figure=True)
         assert (
             sum(len(c.get_offsets()) for c in fig1.axes[0].collections) == v.size // 2
         )
+        # reproject: all of the vectors are shown
         fig2 = v.scatter(hemisphere="upper", reproject=True, return_figure=True)
         assert sum(len(c.get_offsets()) for c in fig2.axes[0].collections) == v.size
+        # reproject: all of the vectors are shown
         fig3 = v.scatter(hemisphere="lower", reproject=True, return_figure=True)
         assert sum(len(c.get_offsets()) for c in fig3.axes[0].collections) == v.size
+        # reproject hemisphere="both": reprojection is ignored so
+        # half of the vectors are shown on each axes as normal
         fig4 = v.scatter(hemisphere="both", reproject=True, return_figure=True)
         for ax in fig4.axes:
             assert sum(len(c.get_offsets()) for c in ax.collections) == v.size // 2

--- a/orix/tests/test_vector3d.py
+++ b/orix/tests/test_vector3d.py
@@ -20,7 +20,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
-from orix.quaternion import symmetry
+from orix.quaternion import Orientation, symmetry
 from orix.vector import Vector3d, check_vector
 
 
@@ -558,6 +558,21 @@ class TestPlotting:
             NotImplementedError, match="Stereographic is the only supported"
         ):
             self.v.scatter(projection="equal_angle")
+
+    def test_scatter_reproject(self):
+        o = Orientation.from_axes_angles((-1, 8, 1), np.deg2rad(65))
+        v = (symmetry.Oh * o) * Vector3d.zvector()
+        fig1 = v.scatter(hemisphere="upper", reproject=False, return_figure=True)
+        assert (
+            sum(len(c.get_offsets()) for c in fig1.axes[0].collections) == v.size // 2
+        )
+        fig2 = v.scatter(hemisphere="upper", reproject=True, return_figure=True)
+        assert sum(len(c.get_offsets()) for c in fig2.axes[0].collections) == v.size
+        fig3 = v.scatter(hemisphere="lower", reproject=True, return_figure=True)
+        assert sum(len(c.get_offsets()) for c in fig3.axes[0].collections) == v.size
+        fig4 = v.scatter(hemisphere="both", reproject=True, return_figure=True)
+        for ax in fig4.axes:
+            assert sum(len(c.get_offsets()) for c in ax.collections) == v.size // 2
 
     def test_draw_circle(self):
         v = self.v

--- a/orix/tests/test_vector3d.py
+++ b/orix/tests/test_vector3d.py
@@ -568,8 +568,13 @@ class TestPlotting:
             sum(len(c.get_offsets()) for c in fig1.axes[0].collections) == v.size // 2
         )
         # reproject: all of the vectors are shown
-        fig2 = v.scatter(hemisphere="upper", reproject=True, return_figure=True)
+        fig2 = v.scatter(hemisphere="upper", reproject=True, return_figure=True, c="r")
         assert sum(len(c.get_offsets()) for c in fig2.axes[0].collections) == v.size
+        # (1, 0, 0, 1) is red in RGBA
+        assert all(
+            np.allclose(c.get_edgecolor(), (1, 0, 0, 1))
+            for c in fig2.axes[0].collections
+        )
         # reproject: all of the vectors are shown
         fig3 = v.scatter(hemisphere="lower", reproject=True, return_figure=True)
         assert sum(len(c.get_offsets()) for c in fig3.axes[0].collections) == v.size

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -637,27 +637,24 @@ class Vector3d(Object3d):
             Azimuth and polar grid resolution in degrees, as a tuple.
             Default is whatever is default in
             :class:`~orix.plot.StereographicPlot.stereographic_grid`.
-        reproject_marker : str, optional
-            Marker used to represent reprojected vectors.
-            Default is "+".
         figure_kwargs : dict, optional
             Dictionary of keyword arguments passed to
             :func:`matplotlib.pyplot.subplots`.
         reproject_scatter_kwargs: dict, optional
             Dictionary of keyword arguments for the reprojected scatter
             points which is passed to
-            func:`~orix.plot.StereographicPlot.scatter`, which passes
+            :meth:`~orix.plot.StereographicPlot.scatter`, which passes
             these on to :meth:`matplotlib.axes.Axes.scatter`. The
             default marker style for reprojected vectors is "+".
         text_kwargs : dict, optional
             Dictionary of keyword arguments passed to
-            :func:`~orix.plot.StereographicPlot.text`, which passes
+            :meth:`~orix.plot.StereographicPlot.text`, which passes
             these on to :meth:`matplotlib.axes.Axes.text`.
         return_figure : bool, optional
             Whether to return the figure (default is False).
         kwargs : dict, optional
             Keyword arguments passed to
-            :func:`~orix.plot.StereographicPlot.scatter`, which passes
+            :meth:`~orix.plot.StereographicPlot.scatter`, which passes
             these on to :meth:`matplotlib.axes.Axes.scatter`.
 
         Returns
@@ -704,22 +701,22 @@ class Vector3d(Object3d):
             text_kwargs=text_kwargs,
             axes_labels=axes_labels,
         )
+        # setup reproject scatter plotting args
+        if reproject_scatter_kwargs is None:
+            reproject_scatter_kwargs = {}
+        reproject_scatter_kwargs.setdefault("marker", "+")
+        # unless otherwise defined, copy normal scatter kwargs
+        for k, v in kwargs.items():
+            if k not in reproject_scatter_kwargs.keys():
+                reproject_scatter_kwargs[k] = v
+        # multiplicative factor to project z-data to other hemisphere
+        factor = (1, 1, -1)
         # Use methods of the StereographicPlot class
         for i, ax in enumerate(axes):  # Assumes a maximum of two axes
             ax.hemisphere = hemisphere[i]
             ax.scatter(self, **kwargs)
             # only reproject if both hemispheres are not shown
             if reproject and not both_hemispheres:
-                # setup reproject scatter plotting args
-                if reproject_scatter_kwargs is None:
-                    reproject_scatter_kwargs = {}
-                reproject_scatter_kwargs.setdefault("marker", "+")
-                # unless otherwise defined, copy normal scatter kwargs
-                for k, v in kwargs.items():
-                    if k not in reproject_scatter_kwargs.keys():
-                        reproject_scatter_kwargs[k] = v
-                # project z-data to other hemisphere
-                factor = (1, 1, -1)
                 visible = _is_visible(self.polar, ax.pole)
                 ax.scatter(
                     self.__class__(self[~visible].data * factor),

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -670,7 +670,10 @@ class Vector3d(Object3d):
         --------
         orix.plot.StereographicPlot
         """
-        both_hemispheres = True if hemisphere.lower() == "both" else False
+        if hemisphere is None or hemisphere.lower() != "both":
+            both_hemispheres = False
+        else:
+            both_hemispheres = True
         (
             fig,
             axes,

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -645,7 +645,9 @@ class Vector3d(Object3d):
             points which is passed to
             :meth:`~orix.plot.StereographicPlot.scatter`, which passes
             these on to :meth:`matplotlib.axes.Axes.scatter`. The
-            default marker style for reprojected vectors is "+".
+            default marker style for reprojected vectors is "+". Values
+            used for vector(s) on the visible hemisphere are used unless
+            another value is passed here.
         text_kwargs : dict, optional
             Dictionary of keyword arguments passed to
             :meth:`~orix.plot.StereographicPlot.text`, which passes

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -623,8 +623,9 @@ class Vector3d(Object3d):
             projections side by side.
         reproject : bool, optional
             Whether to reproject vectors onto the chosen hemisphere.
-            Reprojection is achieved by reflection in the x-y plane.
-            Ignored if hemisphere is "both".
+            Reprojection is achieved by reflection of the vectors
+            located on the opposite hemisphere in the x-y plane.
+            Ignored if `hemisphere` is "both".
         show_hemisphere_label : bool, optional
             Whether to show hemisphere labels "upper" or "lower".
             Default is True if `hemisphere` is "both", otherwise False.

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -701,16 +701,17 @@ class Vector3d(Object3d):
             text_kwargs=text_kwargs,
             axes_labels=axes_labels,
         )
-        # setup reproject scatter plotting args
-        if reproject_scatter_kwargs is None:
-            reproject_scatter_kwargs = {}
-        reproject_scatter_kwargs.setdefault("marker", "+")
-        # unless otherwise defined, copy normal scatter kwargs
-        for k, v in kwargs.items():
-            if k not in reproject_scatter_kwargs.keys():
-                reproject_scatter_kwargs[k] = v
-        # multiplicative factor to project z-data to other hemisphere
-        factor = (1, 1, -1)
+        if reproject and not both_hemispheres:
+            # setup reproject scatter plotting args
+            if reproject_scatter_kwargs is None:
+                reproject_scatter_kwargs = {}
+            reproject_scatter_kwargs.setdefault("marker", "+")
+            # unless otherwise defined, copy normal scatter kwargs
+            for k, v in kwargs.items():
+                if k not in reproject_scatter_kwargs.keys():
+                    reproject_scatter_kwargs[k] = v
+            # multiplicative factor to project z-data to other hemisphere
+            factor = (1, 1, -1)
         # Use methods of the StereographicPlot class
         for i, ax in enumerate(axes):  # Assumes a maximum of two axes
             ax.hemisphere = hemisphere[i]


### PR DESCRIPTION
#### Description of the change

As discussed with @hakonanes in https://github.com/pyxem/orix/pull/306#discussion_r835078799

> This is just an idea for the future, but it might be that we should support a boolean parameter to Vector3d.scatter() to set whether vectors on the other hemisphere (northern if hemisphere="south is passed and vice versa) should be projected up to the projection plane as well. We should then force the scatter points to be different.

We should include the option to reproject vectors onto the visible hemisphere, ie. if `Vector3d.scatter(hemisphere='upper')` is called then vectors projected onto the lower hemisphere are not shown. This PR adds the `reproject` argument to `Vector3d.scatter()` which reprojects vectors located on the hidden hemisphere to the visible hemisphere. This is achieved by reflection of the vectors in the x-y plane.

The reprojected vectors are displayed with a `'+'` marker by default and can be set using the `reproject_marker` argument. If `hemisphere='both'`, `reproject=True` has no effect as all vectors are already shown on one of the two axes.

If approved the changes in this PR should be used to simplify #306.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
from orix.quaternion import Orientation, symmetry
from orix.vector import Vector3d

o = symmetry.O * Orientation.random()
v = o * Vector3d.zvector()

v.scatter(hemisphere='upper', show_hemisphere_label=True)
```
<img width="402" alt="image" src="https://user-images.githubusercontent.com/16853829/160302053-601d73c1-2c04-436c-84bc-c16a94f38032.png">

```python
v.scatter(hemisphere='upper', reproject=True, show_hemisphere_label=True)
```
<img width="412" alt="image" src="https://user-images.githubusercontent.com/16853829/160302085-0623a319-5875-478f-bc2e-93c41277204e.png">

`reproject=True` has no effect if `hemisphere='both'`:
```python
v.scatter(hemisphere='both', reproject=True, show_hemisphere_label=True)
```
<img width="570" alt="image" src="https://user-images.githubusercontent.com/16853829/160302110-51620add-b85b-4d2f-a585-c1a51bc53d13.png">


#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
