### PR TITLE
Fix writing property arrays in masked CrystalMap to .ang file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,7 @@ Fixed
 -----
 - The results from `Orientation.dot_outer()` are now returned as 
   `self.shape + other.shape`, which is consistent with `Rotation.dot_outer()`.
+- Writing of property arrays in .ang writer from masked CrystalMap.
 
 Removed
 -------

--- a/orix/io/plugins/ang.py
+++ b/orix/io/plugins/ang.py
@@ -656,7 +656,6 @@ def _get_prop_arrays(xmap, prop_names, desired_prop_names, map_size, index, deci
     for i, (name, names) in enumerate(zip(desired_prop_names, all_expected_prop_names)):
         prop = _get_prop_array(
             xmap=xmap,
-            map_size=map_size,
             prop_name=name,
             expected_prop_names=names,
             prop_names=prop_names,
@@ -672,7 +671,6 @@ def _get_prop_arrays(xmap, prop_names, desired_prop_names, map_size, index, deci
 
 def _get_prop_array(
     xmap,
-    map_size,
     prop_name,
     expected_prop_names,
     prop_names,
@@ -691,7 +689,6 @@ def _get_prop_array(
     Parameters
     ----------
     xmap : CrystalMap
-    map_size : int
     prop_name : str
     expected_prop_names : list of str
     prop_names : list of str
@@ -718,14 +715,10 @@ def _get_prop_array(
             else:  # If no suitable property was found
                 return
         # There is a property
-        try:
-            prop_array_size = xmap.prop[prop_name].size
-            if prop_array_size == map_size:
-                # Return the single array even if `index` is given
-                return xmap.get_map_data(prop_name, **kwargs)
-            else:
-                if index is None:
-                    index = 0
-                return xmap.get_map_data(xmap.prop[prop_name][:, index], **kwargs)
-        except IndexError:
-            return
+        if len(xmap.prop[prop_name].shape) == 1:
+            # Return the single array even if `index` is given
+            return xmap.get_map_data(prop_name, **kwargs)
+        else:
+            if index is None:
+                index = 0
+            return xmap.get_map_data(xmap.prop[prop_name][:, index], **kwargs)

--- a/orix/tests/io/test_ang.py
+++ b/orix/tests/io/test_ang.py
@@ -665,6 +665,9 @@ class TestAngWriter:
         save(fname, xmap, index=index, extra_prop=[extra_prop, "iq"])
 
         xmap_reload = load(fname)
+        assert np.allclose(
+            xmap_reload.rotations.to_euler(), xmap.rotations[:, index].to_euler()
+        )
         assert np.allclose(xmap_reload.iq, xmap.iq)
         assert np.allclose(xmap_reload.ci, xmap.ci[:, index])
         assert np.allclose(xmap_reload.iq_times_ci, xmap.iq_times_ci[:, index])

--- a/orix/tests/io/test_ang.py
+++ b/orix/tests/io/test_ang.py
@@ -656,11 +656,8 @@ class TestAngWriter:
     )
     def test_write_data_index(self, crystal_map_input, tmp_path, index):
         xmap = CrystalMap(**crystal_map_input)
-        xmap.prop["ci"] = (
-            np.arange(xmap.size * xmap.rotations_per_point)
-            .reshape((xmap.size, xmap.rotations_per_point))
-            .squeeze()
-        )
+        ci = np.arange(xmap.size * xmap.rotations_per_point).reshape((xmap.size, -1))
+        xmap.prop["ci"] = ci
         xmap.prop["iq"] = np.arange(xmap.size)
         extra_prop = "iq_times_ci"
         xmap.prop[extra_prop] = xmap.ci * xmap.iq[:, np.newaxis]

--- a/orix/tests/io/test_ang.py
+++ b/orix/tests/io/test_ang.py
@@ -656,8 +656,10 @@ class TestAngWriter:
     )
     def test_write_data_index(self, crystal_map_input, tmp_path, index):
         xmap = CrystalMap(**crystal_map_input)
-        xmap.prop["ci"] = np.arange(xmap.size * xmap.rotations_per_point).reshape(
-            (xmap.size, xmap.rotations_per_point)
+        xmap.prop["ci"] = (
+            np.arange(xmap.size * xmap.rotations_per_point)
+            .reshape((xmap.size, xmap.rotations_per_point))
+            .squeeze()
         )
         xmap.prop["iq"] = np.arange(xmap.size)
         extra_prop = "iq_times_ci"
@@ -666,10 +668,36 @@ class TestAngWriter:
         save(fname, xmap, index=index, extra_prop=[extra_prop, "iq"])
 
         xmap_reload = load(fname)
-
-        assert np.allclose(
-            xmap.rotations[:, index].to_euler(), xmap_reload.rotations.to_euler()
-        )
         assert np.allclose(xmap_reload.iq, xmap.iq)
         assert np.allclose(xmap_reload.ci, xmap.ci[:, index])
         assert np.allclose(xmap_reload.iq_times_ci, xmap.iq_times_ci[:, index])
+
+    @pytest.mark.parametrize(
+        "crystal_map_input",
+        [((1, 4, 3), (1, 2, 2), 2, [0])],
+        indirect=["crystal_map_input"],
+    )
+    def test_write_data_index_none(self, crystal_map_input, tmp_path):
+        """In a CrystalMap with more properties per point, check that
+        the first property value is written to file when `index` is
+        None.
+
+        Also check that passing `index` greater than the number of
+        rotations per point raises an error before reaching writing of
+        property arrays.
+        """
+        xmap = CrystalMap(**crystal_map_input)
+        xmap.prop["ci"] = np.arange(xmap.size * xmap.rotations_per_point).reshape(
+            (xmap.size, xmap.rotations_per_point)
+        )
+        fname = tmp_path / "test_write_data_index_none.ang"
+        save(fname, xmap, extra_prop=["ci"])
+
+        # First property values were written to file
+        xmap_reload = load(fname)
+        assert np.allclose(xmap_reload.ci, xmap.ci[:, 0])
+
+        # IndexError raised when indexing into `xmap.rotations`
+        fname2 = tmp_path / "test_write_data_index_none2.ang"
+        with pytest.raises(IndexError):
+            save(fname2, xmap, index=2, extra_prop=["ci"])


### PR DESCRIPTION
#### Description of the change
Property array columns (like "image quality" or custom properties) in .ang files written from masked a `CrystalMap` (some points not in the data, entered as `False` in `CrystalMap.is_in_data`) were filled with only zeros. Turns out this check

https://github.com/pyxem/orix/blob/9ef1bf8e2ac45796934132ba002cdc293943cdb4/orix/io/plugins/ang.py#L723

is never true for masked crystal maps, since `prop_array_size` has the same size as `is_in_data.sum()`, while `map_size` always equals the full unmasked map size (`is_in_data.size`). This PR fixes this issue.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
