### PR TITLE
Remove functions deprecated for removal in 0.9

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,7 +54,7 @@ Removed
 -------
 - `orix.scalar.Scalar` class has been removed and the data held by `Scalar` is now
   returned directly as a `numpy.ndarray`.
-- Functions: `(Mis)Orientation.set_symmetry` and `Orientation.distance`  and property:
+- Functions: `(Mis)Orientation.set_symmetry` and `Orientation.distance` and property:
  `Object3d.data_dim` were previously deprecated and have now been removed. 
 
 2022-02-21 - version 0.8.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,8 +54,8 @@ Removed
 -------
 - `orix.scalar.Scalar` class has been removed and the data held by `Scalar` is now
   returned directly as a `numpy.ndarray`.
-- Functions: `(Mis)Orientation.set_symmetry` and `Orientation.distance` and property:
-  `Object3d.data_dim` were previously deprecated and have now been removed.
+- Functions: `(Mis)Orientation.set_symmetry()` and `Orientation.distance()` and
+  property: `Object3d.data_dim` were previously deprecated and have now been removed.
 
 2022-02-21 - version 0.8.2
 ==========================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,6 +54,8 @@ Removed
 -------
 - `orix.scalar.Scalar` class has been removed and the data held by `Scalar` is now
   returned directly as a `numpy.ndarray`.
+- Functions: `(Mis)Orientation.set_symmetry` and `Orientation.distance`  and property:
+ `Object3d.data_dim` were previously deprecated and have now been removed. 
 
 2022-02-21 - version 0.8.2
 ==========================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,8 +54,8 @@ Removed
 -------
 - `orix.scalar.Scalar` class has been removed and the data held by `Scalar` is now
   returned directly as a `numpy.ndarray`.
-- Functions: `(Mis)Orientation.set_symmetry()` and `Orientation.distance()` and
-  property: `Object3d.data_dim` were previously deprecated and have now been removed.
+- Function: `(Mis)Orientation.set_symmetry()` and property: `Object3d.data_dim` were
+  previously deprecated and have now been removed.
 
 2022-02-21 - version 0.8.2
 ==========================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,7 +55,7 @@ Removed
 - `orix.scalar.Scalar` class has been removed and the data held by `Scalar` is now
   returned directly as a `numpy.ndarray`.
 - Functions: `(Mis)Orientation.set_symmetry` and `Orientation.distance` and property:
- `Object3d.data_dim` were previously deprecated and have now been removed. 
+  `Object3d.data_dim` were previously deprecated and have now been removed.
 
 2022-02-21 - version 0.8.2
 ==========================

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -343,6 +343,7 @@ Orientation
     get_distance_matrix
     in_euler_fundamental_region
     scatter
+    set_symmetry
     to_euler
     transpose
 .. autoclass:: orix.quaternion.Orientation
@@ -355,6 +356,7 @@ Misorientation
 .. currentmodule:: orix.quaternion.Misorientation
 .. autosummary::
     equivalent
+    set_symmetry
     transpose
 .. autoclass:: orix.quaternion.Misorientation
     :show-inheritance:

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -344,7 +344,6 @@ Orientation
     get_distance_matrix
     in_euler_fundamental_region
     scatter
-    set_symmetry
     to_euler
     transpose
 .. autoclass:: orix.quaternion.Orientation
@@ -358,7 +357,6 @@ Misorientation
 .. autosummary::
     distance
     equivalent
-    set_symmetry
     transpose
 .. autoclass:: orix.quaternion.Misorientation
     :show-inheritance:

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -343,7 +343,6 @@ Orientation
     get_distance_matrix
     in_euler_fundamental_region
     scatter
-    set_symmetry
     to_euler
     transpose
 .. autoclass:: orix.quaternion.Orientation
@@ -356,7 +355,6 @@ Misorientation
 .. currentmodule:: orix.quaternion.Misorientation
 .. autosummary::
     equivalent
-    set_symmetry
     transpose
 .. autoclass:: orix.quaternion.Misorientation
     :show-inheritance:

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -334,6 +334,7 @@ Orientation
 .. autosummary::
     angle_with
     angle_with_outer
+    distance
     dot
     dot_outer
     from_axes_angles
@@ -354,6 +355,7 @@ Misorientation
 ~~~~~~~~~~~~~~
 .. currentmodule:: orix.quaternion.Misorientation
 .. autosummary::
+    distance
     equivalent
     transpose
 .. autoclass:: orix.quaternion.Misorientation

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -334,7 +334,6 @@ Orientation
 .. autosummary::
     angle_with
     angle_with_outer
-    distance
     dot
     dot_outer
     from_axes_angles
@@ -355,7 +354,6 @@ Misorientation
 ~~~~~~~~~~~~~~
 .. currentmodule:: orix.quaternion.Misorientation
 .. autosummary::
-    distance
     equivalent
     transpose
 .. autoclass:: orix.quaternion.Misorientation

--- a/orix/base/__init__.py
+++ b/orix/base/__init__.py
@@ -23,8 +23,6 @@ Note that this class is not meant to be used directly.
 
 import numpy as np
 
-from orix._util import deprecated
-
 
 # Lists what will be imported when calling "from orix.base import *"
 __all__ = [
@@ -120,7 +118,7 @@ class Object3d:
     def ndim(self):
         """int : The number of navigation dimensions of the instance.
 
-        For example, if `data` has shape (4, 5, 6), `data_dim` is 3.
+        For example, if `data` has shape (4, 5, 6), `ndim` is 3.
 
         """
         return len(self.shape)

--- a/orix/base/__init__.py
+++ b/orix/base/__init__.py
@@ -117,16 +117,6 @@ class Object3d:
         return self.data.shape[:-1]
 
     @property
-    @deprecated(since="0.8", alternative="ndim", removal="0.9", object_type="property")
-    def data_dim(self):
-        """int : The dimensions of the data.
-
-        For example, if `data` has shape (4, 5, 6), `data_dim` is 3.
-
-        """
-        return self.ndim
-
-    @property
     def ndim(self):
         """int : The number of navigation dimensions of the instance.
 

--- a/orix/base/__init__.py
+++ b/orix/base/__init__.py
@@ -23,6 +23,8 @@ Note that this class is not meant to be used directly.
 
 import numpy as np
 
+from orix._util import deprecated
+
 
 # Lists what will be imported when calling "from orix.base import *"
 __all__ = [
@@ -118,7 +120,7 @@ class Object3d:
     def ndim(self):
         """int : The number of navigation dimensions of the instance.
 
-        For example, if `data` has shape (4, 5, 6), `ndim` is 3.
+        For example, if `data` has shape (4, 5, 6), `data_dim` is 3.
 
         """
         return len(self.shape)

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -694,6 +694,14 @@ class Orientation(Misorientation):
         )
         return highest_dot_product.transpose(*order)
 
+    @deprecated(
+        since="0.7",
+        alternative="orix.quaternion.Orientation.get_distance_matrix",
+        removal="0.8",
+    )
+    def distance(self, verbose=False, split_size=100):
+        return super().distance(verbose=verbose, split_size=split_size)
+
     def plot_unit_cell(
         self,
         c="tab:blue",

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -51,6 +51,63 @@ from orix.quaternion.orientation_region import OrientationRegion
 from orix.quaternion.rotation import Rotation
 from orix.quaternion.symmetry import C1, Symmetry, _get_unique_symmetry_elements
 from orix.vector import AxAngle
+from orix._util import deprecated
+
+
+def _distance(misorientation, verbose, split_size=100):
+    """Private function to find the symmetry reduced distance between
+    all pairs of (mis)orientations
+
+    Parameters
+    ----------
+    misorientation : orix.quaternion.Misorientation
+        The misorientation to be considered.
+    verbose : bool
+        Output progress bar while computing.
+    split_size : int
+        Size of block to compute at a time.
+
+    Returns
+    -------
+    distance : numpy.ndarray
+        2D matrix containing the angular distance between every
+        orientation, considering symmetries.
+    """
+    num_orientations = misorientation.shape[0]
+    S_1, S_2 = misorientation._symmetry
+    distance = np.full(misorientation.shape + misorientation.shape, np.infty)
+    split_size = split_size // S_1.shape[0]
+    outer_range = range(0, num_orientations, split_size)
+    if verbose:
+        outer_range = tqdm(outer_range, total=np.ceil(num_orientations / split_size))
+
+    S_1_outer_S_1 = S_1.outer(S_1)
+
+    # Calculate the upper half of the distance matrix block by block
+    for start_index_b in outer_range:
+        # we use slice object for compactness
+        index_slice_b = slice(
+            start_index_b, min(num_orientations, start_index_b + split_size)
+        )
+        o_sub_b = misorientation[index_slice_b]
+        for start_index_a in range(0, start_index_b + split_size, split_size):
+            index_slice_a = slice(
+                start_index_a, min(num_orientations, start_index_a + split_size)
+            )
+            o_sub_a = misorientation[index_slice_a]
+            axis = (len(o_sub_a.shape), len(o_sub_a.shape) + 1)
+            mis2orientation = (~o_sub_a).outer(S_1_outer_S_1).outer(o_sub_b)
+            # This works through all the identity rotations
+            for s_2_1, s_2_2 in icombinations(S_2, 2):
+                m = s_2_1 * mis2orientation * s_2_2
+                angle = m.angle.min(axis=axis)
+                distance[index_slice_a, index_slice_b] = np.minimum(
+                    distance[index_slice_a, index_slice_b], angle
+                )
+    # Symmetrize the matrix for convenience
+    i_lower = np.tril_indices(distance.shape[0], -1)
+    distance[i_lower] = distance.T[i_lower]
+    return distance
 
 
 class Misorientation(Rotation):
@@ -176,6 +233,40 @@ class Misorientation(Rotation):
                 break
         o_inside._symmetry = (Gl, Gr)
         return o_inside
+
+    def distance(self, verbose=False, split_size=100):
+        """Symmetry reduced distance.
+
+        Compute the shortest distance between all orientations
+        considering symmetries.
+
+        Parameters
+        ---------
+        verbose : bool
+            Output progress bar while computing. Default is False.
+        split_size : int
+            Size of block to compute at a time. Default is 100.
+
+        Returns
+        -------
+        distance : numpy.ndarray
+            2D matrix containing the angular distance between every
+            orientation, considering symmetries.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from orix.quaternion import Misorientation, symmetry
+        >>> data = np.array([[0.5, 0.5, 0.5, 0.5], [0, 1, 0, 0]])
+        >>> m = Misorientation(data)
+        >>> m.symmetry = (symmetry.C4, symmetry.C2)
+        >>> m = m.map_into_symmetry_reduced_zone()
+        >>> m.distance()
+        array([[3.14159265, 1.57079633],
+               [1.57079633, 0.        ]])
+        """
+        distance = _distance(self, verbose, split_size)
+        return distance.reshape(self.shape + self.shape)
 
     def __repr__(self):
         """String representation."""

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -197,40 +197,6 @@ class Misorientation(Rotation):
         equivalent = Gr.outer(orientations.outer(Gl))
         return self.__class__(equivalent).flatten()
 
-    @deprecated(
-        since="0.8",
-        alternative="orix.quaternion.Misorientation.map_into_symmetry_reduced_zone",
-        removal="0.9",
-    )
-    def set_symmetry(self, Gl, Gr, verbose=False):
-        """Assign symmetries to this misorientation.
-
-        Computes equivalent transformations which have the smallest
-        angle of rotation and assigns these in-place.
-
-        Parameters
-        ----------
-        Gl, Gr : Symmetry
-
-        Returns
-        -------
-        Misorientation
-            A new misorientation object with the assigned symmetry.
-
-        Examples
-        --------
-        >>> from orix.quaternion.symmetry import C4, C2
-        >>> data = np.array([[0.5, 0.5, 0.5, 0.5], [0, 1, 0, 0]])
-        >>> m = Misorientation(data).set_symmetry(C4, C2)
-        >>> m
-        Misorientation (2,) 4, 2
-        [[-0.7071  0.7071  0.      0.    ]
-        [ 0.      1.      0.      0.    ]]
-        """
-        misori = self.__class__(self.data)
-        misori.symmetry = (Gl, Gr)
-        return misori.map_into_symmetry_reduced_zone()
-
     def map_into_symmetry_reduced_zone(self, verbose=False):
         """Computes equivalent transformations which have the smallest
         angle of rotation and return these as a new Misorientation object.
@@ -728,14 +694,6 @@ class Orientation(Misorientation):
         )
         return highest_dot_product.transpose(*order)
 
-    @deprecated(
-        since="0.7",
-        alternative="orix.quaternion.Orientation.get_distance_matrix",
-        removal="0.8",
-    )
-    def distance(self, verbose=False, split_size=100):
-        return super().distance(verbose=verbose, split_size=split_size)
-
     def plot_unit_cell(
         self,
         c="tab:blue",
@@ -793,40 +751,6 @@ class Orientation(Misorientation):
 
         if return_figure:
             return fig
-
-    @deprecated(
-        since="0.8",
-        alternative="orix.quaternion.Orientation.map_into_symmetry_reduced_zone",
-        removal="0.9",
-    )
-    def set_symmetry(self, symmetry):
-        """Assign a symmetry to this orientation.
-
-        Computes equivalent transformations which have the smallest
-        angle of rotation and assigns these in-place.
-
-        Parameters
-        ----------
-        symmetry : Symmetry
-
-        Returns
-        -------
-        Orientation
-            The instance itself, with equivalent values.
-
-        Examples
-        --------
-        >>> from orix.quaternion.symmetry import C4
-        >>> data = np.array([[0.5, 0.5, 0.5, 0.5], [0, 1, 0, 0]])
-        >>> o = Orientation(data).set_symmetry(C4)
-        >>> o
-        Orientation (2,) 4
-        [[-0.7071  0.     -0.7071  0.    ]
-        [ 0.      1.      0.      0.    ]]
-        """
-        o = self.__class__(self.data)
-        o.symmetry = symmetry
-        return o.map_into_symmetry_reduced_zone()
 
     def in_euler_fundamental_region(self):
         """Euler angles in the fundamental Euler region of the proper

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -186,6 +186,14 @@ def test_transpose_2d():
     assert o1.shape == o2.shape[::-1]
 
 
+def test_map_into_reduced_symmetry_zone_verbose():
+    o = Orientation.random()
+    o.symmetry = Oh
+    o1 = o.map_into_symmetry_reduced_zone()
+    o2 = o.map_into_symmetry_reduced_zone(verbose=True)
+    assert np.allclose(o1.data, o2.data)
+
+
 @pytest.mark.parametrize(
     "shape, expected_shape, axes",
     [((11, 3, 5), (11, 5, 3), (0, 2, 1)), ((11, 3, 5), (3, 5, 11), (1, 2, 0))],

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -657,15 +657,3 @@ class TestOrientation:
             ori.symmetry = pg
             region = np.radians(pg.euler_fundamental_region)
             assert np.all(np.max(ori.in_euler_fundamental_region(), axis=0) <= region)
-
-
-def test_set_symmetry_deprecation_warning_orientation():
-    o = Orientation.random((3, 2))
-    with pytest.warns(np.VisibleDeprecationWarning, match="Function `set_symmetry()"):
-        _ = o.set_symmetry(C2)
-
-
-def test_set_symmetry_deprecation_warning_misorientation():
-    o = Misorientation.random((3, 2))
-    with pytest.warns(np.VisibleDeprecationWarning, match="Function `set_symmetry()"):
-        _ = o.set_symmetry(C2, C2)

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -49,31 +49,6 @@ def orientation(request):
 
 
 @pytest.mark.parametrize(
-    "orientation, symmetry, expected",
-    [
-        ([(1, 0, 0, 0)], C1, [(1, 0, 0, 0)]),
-        ([(1, 0, 0, 0)], C4, [(1, 0, 0, 0)]),
-        ([(1, 0, 0, 0)], D3, [(1, 0, 0, 0)]),
-        ([(1, 0, 0, 0)], T, [(1, 0, 0, 0)]),
-        ([(1, 0, 0, 0)], O, [(1, 0, 0, 0)]),
-        # 7pi/12 -C2-> # 7pi/12
-        ([(0.6088, 0, 0, 0.7934)], C2, [(-0.7934, 0, 0, 0.6088)]),
-        # 7pi/12 -C3-> # 7pi/12
-        ([(0.6088, 0, 0, 0.7934)], C3, [(-0.9914, 0, 0, 0.1305)]),
-        # 7pi/12 -C4-> # pi/12
-        ([(0.6088, 0, 0, 0.7934)], C4, [(-0.9914, 0, 0, -0.1305)]),
-        # 7pi/12 -O-> # pi/12
-        ([(0.6088, 0, 0, 0.7934)], O, [(-0.9914, 0, 0, -0.1305)]),
-    ],
-    indirect=["orientation"],
-)
-def test_set_symmetry(orientation, symmetry, expected):
-    o = Orientation(orientation.data, symmetry=symmetry)
-    o = o.map_into_symmetry_reduced_zone()
-    assert np.allclose(o.data, expected, atol=1e-3)
-
-
-@pytest.mark.parametrize(
     "symmetry, vector",
     [(C1, (1, 2, 3)), (C2, (1, -1, 3)), (C3, (1, 1, 1)), (O, (0, 1, 0))],
     indirect=["vector"],
@@ -88,34 +63,6 @@ def test_orientation_persistence(symmetry, vector):
     v2 = oc * v
     v2 = Vector3d(v2.data.round(4))
     assert v1._tuples == v2._tuples
-
-
-@pytest.mark.parametrize(
-    "orientation, symmetry, expected",
-    [
-        ((1, 0, 0, 0), C1, [0]),
-        ([(1, 0, 0, 0), (0.7071, 0.7071, 0, 0)], C1, [[0, np.pi / 2], [np.pi / 2, 0]]),
-        ([(1, 0, 0, 0), (0.7071, 0.7071, 0, 0)], C4, [[0, np.pi / 2], [np.pi / 2, 0]]),
-        ([(1, 0, 0, 0), (0.7071, 0, 0, 0.7071)], C4, [[0, 0], [0, 0]]),
-        (
-            [
-                [(1, 0, 0, 0), (0.7071, 0, 0, 0.7071)],
-                [(0, 0, 0, 1), (0.9239, 0, 0, 0.3827)],
-            ],
-            C4,
-            [
-                [[[0, 0], [0, np.pi / 4]], [[0, 0], [0, np.pi / 4]]],
-                [[[0, 0], [0, np.pi / 4]], [[np.pi / 4, np.pi / 4], [np.pi / 4, 0]]],
-            ],
-        ),
-    ],
-    indirect=["orientation"],
-)
-def test_distance(orientation, symmetry, expected):
-    orientation.symmetry = symmetry
-    orientation = orientation.map_into_symmetry_reduced_zone(verbose=True)
-    distance = orientation.distance(verbose=True)
-    assert np.allclose(distance, expected, atol=1e-3)
 
 
 @pytest.mark.parametrize("symmetry", [C1, C2, C4, D2, D6, T, O])
@@ -649,15 +596,3 @@ class TestOrientation:
             ori.symmetry = pg
             region = np.radians(pg.euler_fundamental_region)
             assert np.all(np.max(ori.in_euler_fundamental_region(), axis=0) <= region)
-
-
-def test_set_symmetry_deprecation_warning_orientation():
-    o = Orientation.random((3, 2))
-    with pytest.warns(np.VisibleDeprecationWarning, match="Function `set_symmetry()"):
-        _ = o.set_symmetry(C2)
-
-
-def test_set_symmetry_deprecation_warning_misorientation():
-    o = Misorientation.random((3, 2))
-    with pytest.warns(np.VisibleDeprecationWarning, match="Function `set_symmetry()"):
-        _ = o.set_symmetry(C2, C2)

--- a/orix/tests/test_object3d.py
+++ b/orix/tests/test_object3d.py
@@ -154,6 +154,10 @@ def test_shape(object3d):
     assert object3d.shape == object3d.data.shape[:-1]
 
 
+def test_data_dim(object3d):
+    assert object3d.data_dim == len(object3d.data.shape[:-1])
+
+
 def test_ndim(object3d):
     assert object3d.ndim == len(object3d.data.shape[:-1])
 
@@ -172,7 +176,7 @@ def test_stack(object3d, n):
 def test_flatten(object3d):
     flat = object3d.flatten()
     assert isinstance(flat, object3d.__class__)
-    assert flat.ndim == 1
+    assert flat.data_dim == 1
     assert flat.shape[0] == object3d.size
 
 
@@ -201,3 +205,12 @@ def test_get_random_sample(test_object3d):
 
     with pytest.raises(ValueError, match="Cannot draw a sample greater than 20"):
         _ = o3d.get_random_sample(21)
+
+
+@pytest.mark.parametrize("test_object3d", [3], indirect=["test_object3d"])
+def test_deprecation_warning_data_dim(test_object3d):
+    o3d = test_object3d(np.arange(21).reshape((7, 3)))
+    with pytest.warns(
+        np.VisibleDeprecationWarning, match="Property `data_dim` is deprecated and "
+    ):
+        assert o3d.data_dim == 1

--- a/orix/tests/test_object3d.py
+++ b/orix/tests/test_object3d.py
@@ -154,10 +154,6 @@ def test_shape(object3d):
     assert object3d.shape == object3d.data.shape[:-1]
 
 
-def test_data_dim(object3d):
-    assert object3d.data_dim == len(object3d.data.shape[:-1])
-
-
 def test_ndim(object3d):
     assert object3d.ndim == len(object3d.data.shape[:-1])
 
@@ -176,7 +172,7 @@ def test_stack(object3d, n):
 def test_flatten(object3d):
     flat = object3d.flatten()
     assert isinstance(flat, object3d.__class__)
-    assert flat.data_dim == 1
+    assert flat.ndim == 1
     assert flat.shape[0] == object3d.size
 
 
@@ -205,12 +201,3 @@ def test_get_random_sample(test_object3d):
 
     with pytest.raises(ValueError, match="Cannot draw a sample greater than 20"):
         _ = o3d.get_random_sample(21)
-
-
-@pytest.mark.parametrize("test_object3d", [3], indirect=["test_object3d"])
-def test_deprecation_warning_data_dim(test_object3d):
-    o3d = test_object3d(np.arange(21).reshape((7, 3)))
-    with pytest.warns(
-        np.VisibleDeprecationWarning, match="Property `data_dim` is deprecated and "
-    ):
-        assert o3d.data_dim == 1


### PR DESCRIPTION
#### Description of the change
Functions and properties previously deprecated and tagged for removal in release `0.9` have been removed. The changelog has been updated.

Question, `Misorientation.distance()` was not flagged for deprecation (whereas `Orientation.distance()` was. I believe we want to remove both here?

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)


#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
