### PR TITLE
Add orix data module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Added
   on the other hemisphere to the current hemisphere.
 - Notebook on clustering of misorientations across fundamental region boundaries added
   to the user guide from the orix-demos repository.
+- `orix.data` module with test data used in the user guide and tests.
 
 Changed
 -------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -206,23 +206,42 @@ framework. The tests reside in a ``test`` directory within each module. Tests ar
 methods that call functions in orix and compare resulting output values with known
 answers. Install necessary dependencies to run the tests::
 
-   $ pip install --editable .[tests]
+   pip install --editable .[tests]
 
 Some useful `fixtures <https://docs.pytest.org/en/latest/fixture.html>`_ are available
 in the ``conftest.py`` file.
 
 To run the tests::
 
-   $ pytest --cov --pyargs orix
+   pytest --cov --pyargs orix
 
 The ``--cov`` flag makes `coverage.py <https://coverage.readthedocs.io/en/latest/>`_
 print a nice report in the terminal. For an even nicer presentation, you can use
 ``coverage.py`` directly::
 
-   $ coverage html
+   coverage html
 
 Then, you can open the created ``htmlcov/index.html`` in the browser and inspect the
 coverage in more detail.
+
+Adding data to the data module
+==============================
+
+Test data for user guides and tests are included in the :mod:`orix.data` module via the
+`pooch <https://www.fatiando.org/pooch/latest>`_ Python library. These are listed in a
+file registry (`orix.data._registry.py`) with their file verification string (hash,
+SHA256, obtained with e.g. `sha256sum <file>`) and location, the latter potentially not
+within the package but from the `orix-data <https://github.com/pyxem/orix-data>`_
+repository, since some files are considered too large to include in the package.
+
+If a required dataset isn't in the package, but is in the registry, it can be downloaded
+from the repository when the user passes `allow_download=True` to e.g.
+`sdss_austenite()`. The dataset is then downloaded to a local cache, e.g.
+`/home/user/.cache/orix/`. The data cache directory can be set with a global
+`ORIX_DATA_DIR` variable locally, e.g. by setting export `ORIX_DATA_DIR=~/orix_data` in
+`~/.bashrc`. Pooch handles downloading, caching, version control, file verification
+(against hash) etc. If we have updated the file hash, pooch will re-download it. If the
+file is available in the cache, it can be loaded as the other files in the data module.
 
 Continuous integration (CI)
 ===========================

--- a/doc/crystal_map.ipynb
+++ b/doc/crystal_map.ipynb
@@ -24,9 +24,9 @@
     "\n",
     "Orientations and other properties acquired from a super-duplex stainless steel\n",
     "EBSD data set with two phases, austenite and ferrite, are used as example data.\n",
-    "The data is available here: http://folk.ntnu.no/hakonwii/files/orix-demos/,\n",
-    "courtesy of Prof. Jarle Hjelen (Norwegian University of Science and Technology,\n",
-    "Norway)."
+    "The data is downloaded via `orix.data` from\n",
+    "http://folk.ntnu.no/hakonwii/files/orix-demos/, courtesy of Prof. Jarle Hjelen\n",
+    "(Norwegian University of Science and Technology, Norway)."
    ]
   },
   {
@@ -38,18 +38,21 @@
    "source": [
     "%matplotlib inline\n",
     "\n",
+    "import tempfile\n",
+    "\n",
     "from diffpy.structure import Atom, Lattice, Structure\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
-    "from orix import plot\n",
+    "from orix import data, plot\n",
     "from orix.crystal_map import CrystalMap, Phase, PhaseList\n",
     "from orix.io import load, save\n",
     "from orix.quaternion import Orientation, Rotation, symmetry\n",
     "from orix.vector import Vector3d\n",
     "\n",
     "\n",
-    "plt.rcParams.update({\"figure.figsize\": (7, 7), \"font.size\": 15})"
+    "plt.rcParams.update({\"figure.figsize\": (7, 7), \"font.size\": 15})\n",
+    "tempdir = tempfile.mkdtemp() + \"/\""
    ]
   },
   {
@@ -82,25 +85,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56f5e1c5",
+   "id": "41783cca-cc61-4ee1-bba6-899a5f2b770d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "import tempfile\n",
-    "\n",
-    "tempdir = tempfile.mkdtemp() + \"/\"\n",
-    "fname = \"sdss_ferrite_austenite.ang\"\n",
-    "source = f\"https://folk.ntnu.no/hakonwii/files/orix-demos/{fname}\"\n",
-    "target = os.path.join(tempdir, fname)\n",
-    "\n",
-    "try:\n",
-    "    os.mkdir(tempdir)\n",
-    "except:\n",
-    "    pass\n",
-    "if not os.path.exists(target):\n",
-    "    import urllib.request\n",
-    "    urllib.request.urlretrieve(source, target)"
+    "xmap = data.sdss_ferrite_austenite(allow_download=True)"
    ]
   },
   {
@@ -120,7 +109,6 @@
    },
    "outputs": [],
    "source": [
-    "xmap = load(target)\n",
     "xmap.plot(overlay=\"dp\")  # Dot product values added to the alpha (RGBA) channel\n",
     "xmap"
    ]
@@ -136,20 +124,7 @@
     "pattern.\n",
     "\n",
     "The same `CrystalMap` object can be obtained by reading each array from the .ang\n",
-    "file ourselves and passing this to `CrystalMap.__init__()`\n",
-    "\n",
-    "Let's remove the duplicates in the phase names..."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3eb5a972",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "xmap.phases[1].name = \"austenite\"\n",
-    "xmap.phases[2].name = \"ferrite\""
+    "file ourselves and passing this to `CrystalMap.__init__()`"
    ]
   },
   {
@@ -159,8 +134,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Access *private* cache data path from module\n",
+    "_target = data.cache_data_path.joinpath(\"sdss/sdss_ferrite_austenite.ang\")\n",
+    "\n",
     "# Read each column from the file\n",
-    "euler1, euler2, euler3, x, y, iq, dp, phase_id = np.loadtxt(target, unpack=True)\n",
+    "euler1, euler2, euler3, x, y, iq, dp, phase_id = np.loadtxt(_target, unpack=True)\n",
     "\n",
     "# Create a Rotation object from Euler angles\n",
     "euler_angles = np.column_stack((euler1, euler2, euler3))\n",
@@ -1712,7 +1690,7 @@
     "# Remove files written to disk in this user guide\n",
     "import os\n",
     "for f in [\n",
-    "    target,\n",
+    "    _target,\n",
     "    tempdir + \"sdss_ferrite_austenite2.h5\",\n",
     "    tempdir + \"sdss_dp_ci.ang\",\n",
     "    tempdir + 'phase_map.png',\n",
@@ -1739,7 +1717,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -17,6 +17,7 @@ The list of top modules:
 
 .. autosummary::
     base
+    data
     crystal_map
     io
     plot
@@ -31,6 +32,22 @@ base
 ====
 .. automodule:: orix.base
     :members:
+
+....
+
+data
+====
+
+.. currentmodule:: orix.data
+
+.. autosummary::
+    sdss_austenite
+    sdss_ferrite_austenite
+..    ti_orientations
+
+.. automodule:: orix.data
+    :members:
+    :undoc-members:
 
 ....
 

--- a/orix/data/__init__.py
+++ b/orix/data/__init__.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2022 the orix developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test data.
+
+Some datasets must be downloaded from the web. For more test datasets,
+see :doc:`open datasets <open_datasets>`.
+"""
+
+import os
+from pathlib import Path
+
+# import numpy as np
+import pooch as ppooch
+
+from orix import __version__, io
+from orix.data._registry import registry, registry_urls
+
+# from orix.quaternion import Orientation, symmetry
+
+
+__all__ = [
+    "sdss_austenite",
+    "sdss_ferrite_austenite",
+    #    "ti_orientations",
+]
+
+
+fetcher = ppooch.create(
+    path=ppooch.os_cache("orix"),
+    base_url="",
+    version=__version__.replace(".dev", "+"),
+    env="ORIX_DATA_DIR",
+    registry=registry,
+    urls=registry_urls,
+)
+cache_data_path = fetcher.path.joinpath("data")
+package_data_path = Path(os.path.abspath(os.path.dirname(__file__)))
+
+
+def _has_hash(path, expected_hash):
+    """Check if the provided path has the expected hash."""
+    if not os.path.exists(path):
+        return False
+    else:
+        return ppooch.file_hash(path) == expected_hash  # pragma: no cover
+
+
+def _cautious_downloader(url, output_file, pooch):
+    if pooch.allow_download:
+        delattr(pooch, "allow_download")
+        # HTTPDownloader() requires tqdm
+        download = ppooch.HTTPDownloader(progressbar=True)
+        download(url, output_file, pooch)
+    else:
+        raise ValueError(
+            "The dataset must be (re)downloaded from the orix-data repository on GitHub"
+            " (https://github.com/pyxem/orix-data) to your local cache with the pooch "
+            "Python package. Pass `allow_download=True` to allow this download."
+        )
+
+
+def _fetch(filename, allow_download):
+    resolved_path = os.path.join(package_data_path, "..", filename)
+    expected_hash = registry[filename]
+    if _has_hash(resolved_path, expected_hash):  # File already in data module
+        return resolved_path  # pragma: no cover
+    else:  # Pooch must download the data to the local cache
+        fetcher.allow_download = allow_download  # Extremely ugly
+        resolved_path = fetcher.fetch(filename, downloader=_cautious_downloader)
+    return resolved_path
+
+
+def sdss_austenite(allow_download=False, **kwargs):
+    """Single phase Austenite crystallographic map of shape (100, 117)
+    produced from dictionary indexing of electron backscatter
+    diffraction patterns of a super duplex stainless steel (SDSS) sample
+    containing both Austenite and Ferrite grains.
+
+    Parameters
+    ----------
+    allow_download : bool, optional
+        Whether to allow downloading the dataset from the internet to
+        the local cache with the pooch Python package. Default is False.
+    kwargs
+        Keyword arguments passed to
+        :func:`~orix.io.plugins.emsoft_h5ebsd.file_reader`.
+
+    Returns
+    -------
+    CrystalMap
+    """
+    fname = _fetch("data/sdss/sdss_austenite_dp.h5", allow_download)
+    return io.load(fname, **kwargs)
+
+
+def sdss_ferrite_austenite(allow_download=False, **kwargs):
+    """Dual phase Austenite and Ferrite crystallographic map of shape
+    (100, 117) produced from dictionary indexing of electron backscatter
+    diffraction patterns of a super duplex stainless steel (SDSS)
+    sample.
+
+    Parameters
+    ----------
+    allow_download : bool, optional
+        Whether to allow downloading the dataset from the internet to
+        the local cache with the pooch Python package. Default is False.
+    kwargs
+        Keyword arguments passed to
+        :func:`~orix.io.plugins.ang.file_reader`.
+
+    Returns
+    -------
+    CrystalMap
+    """
+    fname = _fetch("data/sdss/sdss_ferrite_austenite.ang", allow_download)
+    xmap = io.load(fname, **kwargs)
+    xmap.phases["austenite/austenite"].name = "austenite"
+    xmap.phases["ferrite/ferrite"].name = "ferrite"
+    return xmap
+
+
+# def ti_orientations(allow_download=False):
+#    """Orientations in the MTEX orientation convention (crystal2lab)
+#    from an orientation map produced from Hough indexing of electron
+#    backscatter diffraction patterns of a commercially pure hexagonal
+#    close packed titanium sample (*6/mmm*) :cite:`johnstone2020density`.
+#
+#    Parameters
+#    ----------
+#    allow_download : bool, optional
+#        Whether to allow downloading the dataset from the internet to
+#        the local cache with the pooch Python package. Default is False.
+#
+#    Returns
+#    -------
+#    Orientations
+#    """
+#    fname = _fetch("data/ti_orientations/ti_orientations.ctf", allow_download)
+#    euler = np.loadtxt(fname, skiprows=1, usecols=(0, 1, 2))
+#    return Orientation.from_euler(np.deg2rad(euler), symmetry.D6)

--- a/orix/data/_registry.py
+++ b/orix/data/_registry.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2022 the orix developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+# fmt: off
+registry = {
+    "data/sdss/sdss_austenite_dp.h5": "a650c4b49cafd7019644952dbc8cbb85741119e0d69edbf8b030d50ad0fa855c",
+    "data/sdss/sdss_ferrite_austenite.ang": "ac2fc2fc2b8c9c598703c96f9888677bccc9cd88cddd5e78735653fd5504e371",
+#    "data/ti_orientations/ti_orientations.ctf": "ba1935a4d3cf03f4a81dad0bf3d1190eafb973715069310423a3eaa18fb8171b",
+}
+registry_urls = {
+    "data/sdss/sdss_austenite_dp.h5": "https://folk.ntnu.no/hakonwii/files/orix-demos/sdss_austenite_dp.h5",
+    "data/sdss/sdss_ferrite_austenite.ang": "https://folk.ntnu.no/hakonwii/files/orix-demos/sdss_ferrite_austenite.ang",
+#    "data/ti_orientations/ti_orientations.ctf": "https://drive.google.com/file/d/1GeQIN1FmxYij4HXaf6MH4b5Q9kT2CSn-/view?usp=sharing/Ti_orientations.ctf",
+}
+# fmt: on

--- a/orix/tests/data/__init__.py
+++ b/orix/tests/data/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2022 the orix developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.

--- a/orix/tests/data/test_data.py
+++ b/orix/tests/data/test_data.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2022 the orix developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+import pytest
+
+from orix import data
+from orix.crystal_map import CrystalMap
+
+# from orix.quaternion import Orientation, symmetry
+
+
+class TestData:
+    def test_load_sdss_ferrite_austenite(self):
+        """The file can be read."""
+        xmap = data.sdss_ferrite_austenite(allow_download=True)
+        assert isinstance(xmap, CrystalMap)
+        assert xmap.phases.names == ["austenite", "ferrite"]
+        assert xmap.shape == (100, 117)
+
+    def test_load_sdss_austenite_kwargs(self):
+        """Keyword arguments are passed."""
+        xmap_di = data.sdss_austenite(allow_download=True)
+        xmap_ref = data.sdss_austenite(refined=True)
+
+        assert xmap_di.rotations_per_point == 50
+        assert xmap_ref.rotations_per_point == 1
+
+    def test_load_raises(self):
+        """Raises desired error message."""
+        name = "sdss_ferrite_austenite.ang"
+        file = data.cache_data_path.joinpath("sdss/" + name)
+
+        # Remove file (dangerous!)
+        removed = False
+        if file.exists():  # pragma: no cover
+            os.remove(file)
+            removed = True
+
+        with pytest.raises(ValueError, match="The dataset must be"):
+            _ = data.sdss_ferrite_austenite(allow_download=False)
+
+        # Re-download file if removed
+        if removed:  # pragma: no cover
+            _ = data.sdss_ferrite_austenite(allow_download=True)
+
+
+#    def test_load_ti_orientations(self):
+#        """The file can be read."""
+#        g = data.ti_orientations()
+#        assert isinstance(g, Orientation)
+#        assert g.symmetry == symmetry.D6

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         "numba",
         "numpy",
         "numpy-quaternion",
+        "pooch                  >= 0.13",
         "scipy",
         "tqdm",
     ],


### PR DESCRIPTION
#### Description of the change
Add `orix.data` module as suggested in #149. Data sets, like instances of `CrystalMap`, `Orientation` etc., used in tests and/or user guide notebooks can be conveniently (down)loaded from the module. Whenever a data set is desired, e.g. by calling `orix.data.sdss_austenite()`, a registry is checked for the file location in the local cache (by default ~/.cache/orix, but can be set via a global variable `ORIX_DATA_DIR`) and loaded if it is there. If it's not in the cache, it is downloaded from an HTTPS address to the local cache, provided that `allow_download=True` is passed to the function. File hashes are hard-coded in the registry, preventing harmful files being downloaded, and also making sure that a file is re-downloaded whenever we change the hash in the registry and online. The implemented approach is used in e.g. [kikuchipy.data](https://kikuchipy.org/en/stable/reference.html#module-kikuchipy.data) and [skimage.data](https://scikit-image.org/docs/stable/api/skimage.data.html#module-skimage.data).

This requires a new dependency, [`pooch`](https://github.com/fatiando/pooch): it has a BSD3 license and is [lightweight](https://github.com/fatiando/pooch/blob/7ddc04505de237c7bc8b50c01ad7bc05d440646a/setup.cfg#L37-L46). If people really want to, we can make this dependency optional via a `orix[data]` extra requirement set in setup.py.

So far, only two data sets, from EBSD of super duplex stainless steel (SDSS), are added to the module: `orix.data.sdss_austenite()` (orix HDF5 file) and `orix.data.sdss_ferrite_austenite()` (.ang file). They are downloaded upon request from [here](https://folk.ntnu.no/hakonwii/files/orix-demos/). The latter data set is used in the crystal map user guide. It was previously downloaded with urllib rather inconveniently, but is now downloaded with one call to `sdss_ferrite_austenite(allow_download=True)` (see docs built from this PR).

Google provides a new file hash for "Ti_orientations.ctf" every time it is downloaded from Google Drive, preventing it from being downloaded from `orix.data`. We should add this file to an `orix-data` repo, similar to https://github.com/pyxem/kikuchipy-data. All code lines are added but commented out for a `orix.data.ti_orientations()` function.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> from orix import data

# Create new local data directory and download file here
>>> xmap = data.sdss_ferrite_austenite(allow_download=True)
Downloading file 'data/sdss/sdss_ferrite_austenite.ang' from 'https://folk.ntnu.no/hakonwii/files/orix-demos/sdss_ferrite_austenite.ang' to '/home/hakon/.cache/orix/master'.
100%|████████████████████████████████████████| 652k/652k [00:00<00:00, 967MB/s]
>>> xmap
Phase   Orientations       Name  Space group  Point group  Proper point group       Color
    1   5657 (48.4%)  austenite         None          432                 432    tab:blue
    2   6043 (51.6%)    ferrite         None          432                 432  tab:orange
Properties: iq, dp
Scan unit: um

>>> xmap_di = data.sdss_austenite(allow_download=True)
Downloading file 'data/sdss/sdss_austenite_dp.h5' from 'https://folk.ntnu.no/hakonwii/files/orix-demos/sdss_austenite_dp.h5' to '/home/hakon/.cache/orix/master'.
100%|█████████████████████████████████████| 10.8M/10.8M [00:00<00:00, 13.0GB/s]
>>> xmap_di
Phase    Orientations       Name  Space group  Point group  Proper point group     Color
    0  11700 (100.0%)  austenite         None         m-3m                 432  tab:blue
Properties: AvDotProductMap, CI, IQ, ISM, KAM, OSM, RefinedDotProducts, TopDotProductList, TopMatchIndices
Scan unit: um

# Reload data from cache, also passing kwargs on to orix.io.plugins.orix_hdf5.file_reader()

>>> xmap_ref = data.sdss_austenite(refined=True)
>>> xmap_ref
Phase    Orientations       Name  Space group  Point group  Proper point group     Color
    0  11700 (100.0%)  austenite         None         m-3m                 432  tab:blue
Properties: AvDotProductMap, CI, IQ, ISM, KAM, OSM, RefinedDotProducts, TopDotProductList, TopMatchIndices
Scan unit: um
>>> xmap_di.rotations_per_point
50
>>> xmap_ref.rotations_per_point
1
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
