### PR TITLE
Add Dask-based lazy computation of quaternion-vector outer product

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Unreleased
 
 Added
 -----
+- Dask implementation of the `Quaternion` - `Vector3d` outer product.
 - Point group `Symmetry` elements can now be viewed under the stereographic projection
   using `Symmetry.plot()`. The notebook point_groups.ipynb has been added to the
   documentation.

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -58,11 +58,11 @@ class Quaternion(Object3d):
     :math:`v' = q * v * q^{-1}` and follows as:
 
     .. math::
-       v'_x = x(a^2 + b^2 - c^2 - d^2) + 2z(a * c + b * d) + y(b * c - a * d)
+       v'_x = x(a^2 + b^2 - c^2 - d^2) + 2(z(a * c + b * d) + y(b * c - a * d))
 
-       v'_y = y(a^2 - b^2 + c^2 - d^2) + 2x(a * d + b * c) + z(c * d - a * b)
+       v'_y = y(a^2 - b^2 + c^2 - d^2) + 2(x(a * d + b * c) + z(c * d - a * b))
 
-       v'_z = z(a^2 - b^2 - c^2 + d^2) + 2y(a * b + c * d) + x(b * d - a * c)
+       v'_z = z(a^2 - b^2 - c^2 + d^2) + 2(y(a * b + c * d) + x(b * d - a * c))
 
     Attributes
     ----------
@@ -258,17 +258,18 @@ class Quaternion(Object3d):
 
     def _outer_dask(self, other, chunk_size=20):
         """Compute the product of every quaternion in this instance to
-        every quaternion in another instance, returned as a Dask array.
+        every quaternion or vector in another instance, returned as a
+        Dask array.
 
-        This is also known as the Hamilton product.
+        For quaternion-quaternion multiplication, this is known as the
+        Hamilton product.
 
         Parameters
         ----------
-        other : orix.quaternion.Quaternion
+        other : orix.quaternion.Quaternion or orix.vector.Vector3d
         chunk_size : int, optional
-            Number of quaternions per axis in each quaternion instance
-            to include in each iteration of the computation. Default is
-            20.
+            Number of objects per axis for each input to include in each
+            iteration of the computation. Default is 20.
 
         Returns
         -------
@@ -276,9 +277,15 @@ class Quaternion(Object3d):
 
         Notes
         -----
-        To get a new quaternion from the returned array `qarr`, do
-        `q = Quaternion(qarr.compute())`.
+        For quaternion-quaternion multiplication, to create a new
+        quaternion from the returned array `arr`, do
+        `q = Quaternion(arr.compute())`. Likewise for quaternion-vector
+        multiplication, to create a new vector from the returned array
+        do `v = Vector3d(arr.compute())`.
         """
+        if not isinstance(other, (Quaternion, Vector3d)):
+            raise TypeError("Other must be Quaternion or Vector3d.")
+
         ndim1 = len(self.shape)
         ndim2 = len(other.shape)
 
@@ -286,49 +293,72 @@ class Quaternion(Object3d):
         chunks1 = (chunk_size,) * ndim1 + (-1,)
         chunks2 = (chunk_size,) * ndim2 + (-1,)
 
-        # Get quaternion parameters as dask arrays to be computed later
-        q1 = da.from_array(self.data, chunks=chunks1)
-        a1, b1, c1, d1 = q1[..., 0], q1[..., 1], q1[..., 2], q1[..., 3]
-        q2 = da.from_array(other.data, chunks=chunks2)
-        a2, b2, c2, d2 = q2[..., 0], q2[..., 1], q2[..., 2], q2[..., 3]
-
         # Dask has no dask.multiply.outer(), use dask.array.einsum
         # Summation subscripts
         str1 = "abcdefghijklm"[:ndim1]  # Max. object dimension of 13
         str2 = "nopqrstuvwxyz"[:ndim2]
         sum_over = f"...{str1},{str2}...->{str1 + str2}"
 
+        # Get quaternion parameters as dask arrays to be computed later
+        q1 = da.from_array(self.data, chunks=chunks1)
+        a1, b1, c1, d1 = q1[..., 0], q1[..., 1], q1[..., 2], q1[..., 3]
+
         # We silence dask's einsum performance warnings for "small"
         # chunk sizes, since using the chunk sizes suggested floods
         # memory
         warnings.filterwarnings("ignore", category=da.PerformanceWarning)
 
-        # fmt: off
-        a = (
-            + da.einsum(sum_over, a1, a2)
-            - da.einsum(sum_over, b1, b2)
-            - da.einsum(sum_over, c1, c2)
-            - da.einsum(sum_over, d1, d2)
-        )
-        b = (
-            + da.einsum(sum_over, b1, a2)
-            + da.einsum(sum_over, a1, b2)
-            - da.einsum(sum_over, d1, c2)
-            + da.einsum(sum_over, c1, d2)
-        )
-        c = (
-            + da.einsum(sum_over, c1, a2)
-            + da.einsum(sum_over, d1, b2)
-            + da.einsum(sum_over, a1, c2)
-            - da.einsum(sum_over, b1, d2)
-        )
-        d = (
-            + da.einsum(sum_over, d1, a2)
-            - da.einsum(sum_over, c1, b2)
-            + da.einsum(sum_over, b1, c2)
-            + da.einsum(sum_over, a1, d2)
-        )
-        # fmt: on
+        if isinstance(other, Quaternion):
+            q2 = da.from_array(other.data, chunks=chunks2)
+            a2, b2, c2, d2 = q2[..., 0], q2[..., 1], q2[..., 2], q2[..., 3]
+            # fmt: off
+            a = (
+                + da.einsum(sum_over, a1, a2)
+                - da.einsum(sum_over, b1, b2)
+                - da.einsum(sum_over, c1, c2)
+                - da.einsum(sum_over, d1, d2)
+            )
+            b = (
+                + da.einsum(sum_over, b1, a2)
+                + da.einsum(sum_over, a1, b2)
+                - da.einsum(sum_over, d1, c2)
+                + da.einsum(sum_over, c1, d2)
+            )
+            c = (
+                + da.einsum(sum_over, c1, a2)
+                + da.einsum(sum_over, d1, b2)
+                + da.einsum(sum_over, a1, c2)
+                - da.einsum(sum_over, b1, d2)
+            )
+            d = (
+                + da.einsum(sum_over, d1, a2)
+                - da.einsum(sum_over, c1, b2)
+                + da.einsum(sum_over, b1, c2)
+                + da.einsum(sum_over, a1, d2)
+            )
+            # fmt: on
+            out = da.stack((a, b, c, d), axis=-1)
+        else:  # Vector3d
+            v2 = da.from_array(other.data, chunks=chunks2)
+            x2, y2, z2 = v2[..., 0], v2[..., 1], v2[..., 2]
+            # fmt: off
+            x = (
+                + da.einsum(sum_over, a1**2 + b1**2 - c1**2 - d1**2, x2)
+                + da.einsum(sum_over, a1 * c1 + b1 * d1, z2) * 2
+                + da.einsum(sum_over, b1 * c1 - a1 * d1, y2) * 2
+            )
+            y = (
+                + da.einsum(sum_over, a1**2 - b1**2 + c1**2 - d1**2, y2)
+                + da.einsum(sum_over, a1 * d1 + b1 * c1, x2) * 2
+                + da.einsum(sum_over, c1 * d1 - a1 * b1, z2) * 2
+            )
+            z = (
+                + da.einsum(sum_over, a1**2 - b1**2 - c1**2 + d1**2, z2)
+                + da.einsum(sum_over, a1 * b1 + c1 * d1, y2) * 2
+                + da.einsum(sum_over, b1 * d1 - a1 * c1, x2) * 2
+            )
+            # fmt: on
+            out = da.stack((x, y, z), axis=-1)
 
         new_chunks = tuple(chunks1[:-1]) + tuple(chunks2[:-1]) + (-1,)
-        return da.stack((a, b, c, d), axis=-1).rechunk(new_chunks)
+        return out.rechunk(new_chunks)


### PR DESCRIPTION
#### Description of the change
There is already a Dask-based implementation of the quaternion-quaternion outer product, but currently no such implementation for quaternion-vector outer products. In this PR no new functions are added, but `Quaternion._outer_dask()` will now also work with `Vector3d` inputs, which is consistent with the behaviour of `Quaternion.outer()`.

I have also corrected the missing parentheses in the `Quaternion` docstring relating to quaternion-vector multiplication introduced when we switched to `numpy-quaternion` in #281 [here](https://github.com/pyxem/orix/pull/281/files#diff-5fa95cd8f92d9bc27b217689cd19a42fbf336678e6e4c2354f63a5fc37a512acL113-L124) (sorry about that).

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> from orix.vector import Vector3d
>>> from orix.quaternion import Quaternion
>>> import numpy as np
>>> v = Vector3d(np.random.rand(7, 5, 3)).unit
>>> q = Quaternion(np.random.rand(6, 2, 4)).unit
>>> arr = q._outer_dask(v)
>>> type(arr)
dask.array.Array
>>> v_new = Vector3d(arr.compute())
>>> v_new.shape
(6, 2, 7, 5)
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
