### PR TITLE
Describe and simplify crystal reference frame, restructure user guide

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,8 @@ Added
 - `orix.data` module with test data used in the user guide and tests.
 - `Misorientation.get_distance_matrix()` for memory-efficient calculation of a
   misorientation angle (geodesic distance) matrix between misorientations using Dask.
+- Clarification of crystal axes alignment in documentation.
+- Creation of a `Phase` instance from a CIF file.
 
 Changed
 -------
@@ -46,6 +48,7 @@ Changed
   which is consistent with the default `"crystal2lab"` direction in
   `MTEX <https://mtex-toolbox.github.io/MTEXvsBungeConvention.html>`_.
 - `S4` (-4) `Symmetry` has been corrected.
+- Organized user guide documentation into topics.
 
 Deprecated
 ----------

--- a/doc/bibliography.bib
+++ b/doc/bibliography.bib
@@ -1,3 +1,18 @@
+@article{britton2016tutorial,
+	author = {Britton, T. B. and Jiang, J. and Guo, Y. and Vilalta-Clemente, A. and Wallis, D. and Hansen, L. N. and Winkelmann, A. and Wilkinson, A. J.},
+	doi = {10.1016/j.matchar.2016.04.008},
+	isbn = {1044-5803},
+	issn = {10445803},
+	journal = {Materials Characterization},
+	keywords = {Crystal orientation, Electron backscatter diffraction, Electron microscopy, Texture, ebsd, indexing},
+	mendeley-tags = {ebsd,indexing},
+	pages = {113–126},
+	publisher = {The Authors},
+	title = {{Tutorial: Crystal orientations and EBSD - Or which way is up?}},
+	url = {http://dx.doi.org/10.1016/j.matchar.2016.04.008},
+	volume = {117},
+	year = {2016}
+}
 @book{degraef2003introduction,
 	author = {{De Graef}, Marc},
 	publisher = {Cambridge university press},

--- a/doc/clustering_across_fundamental_region_boundaries.ipynb
+++ b/doc/clustering_across_fundamental_region_boundaries.ipynb
@@ -231,6 +231,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "nbsphinx-thumbnail": {
+     "tooltip": "Density based clustering of crystal orientations with and without crystal symmetry"
+    },
     "tags": [
      "nbsphinx-thumbnail"
     ]
@@ -287,7 +290,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/doc/clustering_misorientations.ipynb
+++ b/doc/clustering_misorientations.ipynb
@@ -482,6 +482,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "nbsphinx-thumbnail": {
+     "tooltip": "Density based clustering of crystal misorientations"
+    },
     "tags": [
      "nbsphinx-thumbnail"
     ]

--- a/doc/clustering_of_orientations.rst
+++ b/doc/clustering_of_orientations.rst
@@ -1,0 +1,13 @@
+===============================
+Clustering of (mis)orientations
+===============================
+
+These guides show how to segment crystallographic map points into clusters based on the
+(mis)orientation distances. This functionality was why ``orix`` was initially written.
+
+.. nbgallery::
+    :hidden:
+
+    clustering_across_fundamental_region_boundaries.ipynb
+    clustering_orientations.ipynb
+    clustering_misorientations.ipynb

--- a/doc/clustering_orientations.ipynb
+++ b/doc/clustering_orientations.ipynb
@@ -519,6 +519,9 @@
    "cell_type": "code",
    "execution_count": 18,
    "metadata": {
+    "nbsphinx-thumbnail": {
+     "tooltip": "Density based clustering of crystal orientations"
+    },
     "tags": [
      "nbsphinx-thumbnail"
     ]

--- a/doc/crystal_directions.ipynb
+++ b/doc/crystal_directions.ipynb
@@ -15,7 +15,7 @@
    "id": "a6c24bbd",
    "metadata": {},
    "source": [
-    "# Crystal geometry\n",
+    "# Crystal vectors\n",
     "\n",
     "This notebook details how to perform operations with and plot directions with\n",
     "respect to the crystal reference system using Miller indices with the\n",
@@ -1050,7 +1050,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/doc/crystal_directions.ipynb
+++ b/doc/crystal_directions.ipynb
@@ -15,7 +15,7 @@
    "id": "a6c24bbd",
    "metadata": {},
    "source": [
-    "# Crystal vectors\n",
+    "# Crystal directions\n",
     "\n",
     "This notebook details how to perform operations with and plot directions with\n",
     "respect to the crystal reference system using Miller indices with the\n",
@@ -1021,6 +1021,9 @@
    "execution_count": null,
    "id": "554ec00e",
    "metadata": {
+    "nbsphinx-thumbnail": {
+     "tooltip": "Operating with vectors in the crystal and sample reference frames"
+    },
     "tags": [
      "nbsphinx-thumbnail"
     ]

--- a/doc/crystal_geometry.rst
+++ b/doc/crystal_geometry.rst
@@ -1,0 +1,15 @@
+================
+Crystal geometry
+================
+
+These guides describe conventions for the unit cell, symmetry operations and relevant
+reference frames, and also show how to operate with vectors in the crystal and sample
+reference frames.
+
+.. nbgallery::
+    :hidden:
+
+    crystal_reference_frame.ipynb
+    crystal_directions.ipynb
+    point_groups.ipynb
+    inverse_pole_figures.ipynb

--- a/doc/crystal_map.ipynb
+++ b/doc/crystal_map.ipynb
@@ -1347,6 +1347,9 @@
    "execution_count": null,
    "id": "6cdefa8a-6394-40d4-9fff-88ade1a28438",
    "metadata": {
+    "nbsphinx-thumbnail": {
+     "tooltip": "Handling and manipulation of crystallographic data"
+    },
     "tags": [
      "nbsphinx-thumbnail"
     ]

--- a/doc/crystal_reference_frame.ipynb
+++ b/doc/crystal_reference_frame.ipynb
@@ -16,7 +16,7 @@
     "# Crystal reference frame\n",
     "\n",
     "This notebook describes the alignment of crystal reference frames and symmetry\n",
-    "operations in orix."
+    "operations in `orix`."
    ]
   },
   {
@@ -30,18 +30,28 @@
     "\n",
     "from diffpy.structure import Atom, Lattice, Structure\n",
     "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
     "\n",
     "from orix.crystal_map import Phase\n",
+    "from orix.quaternion import Rotation\n",
     "from orix.vector import Miller\n",
     "\n",
     "\n",
     "plt.rcParams.update({\n",
-    "    \"figure.figsize\": (7, 7),\n",
+    "    \"figure.figsize\": (10, 5),\n",
     "    \"font.size\": 20,\n",
     "    \"axes.grid\": True,\n",
     "    \"lines.markersize\": 10,\n",
     "    \"lines.linewidth\": 3,\n",
     "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "753aee99-22bd-4808-b3cf-b7e7616411b8",
+   "metadata": {},
+   "source": [
+    "## Alignment and the structure matrix"
    ]
   },
   {
@@ -80,20 +90,21 @@
     "option is $\\mathbf{e_1} || \\mathbf{a^*}/a^*$, $\\mathbf{e_2} ||\n",
     "\\mathbf{e_3} \\times \\mathbf{e_1}$, $\\mathbf{e_3} || \\mathbf{c}/c$, which is used\n",
     "for example in\n",
-    "<cite data-cite=\"britton2016tutorial\">Britton et al. (2016)</cite>.\n",
+    "<cite data-cite=\"britton2016tutorial\">Britton et al. (2016)</cite> and the\n",
+    "`diffpy.structure` Python package, which we'll come back to.\n",
     "\n",
     "In calculations, it is useful to describe the transformation of the Cartesian\n",
-    "unit column vectors to the coordinates of the direct lattice vectors by the\n",
-    "structure matrix $\\mathbf{A}$ (also called the crystal *base*). Given the chosen\n",
-    "alignment of basis vectors with the Cartesian reference frame, $\\mathbf{A}$ is\n",
-    "defined as\n",
+    "unit *row* vectors to the coordinates of the direct lattice vectors by the\n",
+    "structure (row) matrix $\\mathbf{A}$ (also called the crystal *base*). Given the\n",
+    "chosen alignment of basis vectors with the Cartesian reference frame,\n",
+    "$\\mathbf{A}$ is defined as\n",
     "\n",
     "\\begin{equation}\n",
     "\\mathbf{A} = \n",
     "\\begin{pmatrix}\n",
-    "a & b\\cos\\gamma & c\\cos\\beta\\\\\n",
-    "0 & b\\sin\\gamma & -c\\frac{(\\cos\\beta\\cos\\gamma - \\cos\\alpha)}{\\sin\\gamma}\\\\\n",
-    "0 & 0 & \\frac{\\mathrm{V}}{ab\\sin\\gamma}\n",
+    "a & 0 & 0\\\\\n",
+    "b\\cos\\gamma & b\\sin\\gamma & 0\\\\\n",
+    "c\\cos\\beta & -c\\frac{(\\cos\\beta\\cos\\gamma - \\cos\\alpha)}{\\sin\\gamma} & \\frac{\\mathrm{V}}{ab\\sin\\gamma}\n",
     "\\end{pmatrix},\n",
     "\\end{equation}\n",
     "\n",
@@ -101,7 +112,9 @@
     "\n",
     "In `orix`, we use the\n",
     "[Lattice](https://www.diffpy.org/diffpy.structure/mod_lattice.html#diffpy.structure.lattice.Lattice)\n",
-    "class in `diffpy.structure` to keep track of these properties internally"
+    "class in `diffpy.structure` to keep track of these properties internally. Let's\n",
+    "create a triclinic crystal with lattice parameters $(a, b, c)$ = (2, 3, 4) nm\n",
+    "and ($\\alpha, \\beta, \\gamma$) = $(70^{\\circ}, 100^{\\circ}, 120^{\\circ})$"
    ]
   },
   {
@@ -111,8 +124,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lattice = Lattice(1.7, 1.7, 1.4, 90, 90, 120)\n",
-    "lattice"
+    "lat = Lattice(2, 3, 4, 70, 100, 120)\n",
+    "lat"
    ]
   },
   {
@@ -120,8 +133,7 @@
    "id": "932dcf90-8f5d-4e22-a121-d5676614b028",
    "metadata": {},
    "source": [
-    "However, by default, `diffpy.structure` uses the other mentioned alignment above,\n",
-    "which is clear from inspecting the structure matrix"
+    "`diffpy.structure` stores the structure matrix in the `Lattice.base` property"
    ]
   },
   {
@@ -131,17 +143,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lattice.base"
+    "lat.base"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "de92cd06-9408-4a03-81ca-b4ba3376451e",
+   "id": "bc67a5a6-3407-4bb6-b03a-58958eceb024",
    "metadata": {},
    "source": [
-    "Thus, the alignment is updated whenever a\n",
-    "[Phase](reference.rst#orix.crystal_map.Phase) is created, which bring\n",
-    "together this crystal lattice and a\n",
+    "and we see that `diffpy.structure` does not use the `orix` alignment mentioned\n",
+    "above, since since $\\mathbf{e1} \\nparallel \\mathbf{a} / a$. Instead, we see that\n",
+    "$\\mathbf{e3} \\nparallel \\mathbf{c} / c$. This is in line with the alternative\n",
+    "alignment mentioned above.\n",
+    "\n",
+    "Thus, the alignment is updated internally whenever a\n",
+    "[Phase](reference.rst#orix.crystal_map.Phase) is created, a class which brings\n",
+    "together this crystal lattice and a point group\n",
     "[Symmetry](reference.rst#orix.quaternion.Symmetry)"
    ]
   },
@@ -152,8 +169,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "phase = Phase(point_group=\"321\", structure=Structure(lattice=lattice))\n",
+    "phase = Phase(point_group=\"321\", structure=Structure(lattice=lat))\n",
     "phase.structure.lattice.base"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e35f63a1-1008-41e0-a2e7-fcc54695de98",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-warning\">\n",
+    "\n",
+    "Warning\n",
+    "\n",
+    "Using another alignment than the one described above has undefined behaviour in\n",
+    "orix. Therefore, it is important that the structure matrix of a `Phase` instance\n",
+    "is not changed.\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -167,9 +200,9 @@
     "    \n",
     "The lattice is included in a\n",
     "[Structure](https://www.diffpy.org/diffpy.structure/package.html#diffpy.structure.structure.Structure)\n",
-    "which adds\n",
-    "[atoms](https://www.diffpy.org/diffpy.structure/mod_atom.html#diffpy.structure.atom.Atom)\n",
-    "to the lattice, which is useful when simulating diffraction.\n",
+    "because the latter class brings together a lattice and\n",
+    "[atoms](https://www.diffpy.org/diffpy.structure/mod_atom.html#diffpy.structure.atom.Atom),\n",
+    "which is useful when simulating diffraction.\n",
     "\n",
     "</div>"
    ]
@@ -179,8 +212,8 @@
    "id": "c3b093cb-aad7-45e2-9148-d63d66eb389b",
    "metadata": {},
    "source": [
-    "We can inspect the alignment of the direct and reciprocal lattice basis vectors\n",
-    "with the Cartesian reference frame in the stereographic projection"
+    "We can visualize the alignment of the direct and reciprocal lattice basis\n",
+    "vectors with the Cartesian reference frame using the stereographic projection"
    ]
   },
   {
@@ -201,8 +234,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = abc.scatter(c=[\"r\", \"g\", \"b\"], marker=\"o\", return_figure=True, axes_labels=[\"e1\", \"e2\"])\n",
+    "fig = abc.scatter(c=[\"r\", \"g\", \"b\"], marker=\"o\", return_figure=True, axes_labels=[\"e1\", \"e2\"], hemisphere=\"both\")\n",
     "abcr.scatter(c=[\"r\", \"g\", \"b\"], marker=\"x\", s=300, figure=fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7eae7ba-6fd6-44e2-b08d-4504cbc42d65",
+   "metadata": {},
+   "source": [
+    "## Alignment of symmetry operations"
    ]
   },
   {
@@ -210,7 +251,10 @@
    "id": "70881e04-c169-4b75-9f0f-81bf4bf6fca9",
    "metadata": {},
    "source": [
-    "The crystal symmetry operations are aligned with the direct crystal lattice"
+    "To see where the crystallographic axes about which the point group symmetry\n",
+    "operations rotate, we can add symmetry operations to the figure, like is done\n",
+    "in the [Visualizing point groups](point_groups.ipynb) user guide for all point\n",
+    "groups supported in `orix`"
    ]
   },
   {
@@ -227,8 +271,63 @@
    },
    "outputs": [],
    "source": [
-    "phase.point_group.plot(figure=fig)\n",
+    "ori = Rotation.from_axes_angles((0, 1, 0), np.deg2rad(65))\n",
+    "phase.point_group.plot(figure=fig, orientation=ori, fc=\"none\", ec=\"C0\", s=150)\n",
     "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8698c76b-8b01-463f-ab76-3233a2b23912",
+   "metadata": {},
+   "source": [
+    "## Converting crystal vectors"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dee304a4-f305-4554-9cf2-127934286960",
+   "metadata": {},
+   "source": [
+    "The reference frame of the stereographic projection above is the Cartesian\n",
+    "reference frame ($\\mathbf{e_1}, \\mathbf{e_2}, \\mathbf{e_3}$). The Cartesian\n",
+    "coordinates $(\\mathbf{x}, \\mathbf{y}, \\mathbf{z})$ of\n",
+    "$(\\mathbf{a}, \\mathbf{b}, \\mathbf{c})$ and\n",
+    "$(\\mathbf{a^*}, \\mathbf{b^*}, \\mathbf{c^*})$ were found using $\\mathbf{A}$ in\n",
+    "the following conversions\n",
+    "\n",
+    "\\begin{align}\n",
+    "(x, y, z) &= [uvw] \\cdot \\mathbf{A},\\\\\n",
+    "(x, y, z) &= (hkl) \\cdot (\\mathbf{A}^{-1})^T.\n",
+    "\\end{align}\n",
+    "\n",
+    "Let's compute the internal conversions directly and check for equality"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5690186c-af02-4b14-8742-a7f98f66159c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.allclose(\n",
+    "    abc.data,  # (x, y, z)\n",
+    "    np.dot(abc.uvw, phase.structure.lattice.base)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c08f6f6c-e39d-4e25-b398-e99f37ee22ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.allclose(\n",
+    "    abcr.data,  # (x, y, z)\n",
+    "    np.dot(abcr.hkl, np.linalg.inv(phase.structure.lattice.base).T)\n",
+    ")"
    ]
   }
  ],

--- a/doc/crystal_reference_frame.ipynb
+++ b/doc/crystal_reference_frame.ipynb
@@ -59,7 +59,7 @@
    "id": "61084d0b-a023-4cbb-a0d3-7cb0f766575e",
    "metadata": {},
    "source": [
-    "The (direct) Bravais lattice is characterized by basis vectors ($\\mathbf{a},\n",
+    "The direct Bravais lattice is characterized by basis vectors ($\\mathbf{a},\n",
     "\\mathbf{b}, \\mathbf{c}$) with unit cell edge lengths ($a$, $b$, $c$) and angles\n",
     "($\\alpha$, $\\beta$, $\\gamma$). The reciprocal lattice has basis vectors given by\n",
     "\n",
@@ -72,7 +72,7 @@
     "with reciprocal lattice parameters ($a^*$, $b^*$, $c^*$) and angles ($\\alpha^*$,\n",
     "$\\beta^*$, $\\gamma^*$).\n",
     "\n",
-    "Using these two crystallographic lattices, we define a standard Cartesian\n",
+    "Using these two crystallographic lattices, we can define a standard Cartesian\n",
     "(orthonormal) reference frame by the unit vectors ($\\mathbf{e_1}, \\mathbf{e_2},\n",
     "\\mathbf{e_3}$). In principle, the direct lattice reference frame can be oriented\n",
     "arbitrarily in the Cartesian reference frame. In `orix` we have chosen\n",
@@ -95,7 +95,7 @@
     "\n",
     "In calculations, it is useful to describe the transformation of the Cartesian\n",
     "unit *row* vectors to the coordinates of the direct lattice vectors by the\n",
-    "structure (row) matrix $\\mathbf{A}$ (also called the crystal *base*). Given the\n",
+    "structure *row* matrix $\\mathbf{A}$ (also called the crystal *base*). Given the\n",
     "chosen alignment of basis vectors with the Cartesian reference frame,\n",
     "$\\mathbf{A}$ is defined as\n",
     "\n",
@@ -113,8 +113,8 @@
     "In `orix`, we use the\n",
     "[Lattice](https://www.diffpy.org/diffpy.structure/mod_lattice.html#diffpy.structure.lattice.Lattice)\n",
     "class in `diffpy.structure` to keep track of these properties internally. Let's\n",
-    "create a triclinic crystal with lattice parameters $(a, b, c)$ = (2, 3, 4) nm\n",
-    "and ($\\alpha, \\beta, \\gamma$) = $(70^{\\circ}, 100^{\\circ}, 120^{\\circ})$"
+    "create a trigonal crystal with lattice parameters $(a, b, c)$ = (1.7, 1.7, 1.4)\n",
+    "nm and ($\\alpha, \\beta, \\gamma$) = $(90^{\\circ}, 90^{\\circ}, 120^{\\circ})$"
    ]
   },
   {
@@ -124,8 +124,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lat = Lattice(2, 3, 4, 70, 100, 120)\n",
-    "lat"
+    "lattice = Lattice(1.7, 1.7, 1.4, 90, 90, 120)\n",
+    "lattice"
    ]
   },
   {
@@ -143,7 +143,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lat.base"
+    "lattice.base"
    ]
   },
   {
@@ -152,9 +152,9 @@
    "metadata": {},
    "source": [
     "and we see that `diffpy.structure` does not use the `orix` alignment mentioned\n",
-    "above, since since $\\mathbf{e1} \\nparallel \\mathbf{a} / a$. Instead, we see that\n",
-    "$\\mathbf{e3} \\mathbf{c} / c$. This is in line with the alternative alignment\n",
-    "mentioned above.\n",
+    "above, since $\\mathbf{e1} \\nparallel \\mathbf{a} / a$. Instead, we see that\n",
+    "$\\mathbf{e3} \\parallel \\mathbf{c} / c$, which is in line with the alternative\n",
+    "alignment mentioned above.\n",
     "\n",
     "Thus, the alignment is updated internally whenever a\n",
     "[Phase](reference.rst#orix.crystal_map.Phase) is created, a class which brings\n",
@@ -169,7 +169,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "phase = Phase(point_group=\"321\", structure=Structure(lattice=lat))\n",
+    "phase = Phase(point_group=\"321\", structure=Structure(lattice=lattice))\n",
     "phase.structure.lattice.base"
    ]
   },

--- a/doc/crystal_reference_frame.ipynb
+++ b/doc/crystal_reference_frame.ipynb
@@ -153,8 +153,8 @@
    "source": [
     "and we see that `diffpy.structure` does not use the `orix` alignment mentioned\n",
     "above, since since $\\mathbf{e1} \\nparallel \\mathbf{a} / a$. Instead, we see that\n",
-    "$\\mathbf{e3} \\nparallel \\mathbf{c} / c$. This is in line with the alternative\n",
-    "alignment mentioned above.\n",
+    "$\\mathbf{e3} \\mathbf{c} / c$. This is in line with the alternative alignment\n",
+    "mentioned above.\n",
     "\n",
     "Thus, the alignment is updated internally whenever a\n",
     "[Phase](reference.rst#orix.crystal_map.Phase) is created, a class which brings\n",

--- a/doc/crystal_reference_frame.ipynb
+++ b/doc/crystal_reference_frame.ipynb
@@ -218,6 +218,9 @@
    "execution_count": null,
    "id": "26f0ba6c-d0bd-4222-ba17-17eaf42f98fd",
    "metadata": {
+    "nbsphinx-thumbnail": {
+     "tooltip": "Alignment of crystal reference frames and symmetry operations"
+    },
     "tags": [
      "nbsphinx-thumbnail"
     ]

--- a/doc/crystal_reference_frame.ipynb
+++ b/doc/crystal_reference_frame.ipynb
@@ -1,0 +1,253 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "67195845-843f-4de5-b0ee-0addce775c64",
+   "metadata": {},
+   "source": [
+    "This notebook is part of the *orix* documentation https://orix.rtfd.io. Links to the documentation won’t work from the notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f549c08a-bed7-4431-914c-b3edc609f476",
+   "metadata": {},
+   "source": [
+    "# Crystal reference frame\n",
+    "\n",
+    "This notebook describes the alignment of crystal reference frames and symmetry\n",
+    "operations in orix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d97dfe58-a726-4a19-b327-d5c3b6b15844",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "\n",
+    "from diffpy.structure import Atom, Lattice, Structure\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from orix.crystal_map import Phase\n",
+    "from orix.vector import Miller\n",
+    "\n",
+    "\n",
+    "plt.rcParams.update({\n",
+    "    \"figure.figsize\": (7, 7),\n",
+    "    \"font.size\": 20,\n",
+    "    \"axes.grid\": True,\n",
+    "    \"lines.markersize\": 10,\n",
+    "    \"lines.linewidth\": 3,\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61084d0b-a023-4cbb-a0d3-7cb0f766575e",
+   "metadata": {},
+   "source": [
+    "The (direct) Bravais lattice is characterized by basis vectors ($\\mathbf{a},\n",
+    "\\mathbf{b}, \\mathbf{c}$) with unit cell edge lengths ($a$, $b$, $c$) and angles\n",
+    "($\\alpha$, $\\beta$, $\\gamma$). The reciprocal lattice has basis vectors given by\n",
+    "\n",
+    "$$\n",
+    "\\mathbf{a^*} = \\frac{\\mathbf{b} \\times \\mathbf{c}}{\\mathbf{a} \\cdot (\\mathbf{b} \\times \\mathbf{c})},\\:\\:\n",
+    "\\mathbf{b^*} = \\frac{\\mathbf{c} \\times \\mathbf{a}}{\\mathbf{a} \\cdot (\\mathbf{b} \\times \\mathbf{c})},\\:\\:\n",
+    "\\mathbf{c^*} = \\frac{\\mathbf{a} \\times \\mathbf{b}}{\\mathbf{a} \\cdot (\\mathbf{b} \\times \\mathbf{c})},\n",
+    "$$\n",
+    "\n",
+    "with reciprocal lattice parameters ($a^*$, $b^*$, $c^*$) and angles ($\\alpha^*$,\n",
+    "$\\beta^*$, $\\gamma^*$).\n",
+    "\n",
+    "Using these two crystallographic lattices, we define a standard Cartesian\n",
+    "(orthonormal) reference frame by the unit vectors ($\\mathbf{e_1}, \\mathbf{e_2},\n",
+    "\\mathbf{e_3}$). In principle, the direct lattice reference frame can be oriented\n",
+    "arbitrarily in the Cartesian reference frame. In `orix` we have chosen\n",
+    "\n",
+    "$$\n",
+    "\\mathbf{e_1} ||\\: \\frac{\\mathbf{a}}{a},\\:\\:\n",
+    "\\mathbf{e_2} ||\\: \\mathbf{e_3} \\times \\mathbf{e_1},\\:\\:\n",
+    "\\mathbf{e_3} ||\\: \\frac{\\mathbf{c^*}}{c^*}.\n",
+    "$$\n",
+    "\n",
+    "This alignment is used for example in\n",
+    "<cite data-cite=\"rowenhorst2015consistent\">Rowenhorst et al. (2015)</cite> and\n",
+    "<cite data-cite=\"degraef2003introduction\">De Graef (2003)</cite>, the latter\n",
+    "which was the basis for the *EMsoft* Fortran suite of programs. Another common\n",
+    "option is $\\mathbf{e_1} || \\mathbf{a^*}/a^*$, $\\mathbf{e_2} ||\n",
+    "\\mathbf{e_3} \\times \\mathbf{e_1}$, $\\mathbf{e_3} || \\mathbf{c}/c$, which is used\n",
+    "for example in\n",
+    "<cite data-cite=\"britton2016tutorial\">Britton et al. (2016)</cite>.\n",
+    "\n",
+    "In calculations, it is useful to describe the transformation of the Cartesian\n",
+    "unit column vectors to the coordinates of the direct lattice vectors by the\n",
+    "structure matrix $\\mathbf{A}$ (also called the crystal *base*). Given the chosen\n",
+    "alignment of basis vectors with the Cartesian reference frame, $\\mathbf{A}$ is\n",
+    "defined as\n",
+    "\n",
+    "\\begin{equation}\n",
+    "\\mathbf{A} = \n",
+    "\\begin{pmatrix}\n",
+    "a & b\\cos\\gamma & c\\cos\\beta\\\\\n",
+    "0 & b\\sin\\gamma & -c\\frac{(\\cos\\beta\\cos\\gamma - \\cos\\alpha)}{\\sin\\gamma}\\\\\n",
+    "0 & 0 & \\frac{\\mathrm{V}}{ab\\sin\\gamma}\n",
+    "\\end{pmatrix},\n",
+    "\\end{equation}\n",
+    "\n",
+    "where $V$ is the volume of the unit cell.\n",
+    "\n",
+    "In `orix`, we use the\n",
+    "[Lattice](https://www.diffpy.org/diffpy.structure/mod_lattice.html#diffpy.structure.lattice.Lattice)\n",
+    "class in `diffpy.structure` to keep track of these properties internally"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f05c3e3-74fd-41ae-8660-ac997ac74d62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lattice = Lattice(1.7, 1.7, 1.4, 90, 90, 120)\n",
+    "lattice"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "932dcf90-8f5d-4e22-a121-d5676614b028",
+   "metadata": {},
+   "source": [
+    "However, by default, `diffpy.structure` uses the other mentioned alignment above,\n",
+    "which is clear from inspecting the structure matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20a8f43f-b2be-477c-900c-7771cf5c8a47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lattice.base"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de92cd06-9408-4a03-81ca-b4ba3376451e",
+   "metadata": {},
+   "source": [
+    "Thus, the alignment is updated whenever a\n",
+    "[Phase](reference.rst#orix.crystal_map.Phase) is created, which bring\n",
+    "together this crystal lattice and a\n",
+    "[Symmetry](reference.rst#orix.quaternion.Symmetry)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c95a661-e26d-4b07-9ac6-d4908f37305f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phase = Phase(point_group=\"321\", structure=Structure(lattice=lattice))\n",
+    "phase.structure.lattice.base"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4603803-0883-4b1e-b8c4-5c11eae7421e",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Note\n",
+    "    \n",
+    "The lattice is included in a\n",
+    "[Structure](https://www.diffpy.org/diffpy.structure/package.html#diffpy.structure.structure.Structure)\n",
+    "which adds\n",
+    "[atoms](https://www.diffpy.org/diffpy.structure/mod_atom.html#diffpy.structure.atom.Atom)\n",
+    "to the lattice, which is useful when simulating diffraction.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3b093cb-aad7-45e2-9148-d63d66eb389b",
+   "metadata": {},
+   "source": [
+    "We can inspect the alignment of the direct and reciprocal lattice basis vectors\n",
+    "with the Cartesian reference frame in the stereographic projection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55815802-4745-4329-80ff-4310ac3fd66e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "abc = Miller(uvw=[[1, 0, 0], [0, 1, 0], [0, 0, 1]], phase=phase)\n",
+    "abcr = Miller(hkl=[[1, 0, 0], [0, 1, 0], [0, 0, 1]], phase=phase)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "157d6a1d-81b9-4516-a479-7e293b250319",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = abc.scatter(c=[\"r\", \"g\", \"b\"], marker=\"o\", return_figure=True, axes_labels=[\"e1\", \"e2\"])\n",
+    "abcr.scatter(c=[\"r\", \"g\", \"b\"], marker=\"x\", s=300, figure=fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70881e04-c169-4b75-9f0f-81bf4bf6fca9",
+   "metadata": {},
+   "source": [
+    "The crystal symmetry operations are aligned with the direct crystal lattice"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26f0ba6c-d0bd-4222-ba17-17eaf42f98fd",
+   "metadata": {
+    "tags": [
+     "nbsphinx-thumbnail"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "phase.point_group.plot(figure=fig)\n",
+    "fig"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/crystallographic_maps.rst
+++ b/doc/crystallographic_maps.rst
@@ -1,0 +1,10 @@
+=====================
+Crystallographic maps
+=====================
+
+This guide shows how to handle and manipulate crystallographic data.
+
+.. nbgallery::
+    :hidden:
+
+    crystal_map.ipynb

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,59 +11,18 @@ Work using orix
 
 .. toctree::
     :hidden:
-    :caption: Getting started
 
     installation.rst
 
-
-.. _user-guide:
-
-User guide
-----------
-
-Crystal geometry
-~~~~~~~~~~~~~~~~
-
-Conventions for the unit cell, symmetry operations and relevant reference frames, and
-how to operate with vectors in the crystal and sample reference frames.
-
-.. nbgallery::
+.. toctree::
+    :hidden:
     :caption: User guide
 
-    crystal_reference_frame.ipynb
-    crystal_directions.ipynb
-    point_groups.ipynb
-    inverse_pole_figures.ipynb
-
-Orientations
-~~~~~~~~~~~~
-
-.. nbgallery::
-
-    uniform_sampling_of_orientation_space.ipynb
-
-Vectors
-~~~~~~~
-
-.. nbgallery::
-
-    stereographic_projection.ipynb
-
-Clustering of (mis)orientations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. nbgallery::
-
-    clustering_across_fundamental_region_boundaries.ipynb
-    clustering_orientations.ipynb
-    clustering_misorientations.ipynb
-
-Crystallographic maps
-~~~~~~~~~~~~~~~~~~~~~
-
-.. nbgallery::
-
-    crystal_map.ipynb
+    crystal_geometry.rst
+    orientations.rst
+    vectors.rst
+    clustering_of_orientations.rst
+    crystallographic_maps.rst
 
 .. toctree::
     :hidden:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,22 +15,55 @@ Work using orix
 
     installation.rst
 
+
+.. _user-guide:
+
 User guide
 ----------
 
-.. _user-guide:
+Crystal geometry
+~~~~~~~~~~~~~~~~
+
+Conventions for the unit cell, symmetry operations and relevant reference frames, and
+how to operate with vectors in the crystal and sample reference frames.
+
 .. nbgallery::
     :caption: User guide
 
-    crystal_geometry.ipynb
-    stereographic_projection.ipynb
+    crystal_reference_frame.ipynb
+    crystal_directions.ipynb
+    point_groups.ipynb
     inverse_pole_figures.ipynb
-    crystal_map.ipynb
+
+Orientations
+~~~~~~~~~~~~
+
+.. nbgallery::
+
+    uniform_sampling_of_orientation_space.ipynb
+
+Vectors
+~~~~~~~
+
+.. nbgallery::
+
+    stereographic_projection.ipynb
+
+Clustering of (mis)orientations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. nbgallery::
+
     clustering_across_fundamental_region_boundaries.ipynb
     clustering_orientations.ipynb
     clustering_misorientations.ipynb
-    uniform_sampling_of_orientation_space.ipynb
-    point_groups.ipynb
+
+Crystallographic maps
+~~~~~~~~~~~~~~~~~~~~~
+
+.. nbgallery::
+
+    crystal_map.ipynb
 
 .. toctree::
     :hidden:

--- a/doc/inverse_pole_figures.ipynb
+++ b/doc/inverse_pole_figures.ipynb
@@ -95,6 +95,9 @@
    "execution_count": null,
    "id": "63ae1026-b81d-4c60-836a-9f2b7647ddda",
    "metadata": {
+    "nbsphinx-thumbnail": {
+     "tooltip": "Sample directions expressed in terms of the crystallographic frame"
+    },
     "tags": [
      "nbsphinx-thumbnail"
     ]
@@ -229,7 +232,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/doc/orientations.rst
+++ b/doc/orientations.rst
@@ -1,0 +1,10 @@
+============
+Orientations
+============
+
+This guide shows how to sample orientation space *SO(3)*.
+
+.. nbgallery::
+    :hidden:
+
+    uniform_sampling_of_orientation_space.ipynb

--- a/doc/point_groups.ipynb
+++ b/doc/point_groups.ipynb
@@ -1,127 +1,134 @@
 {
-    "cells": [
-        {
-            "cell_type": "markdown",
-            "metadata": {
-                "nbsphinx": "hidden"
-            },
-            "source": [
-                "This notebook is part of the orix documentation https://orix.rtfd.io. Links to the documentation won’t work from the notebook."
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## Visualizing point groups\n",
-                "\n",
-                "Point group symmetry operations are shown here under the stereographic projection.\n",
-                "\n",
-                "Vectors located on the upper (`z >= 0`) hemisphere are displayed as points (`o`), whereas vectors on the lower hemisphere are reprojected onto the upper hemisphere and shown as crosses (`+`) by default. For more information about plot formatting and visualization, see [Vector3d.scatter()](reference.rst#orix.vector.Vector3d.scatter).\n",
-                "\n",
-                "More explanation of these figures is provided at http://xrayweb.chem.ou.edu/notes/symmetry.html#point."
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "For example, the `O (432)` point group:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {
-                "tags": [
-                    "nbsphinx-thumbnail"
-                ]
-            },
-            "outputs": [],
-            "source": [
-                "%matplotlib inline\n",
-                "\n",
-                "from orix.quaternion import symmetry\n",
-                "\n",
-                "symmetry.O.plot()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "The stereographic projection of all point groups is shown below:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "from matplotlib import pyplot as plt\n",
-                "import numpy as np\n",
-                "\n",
-                "from orix import plot\n",
-                "from orix.quaternion import Rotation\n",
-                "from orix.vector import Vector3d\n",
-                "\n",
-                "schoenflies = ['C1', 'Ci', 'C2x', 'C2y', 'C2z', 'Csx', 'Csy', 'Csz', 'C2h', 'D2', 'C2v', 'D2h', 'C4', 'S4', 'C4h', 'D4', 'C4v', 'D2d', 'D4h', 'C3', 'S6', 'D3x', 'D3y', 'D3', 'C3v', 'D3d', 'C6', 'C3h', 'C6h', 'D6', 'C6v', 'D3h', 'D6h', 'T', 'Th', 'O', 'Td', 'Oh']\n",
-                "\n",
-                "assert len(symmetry._groups) == len(schoenflies)\n",
-                "\n",
-                "schoenflies = [s for s in schoenflies if not (s.endswith('x') or s.endswith('y'))]\n",
-                "\n",
-                "assert len(schoenflies) == 32\n",
-                "\n",
-                "orientation = Rotation.from_axes_angles((-1, 8, 1), np.deg2rad(65))\n",
-                "\n",
-                "fig, ax = plt.subplots(nrows=8, ncols=4, figsize=(10, 20), subplot_kw=dict(projection='stereographic'))\n",
-                "ax = ax.ravel()\n",
-                "\n",
-                "for i, s in enumerate(schoenflies):\n",
-                "    sym = getattr(symmetry, s)\n",
-                "\n",
-                "    ori_sym = sym.outer(orientation)\n",
-                "    v = (ori_sym * Vector3d.zvector())\n",
-                "    \n",
-                "    # reflection in the projection plane (x-y) is performed internally in\n",
-                "    # Symmetry.plot() or when using the `reproject=True` argument for\n",
-                "    # Vector3d.scatter()\n",
-                "    v_reproject = Vector3d(v.data.copy())\n",
-                "    v_reproject.z *= -1\n",
-                "    \n",
-                "    # the Symmetry marker formatting for vectors on the upper and lower hemisphere\n",
-                "    # can be set using `kwargs` and `reproject_scatter_kwargs`, respectively, for\n",
-                "    # Symmetry.plot() \n",
-                "    \n",
-                "    # vectors on the upper hemisphere are shown as open circles\n",
-                "    ax[i].scatter(v, marker='o', fc='None', ec='k', s=150)\n",
-                "    # vectors on the lower hemisphere are reprojected onto the upper hemisphere and\n",
-                "    # shown as crosses\n",
-                "    ax[i].scatter(v_reproject, marker='+', ec='C0', s=150)\n",
-                "\n",
-                "    ax[i].set_title(f'${s}$ $({sym.name})$')\n",
-                "    ax[i].set_labels('a', 'b', None)\n",
-                "\n",
-                "fig.tight_layout()"
-            ]
-        }
-    ],
-    "metadata": {
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.9.7"
-        }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the orix documentation https://orix.rtfd.io. Links to the documentation won’t work from the notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualizing point groups\n",
+    "\n",
+    "Point group symmetry operations are shown here in the stereographic projection.\n",
+    "\n",
+    "Vectors located on the upper (`z >= 0`) hemisphere are displayed as points (`o`), whereas vectors on the lower hemisphere are reprojected onto the upper hemisphere and shown as crosses (`+`) by default. For more information about plot formatting and visualization, see [Vector3d.scatter()](reference.rst#orix.vector.Vector3d.scatter).\n",
+    "\n",
+    "More explanation of these figures is provided at http://xrayweb.chem.ou.edu/notes/symmetry.html#point."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For example, the `O (432)` point group:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx-thumbnail": {
+     "tooltip": "Point group symmetry operations visualized in the stereographic projection"
     },
-    "nbformat": 4,
-    "nbformat_minor": 4
+    "tags": [
+     "nbsphinx-thumbnail"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "\n",
+    "from orix.quaternion import symmetry\n",
+    "\n",
+    "symmetry.O.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The stereographic projection of all point groups is shown below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from matplotlib import pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "from orix import plot\n",
+    "from orix.quaternion import Rotation\n",
+    "from orix.vector import Vector3d\n",
+    "\n",
+    "schoenflies = ['C1', 'Ci', 'C2x', 'C2y', 'C2z', 'Csx', 'Csy', 'Csz', 'C2h', 'D2', 'C2v', 'D2h', 'C4', 'S4', 'C4h', 'D4', 'C4v', 'D2d', 'D4h', 'C3', 'S6', 'D3x', 'D3y', 'D3', 'C3v', 'D3d', 'C6', 'C3h', 'C6h', 'D6', 'C6v', 'D3h', 'D6h', 'T', 'Th', 'O', 'Td', 'Oh']\n",
+    "\n",
+    "assert len(symmetry._groups) == len(schoenflies)\n",
+    "\n",
+    "schoenflies = [s for s in schoenflies if not (s.endswith('x') or s.endswith('y'))]\n",
+    "\n",
+    "assert len(schoenflies) == 32\n",
+    "\n",
+    "orientation = Rotation.from_axes_angles((-1, 8, 1), np.deg2rad(65))\n",
+    "\n",
+    "fig, ax = plt.subplots(nrows=8, ncols=4, figsize=(10, 20), subplot_kw=dict(projection='stereographic'))\n",
+    "ax = ax.ravel()\n",
+    "\n",
+    "for i, s in enumerate(schoenflies):\n",
+    "    sym = getattr(symmetry, s)\n",
+    "\n",
+    "    ori_sym = sym.outer(orientation)\n",
+    "    v = (ori_sym * Vector3d.zvector())\n",
+    "    \n",
+    "    # reflection in the projection plane (x-y) is performed internally in\n",
+    "    # Symmetry.plot() or when using the `reproject=True` argument for\n",
+    "    # Vector3d.scatter()\n",
+    "    v_reproject = Vector3d(v.data.copy())\n",
+    "    v_reproject.z *= -1\n",
+    "    \n",
+    "    # the Symmetry marker formatting for vectors on the upper and lower hemisphere\n",
+    "    # can be set using `kwargs` and `reproject_scatter_kwargs`, respectively, for\n",
+    "    # Symmetry.plot() \n",
+    "    \n",
+    "    # vectors on the upper hemisphere are shown as open circles\n",
+    "    ax[i].scatter(v, marker='o', fc='None', ec='k', s=150)\n",
+    "    # vectors on the lower hemisphere are reprojected onto the upper hemisphere and\n",
+    "    # shown as crosses\n",
+    "    ax[i].scatter(v_reproject, marker='+', ec='C0', s=150)\n",
+    "\n",
+    "    ax[i].set_title(f'${s}$ $({sym.name})$')\n",
+    "    ax[i].set_labels('a', 'b', None)\n",
+    "\n",
+    "fig.tight_layout()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "",
+   "name": ""
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -4,7 +4,7 @@ API reference
 
 This reference manual details the public modules, classes, and functions in orix, as
 generated from their docstrings. Many of the docstrings contain examples, however, see
-the :ref:`user guide <user-guide>` for how to use orix.
+the user guide for how to use orix.
 
 .. caution::
 

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -66,6 +66,7 @@ Phase
 .. currentmodule:: orix.crystal_map.Phase
 .. autosummary::
     deepcopy
+    from_cif
 .. autoclass:: orix.crystal_map.Phase
     :members:
     :undoc-members:

--- a/doc/stereographic_projection.ipynb
+++ b/doc/stereographic_projection.ipynb
@@ -527,6 +527,9 @@
    "execution_count": null,
    "id": "4026c090",
    "metadata": {
+    "nbsphinx-thumbnail": {
+     "tooltip": "Visualizing 3D vectors in 2D"
+    },
     "tags": [
      "nbsphinx-thumbnail"
     ]

--- a/doc/uniform_sampling_of_orientation_space.ipynb
+++ b/doc/uniform_sampling_of_orientation_space.ipynb
@@ -250,6 +250,9 @@
    "execution_count": null,
    "id": "7036a94d",
    "metadata": {
+    "nbsphinx-thumbnail": {
+     "tooltip": "Three routes to the sampling of orientation space SO(3)"
+    },
     "tags": [
      "nbsphinx-thumbnail"
     ]
@@ -298,7 +301,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/doc/vectors.rst
+++ b/doc/vectors.rst
@@ -1,0 +1,10 @@
+=======
+Vectors
+=======
+
+This guide shows how to visualize 3D vectors in 2D with the stereographic projection.
+
+.. nbgallery::
+    :hidden:
+
+    stereographic_projection.ipynb

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -820,7 +820,7 @@ def _new_structure_matrix_from_alignment(old_matrix, x=None, y=None, z=None):
 
     # Old reciprocal lattice base vectors in cartesian coordinates
     ar = (bd.cross(cd)).unit
-    br = (ad.cross(cd)).unit
+    br = (cd.cross(ad)).unit
     cr = (ad.cross(bd)).unit
 
     # New unit crystal base

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -18,10 +18,12 @@
 
 from collections import OrderedDict
 import copy
+import os
 from itertools import islice
 import warnings
 
 from diffpy.structure import Structure
+from diffpy.structure.parsers import p_cif
 from diffpy.structure.spacegroups import GetSpaceGroup, SpaceGroup
 import matplotlib.colors as mcolors
 import numpy as np
@@ -222,8 +224,31 @@ class Phase:
             f"proper point group: {ppg_name}. color: {self.color}>"
         )
 
+    @classmethod
+    def from_cif(cls, filename):
+        """Return a `Phase` instance from a CIF file using
+        :mod:`diffpy.structure`'s CIF file parser.
+
+        Parameters
+        ----------
+        filename : str
+            Complete path to CIF file with ".cif" file ending. The phase
+            name is obtained from the file name.
+
+        Returns
+        -------
+        Phase
+        """
+        parser = p_cif.P_cif()
+        name = os.path.splitext(os.path.split(filename)[1])[0]
+        structure = parser.parseFile(filename)
+        space_group = parser.spacegroup.number
+        return cls(name, space_group, structure=structure)
+
     def deepcopy(self):
-        """Return a deep copy using :py:func:`~copy.deepcopy` function."""
+        """Return a deep copy using :py:func:`~copy.deepcopy`
+        function.
+        """
         return copy.deepcopy(self)
 
 

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -253,6 +253,38 @@ class Phase:
         """
         return copy.deepcopy(self)
 
+    def plot_unit_cell_axes(self, figure=None, return_figure=False):
+        """Plot direct and reciprocal lattice base vectors (a, b, c) and
+        (a*, b*, c*) in the stereographic projection.
+
+        Parameters
+        ----------
+        figure : matplotlib.figure.Figure, optional
+            If given, the axes are added to this figure, otherwise a new
+            figure is created.
+        return_figure : bool, optional
+            If True (default is False), return the figure.
+
+        Returns
+        -------
+        figure : matplotlib.figure.Figure or None
+            Figure with the vectors added. None if `return_figure` is
+            False.
+        """
+        axes = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
+        uvw = Miller(uvw=axes, phase=self)
+        hkl = Miller(hkl=axes, phase=self)
+
+        color = ["r", "g", "b"]
+        if figure is None:
+            figure = uvw.scatter(c=color, ec="k", s=50, return_figure=True)
+        else:
+            uvw.scatter(c=color, ec="k", s=50, figure=figure)
+        hkl.scatter(c=color, marker="x", s=200, figure=figure)
+
+        if return_figure:
+            return figure
+
 
 class PhaseList:
     """A list of phases in a crystallographic map.

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -55,7 +55,7 @@ class Phase:
         ----------
         name : str, optional
             Phase name. Overwrites the name in the `structure` object.
-        space_group : int or diffpy.structure.spacegroups.SpaceGroup,\
+        space_group : int or diffpy.structure.spacegroupmod.SpaceGroup,\
                 optional
             Space group describing the symmetry operations resulting from
             associating the point group with a Bravais lattice, according
@@ -69,10 +69,11 @@ class Phase:
             is not None, it is derived from the space group. If both
             `point_group` and `space_group` is not None, the space group
             needs to be derived from the point group.
-        structure : diffpy.structure.Structure, optional
+        structure : diffpy.structure.structure.Structure, optional
             Unit cell with atoms and a lattice. If None is passed
-            (default), a default :class:`diffpy.structure.Structure`
-            object is created.
+            (default), a default
+            :class:`~diffpy.structure.structure.Structure` object is
+            created.
         color : str, optional
             Phase color. If None is passed (default), it is set to
             'tab:blue' (first among the default Matplotlib colors).
@@ -106,12 +107,13 @@ class Phase:
 
     @property
     def structure(self):
-        r"""Crystal structure (:ref:`~diffpy.structure.Structure`)
-        containing a lattice (:ref:`~diffpy.structure.Lattice`) and
-        possibly many atoms (:ref:`~diffpy.structure.Atom`).
+        r"""Crystal structure
+        (:class:`~diffpy.structure.structure.Structure`) containing a
+        lattice (:class:`~diffpy.structure.lattice.Lattice`) and
+        possibly many atoms (:class:`~diffpy.structure.atom.Atom`).
 
         The cartesian reference frame of the crystal lattice is assumed
-        to align :math;`a` with :math:`e_1` and :math:`c*` with
+        to align :math:`a` with :math:`e_1` and :math:`c*` with
         :math:`e_3`. This alignment is assumed when transforming direct,
         reciprocal and cartesian vectors between these spaces.
         """

--- a/orix/io/plugins/_h5ebsd.py
+++ b/orix/io/plugins/_h5ebsd.py
@@ -74,6 +74,7 @@ class H5ebsdFile:
     """
 
     file = None
+    scan_groups = None
     data_dict = dict()
     header_dict = dict()
     sem_dict = dict()

--- a/orix/plot/stereographic_plot.py
+++ b/orix/plot/stereographic_plot.py
@@ -324,6 +324,9 @@ class StereographicPlot(maxes.Axes):
         if x.size == 0:
             return
 
+        if isinstance(opening_angle, np.ndarray) and opening_angle.size == visible.size:
+            opening_angle = opening_angle[visible]
+
         # Get set of `steps` vectors delineating a circle per vector
         v = self._inverse_projection.xy2vector(x, y)
         circles = v.get_circle(opening_angle=opening_angle, steps=steps).unit

--- a/orix/plot/stereographic_plot.py
+++ b/orix/plot/stereographic_plot.py
@@ -299,7 +299,7 @@ class StereographicPlot(maxes.Axes):
             Number of vectors to describe each circle, default is 100.
         reproject : bool, optional
             Whether to reproject parts of the circle(s) visible on the
-            other hemisphere. Reprojection is achieved by reflection of
+            other hemisphere. Re-projection is achieved by reflection of
             the circle(s) parts located on the other hemisphere in the
             projection plane. Ignored if hemisphere is “both”. Default
             is False.

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -600,6 +600,39 @@ class Rotation(Quaternion):
         return cls(Quaternion(q)).unit  # Normalized
 
     @classmethod
+    def from_Rx(cls, angle):
+        matrix = np.array(
+            [
+                [1, 0, 0],
+                [0, np.cos(angle), np.sin(angle)],
+                [0, -np.sin(angle), np.cos(angle)],
+            ]
+        )
+        return cls.from_matrix(matrix)
+
+    @classmethod
+    def from_Ry(cls, angle):
+        matrix = np.array(
+            [
+                [np.cos(angle), 0, np.sin(angle)],
+                [0, 1, 0],
+                [-np.sin(angle), 0, np.cos(angle)],
+            ]
+        )
+        return cls.from_matrix(matrix)
+
+    @classmethod
+    def from_Rz(cls, angle):
+        matrix = np.array(
+            [
+                [np.cos(angle), np.sin(angle), 0],
+                [-np.sin(angle), np.cos(angle), 0],
+                [0, 0, 1],
+            ]
+        )
+        return cls.from_matrix(matrix)
+
+    @classmethod
     def identity(cls, shape=(1,)):
         """Create identity rotations.
 

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -600,39 +600,6 @@ class Rotation(Quaternion):
         return cls(Quaternion(q)).unit  # Normalized
 
     @classmethod
-    def from_Rx(cls, angle):
-        matrix = np.array(
-            [
-                [1, 0, 0],
-                [0, np.cos(angle), np.sin(angle)],
-                [0, -np.sin(angle), np.cos(angle)],
-            ]
-        )
-        return cls.from_matrix(matrix)
-
-    @classmethod
-    def from_Ry(cls, angle):
-        matrix = np.array(
-            [
-                [np.cos(angle), 0, np.sin(angle)],
-                [0, 1, 0],
-                [-np.sin(angle), 0, np.cos(angle)],
-            ]
-        )
-        return cls.from_matrix(matrix)
-
-    @classmethod
-    def from_Rz(cls, angle):
-        matrix = np.array(
-            [
-                [np.cos(angle), np.sin(angle), 0],
-                [-np.sin(angle), np.cos(angle), 0],
-                [0, 0, 1],
-            ]
-        )
-        return cls.from_matrix(matrix)
-
-    @classmethod
     def identity(cls, shape=(1,)):
         """Create identity rotations.
 

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -655,3 +655,62 @@ def crystal_map_input(request, rotations):
 @pytest.fixture
 def crystal_map(crystal_map_input):
     return CrystalMap(**crystal_map_input)
+
+
+@pytest.fixture
+def cif_file(tmpdir):
+    """Actual CIF file of beta double prime phase often seen in Al-Mg-Si
+    alloys.
+    """
+    file_contents = """
+#======================================================================
+
+# CRYSTAL DATA
+
+#----------------------------------------------------------------------
+
+data_VESTA_phase_1
+
+
+_chemical_name_common                  ''
+_cell_length_a                         15.50000
+_cell_length_b                         4.05000
+_cell_length_c                         6.74000
+_cell_angle_alpha                      90
+_cell_angle_beta                       105.30000
+_cell_angle_gamma                      90
+_space_group_name_H-M_alt              'C 2/m'
+_space_group_IT_number                 12
+
+loop_
+_space_group_symop_operation_xyz
+   'x, y, z'
+   '-x, -y, -z'
+   '-x, y, -z'
+   'x, -y, z'
+   'x+1/2, y+1/2, z'
+   '-x+1/2, -y+1/2, -z'
+   '-x+1/2, y+1/2, -z'
+   'x+1/2, -y+1/2, z'
+
+loop_
+   _atom_site_label
+   _atom_site_occupancy
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_adp_type
+   _atom_site_B_iso_or_equiv
+   _atom_site_type_symbol
+   Mg(1)      1.0     0.000000      0.000000      0.000000     Biso  1.000000 Mg
+   Mg(2)      1.0     0.347000      0.000000      0.089000     Biso  1.000000 Mg
+   Mg(3)      1.0     0.423000      0.000000      0.652000     Biso  1.000000 Mg
+   Si(1)      1.0     0.054000      0.000000      0.649000     Biso  1.000000 Si
+   Si(2)      1.0     0.190000      0.000000      0.224000     Biso  1.000000 Si
+   Al         1.0     0.211000      0.000000      0.626000     Biso  1.000000 Al"
+"""
+    f = open(tmpdir.join("betapp.cif"), mode="w")
+    f.write(file_contents)
+    f.close()
+    yield f.name
+    gc.collect()

--- a/orix/tests/plot/test_stereographic_plot.py
+++ b/orix/tests/plot/test_stereographic_plot.py
@@ -28,8 +28,9 @@ from orix.plot.stereographic_plot import (
     FourFoldMarker,
     SixFoldMarker,
 )
-from orix import plot, vector
+from orix import plot
 from orix.quaternion.symmetry import C1, C6, Oh
+from orix.vector import Vector3d
 
 
 plt.rcParams["axes.grid"] = True
@@ -46,7 +47,7 @@ class TestStereographicPlot:
         assert ax.can_pan()
         assert ax.can_zoom()
 
-        v = vector.Vector3d([[0, 0, 1], [2, 0, 2]])
+        v = Vector3d([[0, 0, 1], [2, 0, 2]])
         ax.scatter(v[0])
         ax.scatter(v[1].azimuth, v[1].polar)
 
@@ -57,7 +58,7 @@ class TestStereographicPlot:
 
     def test_annotate(self):
         _, ax = plt.subplots(subplot_kw=dict(projection=PROJ_NAME))
-        v = vector.Vector3d([[0, 0, 1], [-1, 0, 1], [1, 1, 1]])
+        v = Vector3d([[0, 0, 1], [-1, 0, 1], [1, 1, 1]])
         ax.scatter(v)
         format_vector = lambda v: str(v.data[0]).replace(" ", "")
         for vi in v:
@@ -133,7 +134,7 @@ class TestStereographicPlot:
 
         label_xy = [-0.71, 0.71]
 
-        ax[0].scatter(vector.Vector3d([0, 0, 1]))
+        ax[0].scatter(Vector3d([0, 0, 1]))
         ax[0].show_hemisphere_label()
         label_up = ax[0].texts[0]
         assert label_up.get_text() == "upper"
@@ -141,7 +142,7 @@ class TestStereographicPlot:
         assert np.allclose([label_up._x, label_up._y], label_xy)
 
         ax[1].hemisphere = "lower"
-        ax[1].scatter(vector.Vector3d([0, 0, -1]))
+        ax[1].scatter(Vector3d([0, 0, -1]))
         ax[1].show_hemisphere_label(color="r")
         label_low = ax[1].texts[0]
         assert label_low.get_text() == "lower"
@@ -188,7 +189,7 @@ class TestStereographicPlot:
         plt.close("all")
 
     def test_empty_scatter(self):
-        v = vector.Vector3d([0, 0, 1])
+        v = Vector3d([0, 0, 1])
 
         _, ax = plt.subplots(subplot_kw=dict(projection=PROJ_NAME))
         ax.hemisphere = "lower"
@@ -203,14 +204,14 @@ class TestStereographicPlot:
     @pytest.mark.parametrize("shape", [(5, 10), (2, 3)])
     def test_multidimensional_vector(self, shape):
         n = np.prod(shape)
-        v = vector.Vector3d(np.random.normal(size=3 * n).reshape(shape + (3,)))
+        v = Vector3d(np.random.normal(size=3 * n).reshape(shape + (3,)))
         v.scatter()
         v.draw_circle()
 
         plt.close("all")
 
     def test_order_in_hemisphere(self):
-        v = vector.Vector3d.from_polar(
+        v = Vector3d.from_polar(
             azimuth=np.radians([45, 90, 135, 180]),
             polar=np.radians([50, 45, 140, 135]),
         )
@@ -242,7 +243,7 @@ class TestStereographicPlot:
 
 class TestSymmetryMarker:
     def test_properties(self):
-        v2fold = vector.Vector3d([[1, 0, 1], [0, 1, 1]])
+        v2fold = Vector3d([[1, 0, 1], [0, 1, 1]])
         marker2fold = TwoFoldMarker(v2fold)
         assert np.allclose(v2fold.data, marker2fold._vector.data)
         assert marker2fold.fold == 2
@@ -250,7 +251,7 @@ class TestSymmetryMarker:
         assert np.allclose(marker2fold.size, [1.55, 1.55], atol=1e-2)
         assert isinstance(marker2fold._marker[0], mpath.Path)
 
-        v3fold = vector.Vector3d([1, 1, 1])
+        v3fold = Vector3d([1, 1, 1])
         marker3fold = ThreeFoldMarker(v3fold, size=5)
         assert np.allclose(v3fold.data, marker3fold._vector.data)
         assert marker3fold.fold == 3
@@ -263,7 +264,7 @@ class TestSymmetryMarker:
             assert np.allclose(mark, (3, 0, 45 + 90))
             assert size == 5
 
-        v4fold = vector.Vector3d([[0, 0, 1], [1, 0, 0], [0, 1, 0]])
+        v4fold = Vector3d([[0, 0, 1], [1, 0, 0], [0, 1, 0]])
         marker4fold = FourFoldMarker(v4fold, size=11)
         assert np.allclose(v4fold.data, marker4fold._vector.data)
         assert marker4fold.fold == 4
@@ -272,7 +273,7 @@ class TestSymmetryMarker:
         assert marker4fold._marker == ["D"] * 3
 
         marker6fold = SixFoldMarker([0, 0, 1], size=15)
-        assert isinstance(marker6fold._vector, vector.Vector3d)
+        assert isinstance(marker6fold._vector, Vector3d)
         assert np.allclose(marker6fold._vector.data, [0, 0, 1])
         assert marker6fold.fold == 6
         assert marker6fold.n == 1
@@ -286,15 +287,13 @@ class TestSymmetryMarker:
         ax.stereographic_grid(False)
         marker_size = 500
 
-        v4fold = vector.Vector3d(
-            [[0, 0, 1], [1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0]]
-        )
+        v4fold = Vector3d([[0, 0, 1], [1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0]])
         ax.symmetry_marker(v4fold, fold=4, c="C4", s=marker_size)
 
-        v3fold = vector.Vector3d([[1, 1, 1], [1, -1, 1], [-1, -1, 1], [-1, 1, 1]])
+        v3fold = Vector3d([[1, 1, 1], [1, -1, 1], [-1, -1, 1], [-1, 1, 1]])
         ax.symmetry_marker(v3fold, fold=3, c="C3", s=marker_size)
 
-        v2fold = vector.Vector3d(
+        v2fold = Vector3d(
             [
                 [1, 0, 1],
                 [0, 1, 1],
@@ -360,8 +359,8 @@ class TestDrawCircle:
         )
 
     def test_draw_circle(self):
-        v1 = vector.Vector3d([[0, 0, 1], [1, 0, 1], [1, 1, 1]])
-        v2 = vector.Vector3d(np.append(v1.data, -v1.data, axis=0))
+        v1 = Vector3d([[0, 0, 1], [1, 0, 1], [1, 1, 1]])
+        v2 = Vector3d(np.append(v1.data, -v1.data, axis=0))
 
         upper_steps = 100
         lower_steps = 150
@@ -382,12 +381,31 @@ class TestDrawCircle:
         assert ax[1].lines[1]._path._vertices.shape == (lower_steps // 2 + 1, 2)
         assert ax[1].lines[1]._path._vertices.shape == (lower_steps // 2 + 1, 2)
 
+        plt.close("all")
+
     def test_draw_circle_empty(self):
-        v1 = vector.Vector3d([[0, 0, 1], [1, 0, 1], [1, 1, 1]])
+        v1 = Vector3d([[0, 0, 1], [1, 0, 1], [1, 1, 1]])
         _, ax = plt.subplots(subplot_kw=dict(projection=PROJ_NAME))
         ax.hemisphere = "lower"
         ax.draw_circle(v1)
         assert len(ax.lines) == 0
+
+        plt.close("all")
+
+    def test_draw_circle_opening_angle_array(self):
+        """Passing an opening angle per vector as an array works."""
+        v = Vector3d([(0, 0, 1), (0, 0, -1), (1, 0, 1)])
+        fig = v.draw_circle(
+            opening_angle=np.array([np.pi / 2, np.pi / 4, np.pi / 2]),
+            return_figure=True,
+            hemisphere="both",
+        )
+        ax0, ax1 = fig.axes
+
+        assert len(ax0.lines) == 2
+        assert len(ax1.lines) == 1
+
+        plt.close("all")
 
 
 class TestRestrictToFundamentalSector:

--- a/orix/tests/test_miller.py
+++ b/orix/tests/test_miller.py
@@ -195,17 +195,17 @@ class TestMiller:
 
         # Test from MTEX' v5.6.0 documentation
         m = Miller(UVTW=[1, -2, 1, 3], phase=TRIGONAL_PHASE)
-        _, l = m.symmetrise(return_multiplicity=True, unique=True)
-        assert l == 6
+        _, mult = m.symmetrise(return_multiplicity=True, unique=True)
+        assert mult == 6
 
         m2 = Miller(uvw=[[1, 0, 0], [1, 1, 0], [1, 1, 1]], phase=CUBIC_PHASE)
         _, idx = m2.symmetrise(unique=True, return_index=True)
         assert np.allclose(idx, np.array([0] * 6 + [1] * 12 + [2] * 8))
 
-        _, l3, _ = m2.symmetrise(
+        _, mult2, _ = m2.symmetrise(
             unique=True, return_multiplicity=True, return_index=True
         )
-        assert np.allclose(l3, [6, 12, 8])
+        assert np.allclose(mult2, [6, 12, 8])
 
     def test_unique(self):
         # From the "Crystal geometry" notebook

--- a/orix/tests/test_phase_list.py
+++ b/orix/tests/test_phase_list.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
+import sys
+
 from diffpy.structure import Lattice, Structure
 from diffpy.structure.spacegroups import GetSpaceGroup
 import numpy as np
@@ -285,6 +287,11 @@ class TestPhase:
         assert np.allclose(br.data, [0, 0.679, 0], atol=1e-3)
         assert np.allclose(cr.data, [0, 0, 0.714], atol=1e-3)
 
+    @pytest.mark.xfail(
+        sys.platform == "win32",
+        reason="Importing modules from CifFile fails on GitHub's windows server",
+        strict=True,
+    )
     def test_from_cif(self, cif_file):
         """CIF files parsed correctly with space group and all."""
         phase = Phase.from_cif(cif_file)

--- a/orix/vector/miller.py
+++ b/orix/vector/miller.py
@@ -370,6 +370,7 @@ class Miller(Vector3d):
             lattice=phase.structure.lattice, min_dspacing=min_dspacing
         )
         hkl = _get_indices_from_highest(highest_indices=highest_hkl)
+        hkl = hkl.astype(float).round(0)
         return cls(hkl=hkl, phase=phase).unique()
 
     def deepcopy(self):
@@ -736,7 +737,7 @@ def _uvw2xyz(uvw, lattice):
     uvw = np.asarray(uvw)
     shape = uvw.shape
     uvw = uvw.reshape((uvw.size // 3, 3))
-    xyz = _direct_structure_matrix(lattice).dot(uvw.T).T
+    xyz = np.matmul(uvw, lattice.base.T)
     return xyz.reshape(shape)
 
 
@@ -744,7 +745,7 @@ def _xyz2uvw(xyz, lattice):
     xyz = np.asarray(xyz)
     shape = xyz.shape
     xyz = xyz.reshape((xyz.size // 3, 3))
-    uvw = xyz.dot(_reciprocal_structure_matrix(lattice))
+    uvw = np.matmul(xyz, lattice.recbase.T)
     return uvw.reshape(shape)
 
 
@@ -752,7 +753,7 @@ def _hkl2xyz(hkl, lattice):
     hkl = np.asarray(hkl)
     shape = hkl.shape
     hkl = hkl.reshape((hkl.size // 3, 3))
-    xyz = _reciprocal_structure_matrix(lattice).dot(hkl.T).T
+    xyz = np.matmul(hkl, lattice.recbase)
     return xyz.reshape(shape)
 
 
@@ -760,7 +761,7 @@ def _xyz2hkl(xyz, lattice):
     xyz = np.asarray(xyz)
     shape = xyz.shape
     xyz = xyz.reshape((xyz.size // 3, 3))
-    hkl = xyz.dot(_direct_structure_matrix(lattice))
+    hkl = np.matmul(xyz, lattice.base)
     return hkl.reshape(shape)
 
 

--- a/orix/vector/miller.py
+++ b/orix/vector/miller.py
@@ -736,7 +736,7 @@ def _transform_space(v_in, space_in, space_out, lattice):
 
     Parameters
     ----------
-    v_in : numpy.ndarray, tuple or list
+    v_in : numpy.ndarray
         Input vectors.
     space_in, space_out : str
         "d" for direct (uvw), "r" for reciprocal (hkl), or "c" for
@@ -897,7 +897,7 @@ def _round_indices(indices, max_index=12):
     """Round a set of index triplet (Miller) or quartet (Miller-Bravais)
     to the *closest* smallest integers.
 
-    Adopted from MTEX's Miller.round function.
+    Adopted from MTEX' :code:`Miller.round` function.
 
     Parameters
     ----------


### PR DESCRIPTION
#### Description of the change
This PR addresses #319 and parts of #249: an alignment e1 || a / |a|, e2 || e3 x e1, e3 || c* / |c*| is assumed for orix. This alignment is ensured when operating with `Miller` instances. This is done by setting the crystal base (structure matrix) of the `diffpy.structure.lattice.Lattice`, which is part of the `diffpy.structure.structure.Structure`, whenever a `Phase` is created or the `Phase.structure` property is set.

The alignment is explained in a new user guide notebook "Crystal reference frame". This is the 10th notebook, and I find it best to structure the user guide into topics to ease navigation. This I think also lowers the bar for adding more guides.

This will close #236, #248 and #319.

Finally, I added a `Phase.from_cif()` class method which returns a `Phase` instance with the `structure` and `space_group` (and hence point group, `Symmetry`) read from the file. This makes it easier to obtain a `Phase` instance.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
See the [Crystal reference frame](https://orix--322.org.readthedocs.build/en/322/crystal_reference_frame.html) guide in the docs built from this PR.

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
