### PR TITLE
Add `lazy` parameter to `Quaternion` and `Rotation` `.outer()` for easy `Dask` computation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,8 +15,7 @@ Added
 - Dask computation of `Quaternion` and `Rotation` `outer()` methods through addition of
   a `lazy` parameter. This is useful to reduce memory usage when working with large 
   arrays.
-- Dask implementation of the `Quaternion` - `Vector3d` outer product through
-  `Quaternion._outer_dask()`.
+- Dask implementation of the `Quaternion` - `Vector3d` outer product.
 - Point group `Symmetry` elements can now be viewed under the stereographic projection
   using `Symmetry.plot()`. The notebook point_groups.ipynb has been added to the
   documentation.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,11 @@ Unreleased
 
 Added
 -----
-- Dask implementation of the `Quaternion` - `Vector3d` outer product.
+- Dask computation of `Quaternion` and `Rotation` `outer()` methods through addition of
+  a `lazy` parameter. This is useful to reduce memory usage when working with large 
+  arrays.
+- Dask implementation of the `Quaternion` - `Vector3d` outer product through
+  `Quaternion._outer_dask()`.
 - Point group `Symmetry` elements can now be viewed under the stereographic projection
   using `Symmetry.plot()`. The notebook point_groups.ipynb has been added to the
   documentation.

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -230,9 +230,9 @@ class Quaternion(Object3d):
         ----------
         other : orix.quaternion.Quaternion or orix.vector.Vector3d
         lazy : bool
-            Whether to computer this computation using Dask. This is
-            option can be used to reduce memory usage when working with
-            large arrays. Default is False.
+            Whether to computer this computation using Dask. This option
+            can be used to reduce memory usage when working with large
+            arrays. Default is False.
         chunk_size : int, optional
             When using `lazy` computation, `chunk_size` represents the
             number of objects per axis for each input to include in each

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -230,10 +230,12 @@ class Quaternion(Object3d):
         ----------
         other : orix.quaternion.Quaternion or orix.vector.Vector3d
         lazy : bool
-            Whether to computer this computation using Dask. Default is
-            False.
+            Whether to computer this computation using Dask. This is
+            option can be used to reduce memory usage when working with
+            large arrays. Default is False.
         chunk_size : int, optional
-            Number of objects per axis for each input to include in each
+            When using `lazy` computation, `chunk_size` represents the
+            number of objects per axis for each input to include in each
             iteration of the computation. Default is 20.
 
         Returns

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -229,7 +229,7 @@ class Quaternion(Object3d):
         Parameters
         ----------
         other : orix.quaternion.Quaternion or orix.vector.Vector3d
-        lazy : bool
+        lazy : bool, optional
             Whether to computer this computation using Dask. This option
             can be used to reduce memory usage when working with large
             arrays. Default is False.

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -267,10 +267,12 @@ class Rotation(Quaternion):
         ----------
         other : Rotation or Vector3d
         lazy : bool
-            Whether to computer this computation using Dask. Default is
-            False.
+            Whether to computer this computation using Dask. This is
+            option can be used to reduce memory usage when working with
+            large arrays. Default is False.
         chunk_size : int, optional
-            Number of objects per axis for each input to include in each
+            When using `lazy` computation, `chunk_size` represents the
+            number of objects per axis for each input to include in each
             iteration of the computation. Default is 20.
 
         Returns

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -267,9 +267,9 @@ class Rotation(Quaternion):
         ----------
         other : Rotation or Vector3d
         lazy : bool
-            Whether to computer this computation using Dask. This is
-            option can be used to reduce memory usage when working with
-            large arrays. Default is False.
+            Whether to computer this computation using Dask. This option
+            can be used to reduce memory usage when working with large
+            arrays. Default is False.
         chunk_size : int, optional
             When using `lazy` computation, `chunk_size` represents the
             number of objects per axis for each input to include in each

--- a/orix/tests/quaternion/test_quaternion.py
+++ b/orix/tests/quaternion/test_quaternion.py
@@ -205,8 +205,13 @@ class TestQuaternion:
         assert isinstance(qo_dask, da.Array)
         qo_numpy2 = Quaternion(qo_dask.compute())
         assert qo_numpy2.shape == 2 * shape
-
         assert np.allclose(qo_numpy.data, qo_numpy2.data)
+
+        # public function .outer()
+        qo_dask2 = q.outer(q)
+        assert isinstance(qo_dask2, Quaternion)
+        assert qo_dask2.shape == 2 * shape
+        assert np.allclose(qo_numpy.data, qo_dask2.data)
 
     def test_outer_lazy_chunk_size(self):
         shape = (5, 15, 4)
@@ -242,8 +247,13 @@ class TestQuaternion:
         assert isinstance(qvo_dask, da.Array)
         qvo_numpy2 = Vector3d(qvo_dask.compute())
         assert qvo_numpy2.shape == qvo_numpy.shape
-
         assert np.allclose(qvo_numpy.data, qvo_numpy2.data)
+
+        # public function .outer()
+        qvo_dask2 = q.outer(v)
+        assert isinstance(qvo_dask2, Vector3d)
+        assert qvo_dask2.shape == qvo_numpy.shape
+        assert np.allclose(qvo_numpy.data, qvo_dask2.data)
 
     def test_outer_dask_wrong_type_raises(self):
         shape = (5,)

--- a/orix/tests/quaternion/test_quaternion.py
+++ b/orix/tests/quaternion/test_quaternion.py
@@ -262,11 +262,22 @@ class TestQuaternion:
         abcd = rng.normal(size=np.prod(new_shape)).reshape(shape + (4,))
         q = Quaternion(abcd).unit
 
+        # test other is Quaternion
         _ = q.outer(q, lazy=True, progressbar=True)
         out, _ = capsys.readouterr()
         assert "Completed" in out
 
         _ = q.outer(q, lazy=True, progressbar=False)
+        out, _ = capsys.readouterr()
+        assert not out
+
+        # test other is Vector3d
+        v = Vector3d(np.random.rand(2, 3, 3)).unit
+        _ = q.outer(v, lazy=True, progressbar=True)
+        out, _ = capsys.readouterr()
+        assert "Completed" in out
+
+        _ = q.outer(v, lazy=True, progressbar=False)
         out, _ = capsys.readouterr()
         assert not out
 

--- a/orix/tests/quaternion/test_quaternion.py
+++ b/orix/tests/quaternion/test_quaternion.py
@@ -255,6 +255,21 @@ class TestQuaternion:
         assert qvo_dask2.shape == qvo_numpy.shape
         assert np.allclose(qvo_numpy.data, qvo_dask2.data)
 
+    def test_outer_lazy_progressbar_stdout(self, capsys):
+        rng = np.random.default_rng()
+        shape = (5, 3)
+        new_shape = shape + (4,)
+        abcd = rng.normal(size=np.prod(new_shape)).reshape(shape + (4,))
+        q = Quaternion(abcd).unit
+
+        _ = q.outer(q, lazy=True, progressbar=True)
+        out, _ = capsys.readouterr()
+        assert "Completed" in out
+
+        _ = q.outer(q, lazy=True, progressbar=False)
+        out, _ = capsys.readouterr()
+        assert not out
+
     def test_outer_dask_wrong_type_raises(self):
         shape = (5,)
         rng = np.random.default_rng()

--- a/orix/tests/quaternion/test_quaternion.py
+++ b/orix/tests/quaternion/test_quaternion.py
@@ -261,22 +261,18 @@ class TestQuaternion:
         new_shape = shape + (4,)
         abcd = rng.normal(size=np.prod(new_shape)).reshape(shape + (4,))
         q = Quaternion(abcd).unit
-
-        # test other is Quaternion
+        # other is Quaternion
         _ = q.outer(q, lazy=True, progressbar=True)
         out, _ = capsys.readouterr()
         assert "Completed" in out
-
         _ = q.outer(q, lazy=True, progressbar=False)
         out, _ = capsys.readouterr()
         assert not out
-
         # test other is Vector3d
         v = Vector3d(np.random.rand(2, 3, 3)).unit
         _ = q.outer(v, lazy=True, progressbar=True)
         out, _ = capsys.readouterr()
         assert "Completed" in out
-
         _ = q.outer(v, lazy=True, progressbar=False)
         out, _ = capsys.readouterr()
         assert not out

--- a/orix/tests/quaternion/test_quaternion.py
+++ b/orix/tests/quaternion/test_quaternion.py
@@ -207,8 +207,8 @@ class TestQuaternion:
         assert qo_numpy2.shape == 2 * shape
         assert np.allclose(qo_numpy.data, qo_numpy2.data)
 
-        # public function .outer()
-        qo_dask2 = q.outer(q)
+        # public function .outer() with Dask
+        qo_dask2 = q.outer(q, lazy=True)
         assert isinstance(qo_dask2, Quaternion)
         assert qo_dask2.shape == 2 * shape
         assert np.allclose(qo_numpy.data, qo_dask2.data)
@@ -249,8 +249,8 @@ class TestQuaternion:
         assert qvo_numpy2.shape == qvo_numpy.shape
         assert np.allclose(qvo_numpy.data, qvo_numpy2.data)
 
-        # public function .outer()
-        qvo_dask2 = q.outer(v)
+        # public function .outer() with Dask
+        qvo_dask2 = q.outer(v, lazy=True)
         assert isinstance(qvo_dask2, Vector3d)
         assert qvo_dask2.shape == qvo_numpy.shape
         assert np.allclose(qvo_numpy.data, qvo_dask2.data)

--- a/orix/tests/quaternion/test_rotation.py
+++ b/orix/tests/quaternion/test_rotation.py
@@ -559,11 +559,9 @@ def test_outer_lazy_vec():
 def test_outer_lazy_progressbar_stdout(capsys):
     r1 = Rotation.random((5, 3))
     r2 = Rotation.random((6, 4))
-
     _ = r1.outer(r2, lazy=True, progressbar=True)
     out, _ = capsys.readouterr()
     assert "Completed" in out
-
     _ = r1.outer(r2, lazy=True, progressbar=False)
     out, _ = capsys.readouterr()
     assert not out

--- a/orix/tests/quaternion/test_rotation.py
+++ b/orix/tests/quaternion/test_rotation.py
@@ -525,6 +525,37 @@ def test_dot_outer_quat(rotation, improper, quaternion, expected):
     assert np.allclose(cosines.data, expected, atol=1e-4)
 
 
+def test_outer_lazy_rot():
+    r1 = Rotation.random((5, 3))
+    r2 = Rotation.random((11, 4))
+    r12 = r1.outer(r2)
+    r12_lazy = r1.outer(r2, lazy=True, chunk_size=20)
+    assert r12.shape == r12_lazy.shape
+    assert np.allclose(r12.data, r12_lazy.data)
+    assert np.allclose(r12.improper, r12_lazy.improper)
+    # different chunk size
+    r12_lazy2 = r1.outer(r2, lazy=True, chunk_size=3)
+    assert r12.shape == r12_lazy2.shape
+    assert np.allclose(r12.data, r12_lazy2.data)
+    assert np.allclose(r12.improper, r12_lazy2.improper)
+
+
+def test_outer_lazy_vec():
+    r = Rotation.random((5, 3))
+    v = Vector3d(np.random.rand(6, 4, 3)).unit
+    v2 = r.outer(v)
+    v2_lazy = r.outer(v, lazy=True, chunk_size=20)
+    assert isinstance(v2, Vector3d)
+    assert isinstance(v2_lazy, Vector3d)
+    assert v2.shape == v2_lazy.shape
+    assert np.allclose(v2.data, v2_lazy.data)
+    # different chunk size
+    v2_lazy2 = r.outer(v, lazy=True, chunk_size=3)
+    assert isinstance(v2_lazy2, Vector3d)
+    assert v2.shape == v2_lazy.shape
+    assert np.allclose(v2.data, v2_lazy2.data)
+
+
 @pytest.mark.parametrize(
     "rotation, expected",
     [

--- a/orix/tests/quaternion/test_rotation.py
+++ b/orix/tests/quaternion/test_rotation.py
@@ -556,6 +556,19 @@ def test_outer_lazy_vec():
     assert np.allclose(v2.data, v2_lazy2.data)
 
 
+def test_outer_lazy_progressbar_stdout(capsys):
+    r1 = Rotation.random((5, 3))
+    r2 = Rotation.random((6, 4))
+
+    _ = r1.outer(r2, lazy=True, progressbar=True)
+    out, _ = capsys.readouterr()
+    assert "Completed" in out
+
+    _ = r1.outer(r2, lazy=True, progressbar=False)
+    out, _ = capsys.readouterr()
+    assert not out
+
+
 @pytest.mark.parametrize(
     "rotation, expected",
     [


### PR DESCRIPTION
#### Description of the change
Now that `Vector3d` outer products can be computed in `Quaternion._outer_dask()`, and as previously discussed, this PR allows this functionality to be accessed using the public API through `.outer()`. In line with `._outer_dask()` 2 keyword arguments `lazy` and `chunksize` are added, and `lazy` defaults to `False` to conserve the current behaviour.

`Rotation._outer_dask()` has also been removed as it can be called though the inherited `Quaternion._outer_dask()` method.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> from orix.quaternion import Rotation
>>> import numpy as np
>>> r1 = Rotation.random((5, 3))
>>> r2 = Rotation.random((11, 4))
>>> r12 = r1.outer(r2)
>>> r12_lazy = r1.outer(r2, lazy=True, chunk_size=20)
>>> np.allclose(r12.data, r12_lazy.data)
True

>>> r = Rotation.random((5, 3))
>>> v = Vector3d(np.random.rand(6, 4, 3)).unit
>>> v2 = r.outer(v)
>>> v2_lazy = r.outer(v, lazy=True, chunk_size=20)
>>> np.allclose(v2.data, v2_lazy.data)
True
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
