### PR TITLE
Set matplotlib backend in `build.yml` only, remove assignment in tests

### DIFF
--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -24,8 +24,6 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 from matplotlib_scalebar import dimension, scalebar
 import numpy as np
 
-from orix.vector import Vector3d
-
 
 class CrystalMapPlot(Axes):
     """2D plotting of :class:`~orix.crystal_map.crystal_map.CrystalMap`

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -477,7 +477,7 @@ class Rotation(Quaternion):
             )
 
         euler = np.asarray(euler)
-        if np.any(np.abs(euler) > 9):
+        if np.any(np.abs(euler) > 4 * np.pi):
             warnings.warn(
                 "Angles are assumed to be in radians, but degrees might have been "
                 "passed."

--- a/orix/tests/plot/test_crystal_map_plot.py
+++ b/orix/tests/plot/test_crystal_map_plot.py
@@ -27,8 +27,6 @@ import pytest
 from orix.plot import CrystalMapPlot
 from orix.crystal_map import CrystalMap, PhaseList
 
-plt.rcParams["backend"] = "Agg"
-
 # Can be easily changed in the future
 PLOT_MAP = "plot_map"
 

--- a/orix/tests/plot/test_stereographic_plot.py
+++ b/orix/tests/plot/test_stereographic_plot.py
@@ -32,7 +32,6 @@ from orix import plot, vector
 from orix.quaternion.symmetry import C1, C6, Oh
 
 
-plt.rcParams["backend"] = "TkAgg"
 plt.rcParams["axes.grid"] = True
 PROJ_NAME = "stereographic"
 

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -27,8 +27,6 @@ from orix.quaternion import Orientation, Rotation
 from orix.quaternion.symmetry import C2, C3, C4, O
 
 
-plt.rcParams["backend"] = "Agg"
-
 # Note that many parts of the CrystalMap() class are tested while
 # testing IO and the Phase() and PhaseList() classes
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,6 @@ addopts = -ra
 
 [coverage:run]
 source = orix
-include = /orix/*
 omit =
      /orix/__init__.py
 relative_files = True


### PR DESCRIPTION
#### Description of the change
Removing all setting of Matplotlib backend in test files and only setting it in the GitHub YAML file seems to solve #327.

I've also made some minor fixes to silence some test warnings.

Increasing the Euler angle threshold for the warning in `Rotation.from_euler()` is necessary because non-indexed pixels in the .ang file writer sets Euler angles in these pixels to `4 pi`.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [n/a] New functions are imported in corresponding `__init__.py`.
- [n/a] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
