### PR TITLE
Fix reST formatting in project description in source distribution

### DIFF
--- a/.github/workflows/test_documentation_notebooks.yml
+++ b/.github/workflows/test_documentation_notebooks.yml
@@ -8,6 +8,8 @@ name: Test documentation notebooks
 on:
   schedule:
     - cron: '15 6 * * 1' # Run every Monday morning
+  workflow_dispatch:
+    workflow: "*"
 
 jobs:
   test-documentation-notebooks:
@@ -26,7 +28,7 @@ jobs:
       - name: Install dependencies and package
         shell: bash
         run: |
-          pip install -U -e .'[tests]'
+          pip install -U -e .'[tests, doc]'
           pip install nbval
       - name: Test documentation notebooks
         run: |

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,10 @@
       </h1>
     </p>
 
+.. Content above here until EXCLUDE plus one line is excluded from the long description
+.. in the source distributions uploaded to PyPI
+.. EXCLUDE
+
 |binder|_ |build_status|_ |Coveralls|_ |docs|_ |pypi_version|_  |downloads|_ |black|_ |doi|_
 
 .. |binder| image:: https://mybinder.org/badge_logo.svg

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,15 @@ extra_feature_requirements["dev"] = ["black", "manifix", "pre-commit >= 1.16"] +
     chain(*list(extra_feature_requirements.values()))
 )
 
+# Remove the "raw" ReStructuredText directive from the README so we can
+# use it as the long_description on PyPI
+readme = open("README.rst").read()
+readme_split = readme.split("\n")
+for i, line in enumerate(readme_split):
+    if line == ".. EXCLUDE":
+        break
+long_description = "\n".join(readme_split[i + 2 :])
+
 setup(
     name=__name__,
     version=str(__version__),
@@ -31,7 +40,8 @@ setup(
     author=__author__,
     author_email=__author_email__,
     description=__description__,
-    long_description=open("README.rst").read(),
+    long_description=long_description,
+    long_description_content_type="text/x-rst",
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
#### Description of the change
The source distribution couldn't be uploaded to PyPI ([log](https://github.com/pyxem/orix/runs/6367065668?check_suite_focus=true)) due to our newly added "raw" HTML directive in "README.rst", which PyPI doesn't allow. I've now removed this part before adding it to `setup()`. I'll manually re-run the publish action after this PR is merged.

Also, the weekly action checking the user guide notebooks with `nbval` now installs the `doc` dependencies. I've also added a manual trigger for this workflow.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.