### PR TITLE
Deprecate Misorientation.distance() in favour of get_distance_matrix()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,7 @@ Deprecated
 - The ``convention`` parameter in ``from_euler()`` and ``to_euler()`` methods has been
   deprecated, in favour of ``direction`` in the former. This parameter will be removed
   in release 1.0.
+- ``Misorientation.distance()`` in favour of ``Misorientation.get_distance_matrix()``.
 
 Fixed
 -----

--- a/doc/clustering_misorientations.ipynb
+++ b/doc/clustering_misorientations.ipynb
@@ -2,7 +2,10 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "nbsphinx": "hidden",
+    "tags": []
+   },
    "source": [
     "This notebook is part of the *orix* documentation https://orix.readthedocs.io. Links to the documentation won’t work from the notebook."
    ]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,7 +11,7 @@ from os.path import relpath, dirname
 import re
 import sys
 
-from orix import __author__, __version__
+import orix
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -20,9 +20,9 @@ from orix import __author__, __version__
 sys.path.append("../")
 
 project = "orix"
-copyright = f"2018-{str(datetime.now().year)}, {__author__}"
-author = __author__
-release = __version__
+copyright = f"2018-{str(datetime.now().year)}, {orix.__author__}"
+author = orix.__author__
+release = orix.__version__
 
 
 # Add any Sphinx extension module names here, as strings. They can be
@@ -81,10 +81,10 @@ html_favicon = "_static/img/orix_logo.png"
 # modification to point nbviewer and Binder to the GitHub master links
 # when the documentation is launched from a orix version with "dev" in
 # the version
-if "dev" in __version__:
+if "dev" in orix.__version__:
     release_version = "master"
 else:
-    release_version = "v" + __version__
+    release_version = "v" + orix.__version__
 # This is processed by Jinja2 and inserted before each notebook
 nbsphinx_prolog = (
     r"""
@@ -138,8 +138,8 @@ bibtex_bibfiles = ["bibliography.bib"]
 def linkcode_resolve(domain, info):
     """Determine the URL corresponding to Python object.
 
-    This is taken from SciPy's conf.py:
-    https://github.com/scipy/scipy/blob/master/doc/source/conf.py.
+    This is taken from SciPy's ``conf.py``:
+    https://github.com/scipy/scipy/blob/main/doc/source/conf.py.
     """
     if domain != "py":
         return None
@@ -157,6 +157,9 @@ def linkcode_resolve(domain, info):
             obj = getattr(obj, part)
         except Exception:
             return None
+
+    # Use the original function object if it is wrapped.
+    obj = getattr(obj, "__wrapped__", obj)
 
     try:
         fn = inspect.getsourcefile(obj)
@@ -180,17 +183,17 @@ def linkcode_resolve(domain, info):
     else:
         linespec = ""
 
-    startdir = os.path.abspath(os.path.join(dirname(__file__), ".."))
+    startdir = os.path.abspath(os.path.join(dirname(orix.__file__), ".."))
     fn = relpath(fn, start=startdir).replace(os.path.sep, "/")
 
     if fn.startswith("orix/"):
-        m = re.match(r"^.*dev0\+([a-f0-9]+)$", __version__)
+        m = re.match(r"^.*dev0\+([a-f\d]+)$", orix.__version__)
         pre_link = "https://github.com/pyxem/orix/blob/"
         if m:
             return pre_link + "%s/%s%s" % (m.group(1), fn, linespec)
-        elif "dev" in __version__:
+        elif "dev" in orix.__version__:
             return pre_link + "master/%s%s" % (fn, linespec)
         else:
-            return pre_link + "v%s/%s%s" % (__version__, fn, linespec)
+            return pre_link + "v%s/%s%s" % (orix.__version__, fn, linespec)
     else:
         return None

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -234,6 +234,11 @@ class Misorientation(Rotation):
         o_inside._symmetry = (Gl, Gr)
         return o_inside
 
+    @deprecated(
+        since="0.9",
+        alternative="orix.quaternion.Misorientation.get_distance_matrix",
+        removal="0.10",
+    )
     def distance(self, verbose=False, split_size=100):
         """Symmetry reduced distance.
 

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -91,6 +91,7 @@ def test_orientation_persistence(symmetry, vector):
     assert v1._tuples == v2._tuples
 
 
+# TODO: Remove in 0.10
 @pytest.mark.parametrize(
     "orientation, symmetry, expected",
     [
@@ -115,7 +116,8 @@ def test_orientation_persistence(symmetry, vector):
 def test_distance(orientation, symmetry, expected):
     orientation.symmetry = symmetry
     orientation = orientation.map_into_symmetry_reduced_zone(verbose=True)
-    distance = orientation.distance(verbose=True)
+    with pytest.warns(np.VisibleDeprecationWarning, match="Function "):
+        distance = orientation.distance(verbose=True)
     assert np.allclose(distance, expected, atol=1e-3)
 
 
@@ -376,7 +378,7 @@ class TestMisorientation:
         angle2 = p12.angle.min(axis=(0, 2, 3, 5))
         assert np.allclose(angle1, angle2)
 
-    # TODO: remove when distance() is removed
+    # TODO: Remove in 0.10
     @pytest.mark.parametrize("symmetry", _groups[:-1])
     def test_get_distance_matrix_equal_distance(self, symmetry):
         # do not test Oh, as this takes ~4 GB
@@ -388,7 +390,8 @@ class TestMisorientation:
         m1 = m.flatten()
         angle2 = m1.get_distance_matrix()
         assert np.allclose(angle1, angle2)
-        angle3 = m1.distance()
+        with pytest.warns(np.VisibleDeprecationWarning, match="Function "):
+            angle3 = m1.distance()
         assert np.allclose(angle1, angle3)
 
 


### PR DESCRIPTION
#### Description of the change
This PR adds a deprecation warning to `Misorientation.distance()`, which I forgot to do following #317. The warning states that it is deprecated in v0.9 and will be removed in v0.10, and points users to `get_distance_matrix()`.

We can remove the `distance()` method in both `Misorientation` and `Orientation` classes after v0.9 is released.

This must be merged before releasing v0.9.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
Calling `Orientation.distance()` emits two warnings now, since `Orientation` calls `Misorientation.distance()`. Should the deprecation warning for `Orientation.distance()` be removed?

```python
>>> from orix.quaternion import Orientation
>>> g = Orientation.random(2)
>>> g
Orientation (2,) 1
[[ 0.0689 -0.5322 -0.5434 -0.6456]
 [ 0.5999  0.2899 -0.3658  0.6499]]
>>> g.distance()
/home/hakon/kode/orix/orix/quaternion/orientation.py:792: VisibleDeprecationWarning: Function `distance()` is deprecated and will be removed in version 0.8. Use `orix.quaternion.Orientation.get_distance_matrix()` instead.
  since="0.7",
/home/hakon/kode/orix/orix/quaternion/orientation.py:238: VisibleDeprecationWarning: Function `distance()` is deprecated and will be removed in version 0.10. Use `orix.quaternion.Misorientation.get_distance_matrix()` instead.
  since="0.9",
array([[0.        , 2.46117879],
       [2.46117879, 0.        ]])
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.