### PR TITLE
Final preparations for 0.9 release

### DIFF
--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -1,5 +1,5 @@
 __name__ = "orix"
-__version__ = "0.9.0rc2"
+__version__ = "0.9.0"
 __author__ = "orix developers"
 __author_email__ = "pyxem.team@gmail.com"
 __description__ = "orix is an open-source Python library for handling crystal orientation mapping data."


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
Change version from "0.9.0rc2" to "0.9.0".

I plan to release 0.9.0 immediately after this PR is merged. Maintainers can inspect the [0.9.0 release draft](https://github.com/pyxem/orix/releases/tag/untagged-f619fd2243bb6a3dcfb3), which is identical to the 0.9.0rc1-2 release drafts apart from the versions.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)
- [ ] Merge #336.

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.