### PR TITLE
Post 0.9.0 release updates

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,30 +1,32 @@
-[
+{
+  "creators": [
     {
-        "name":"Håkon Wiik Ånes",
-        "orcid": "0000-0002-1213-2911",
-        "affiliation": "Norwegian University of Science and Technology"
+      "name": "Håkon Wiik Ånes",
+      "orcid": "0000-0002-1213-2911",
+      "affiliation": "Norwegian University of Science and Technology"
     },
     {
-        "name":"Ben Martineau"
+      "name": "Ben Martineau"
     },
     {
-        "name":"Phillip Crout",
-        "orcid": "0000-0001-5754-0938"
+      "name": "Phillip Crout",
+      "orcid": "0000-0001-5754-0938"
     },
     {
-        "name":"Paddy Harrison",
-        "orcid": "0000-0001-9798-8710",
-        "affiliation": "SIMaP, Grenoble INP"
+      "name": "Paddy Harrison",
+      "orcid": "0000-0001-9798-8710",
+      "affiliation": "SIMaP, Grenoble INP"
     },
     {
-        "name":"Duncan Johnstone",
-        "orcid": "0000-0003-3663-3793"
+      "name": "Duncan Johnstone",
+      "orcid": "0000-0003-3663-3793"
     },
     {
-        "name":"Niels Cautaerts",
-        "orcid": "0000-0002-6402-9879"
+      "name": "Niels Cautaerts",
+      "orcid": "0000-0002-6402-9879"
     },
     {
-        "name":"Simon Høgås"
+      "name": "Simon Høgås"
     }
-]
+  ]
+}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ All notable changes to the ``orix`` project are documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_, and
 this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+Unreleased
+==========
+
 2022-05-16 - version 0.9.0
 ==========================
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -198,7 +198,12 @@ the documentation doesn't take too long to build, either by us locally or the Re
 Docs GitHub action. To check that the notebooks with stored cell outputs are compatible
 with the current API, we run a scheduled GitHub Action every Monday morning which checks
 that the notebooks run OK and that they produce the same output now as when they were
-last executed. We use `nbval <https://nbval.readthedocs.io/en/latest/>`_ for this.
+last executed. We use `nbval <https://nbval.readthedocs.io>`_ for this.
+
+The user guide notebooks can be run interactively in the browser with the help of
+`Binder <https://mybinder.readthedocs.io>`_. When creating a server from the orix source
+code, Binder installs the packages listed in the `environment.yml` configuration file,
+which must include all `doc` dependencies in `setup.py` necessary to run the notebooks.
 
 Deprecations
 ============

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include CHANGELOG.rst
 include CONTRIBUTING.rst
 include getting_started.rst
+include environment.yml
 include LICENSE
 include MANIFEST.in
 include README.rst

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -12,22 +12,28 @@ Preparation
   ``.zenodo.json`` file.
 - Bump ``__version__`` in ``orix/__init__.py``, for example to "0.8.2".
 - Update the changelog ``CHANGELOG.rst``.
-- Let the PR collect comments for a day to ensure that other maintainers are
-  comfortable with releasing. Merge.
+- Let the PR collect comments for a day to ensure that other maintainers are comfortable
+  with releasing. Merge.
 
-Release (and tag)
------------------
-- Create a tagged, annotated (meaning with a release text) with the name 
-  v0.8.2" and title "orix 0.8.2". The tag target will be the ``master`` branch.
-  Draw inspiration from previous release texts. Publish the release.
-- Monitor the publish GitHub Action to ensure the release is successfully 
-  published to PyPI.
+Tag and release
+---------------
+- Create a tagged and annotated (meaning with text) release with the name "v0.8.2" and
+  title "orix 0.8.2". The tag target will be the ``master`` branch. Draw inspiration
+  from previous release texts. Publish the release.
+- Monitor the publish GitHub Action to ensure the release is successfully published to
+  PyPI.
 
 Post-release action
 -------------------
 - Monitor the `documentation build <https://readthedocs.org/projects/orix/builds>`_ to
   ensure that the new stable documentation is successfully built from the release.
-- Make a post-release PR to ``master`` with ``__version__`` updated (or 
-  reverted), e.g. to "0.9.dev0", and any updates to this guide if necessary.
+- Ensure that `Zenodo <https://doi.org/10.5281/zenodo.3459662>`_ received the new
+  release.
+- Ensure that Binder can run the user guide notebooks by clicking the Binder badges in
+  the top banner of one of the user guide notebooks via
+  `Read The Docs <https://orix.readthedocs.io/en/stable>`_.
+- Make a post-release PR to ``master`` with ``__version__`` updated (or reverted), e.g.
+  to "0.9.dev0", the "Unreleased" header added to the changelog, and any updates to this
+  guide if necessary.
 - Tidy up GitHub issues and close the corresponding milestone.
 - A PR to the conda-forge feedstock will be created by the conda-forge bot.

--- a/environment.yml
+++ b/environment.yml
@@ -2,24 +2,7 @@ name: doc-dependencies-for-binder
 channels:
   - conda-forge
 dependencies:
-  # Core dependencies
-  - dask
-  - diffpy.structure>=3
-  - h5py
-  - matplotlib>=3.3
-  - matplotlib-scalebar
-  - numba
-  - numpy
-  - pooch>=0.13
-  - quaternion
-  - scipy
-  - tqdm
-
-  # Documentation dependencies
-  - scikit-image
-  - scikit-learn
-
-  # Package
   - pip
   - pip:
       - --editable .
+      - --editable .[doc]

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: doc-dependencies-for-binder
 channels:
   - conda-forge
 dependencies:
+  # Core dependencies
   - dask
   - diffpy.structure>=3
   - h5py
@@ -12,6 +13,13 @@ dependencies:
   - pooch>=0.13
   - quaternion
   - scipy
+  - tqdm
+
+  # Documentation dependencies
   - scikit-image
   - scikit-learn
-  - tqdm
+
+  # Package
+  - pip
+  - pip:
+      - --editable .

--- a/environment.yml
+++ b/environment.yml
@@ -4,5 +4,4 @@ channels:
 dependencies:
   - pip
   - pip:
-      - --editable .
       - --editable .[doc]

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,17 @@
+name: doc-dependencies-for-binder
+channels:
+  - conda-forge
+dependencies:
+  - dask
+  - diffpy.structure>=3
+  - h5py
+  - matplotlib>=3.3
+  - matplotlib-scalebar
+  - numba
+  - numpy
+  - numpy-quaternion
+  - pooch>=0.13
+  - scipy
+  - scikit-image
+  - scikit-learn
+  - tqdm

--- a/environment.yml
+++ b/environment.yml
@@ -9,8 +9,8 @@ dependencies:
   - matplotlib-scalebar
   - numba
   - numpy
-  - numpy-quaternion
   - pooch>=0.13
+  - quaternion
   - scipy
   - scikit-image
   - scikit-learn

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -1,5 +1,5 @@
 __name__ = "orix"
-__version__ = "0.9.0"
+__version__ = "0.10.dev0"
 __author__ = "orix developers"
 __author_email__ = "pyxem.team@gmail.com"
 __description__ = "orix is an open-source Python library for handling crystal orientation mapping data."


### PR DESCRIPTION
#### Description of the change
* Bump version to `0.10.dev0`
* Add `environment.yml` file to inform Binder to install documentation dependencies. Merging this change will close #339.
* Update release guide with two steps to check the Zenodo DOI (didn't update properly from the 0.9.0 release) and Binder
* Fix the Zenodo metadata file

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.