### PR TITLE
Bump oldest supported Python version to 3.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.9, '3.10']
+        python-version: [3.9, "3.10"]
         include:
           - os: ubuntu-latest
-            python-version: 3.6
+            python-version: 3.7
             OLDEST_SUPPORTED_VERSION: true
             DEPENDENCIES: diffpy.structure==3  matplotlib==3.3
             LABEL: -oldest
@@ -70,7 +70,7 @@ jobs:
     needs: build-with-pip
     runs-on: ubuntu-latest
     steps:
-    - name: Coveralls finished
-      uses: AndreMiras/coveralls-python-action@develop
-      with:
-        parallel-finished: true
+      - name: Coveralls finished
+        uses: AndreMiras/coveralls-python-action@develop
+        with:
+          parallel-finished: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,10 +15,10 @@ Added
 - Support for type hints has been introduced and a section on this topic has been added
   to the contributing guide.
 
-Deprecated
-----------
-- Python 3.6 has been deprecated and the minimum supported version in ``orix`` is now
-  Python 3.7.
+Removed
+-------
+- Support for Python 3.6 has been removed. The minimum supported version in ``orix`` is
+  now Python 3.7.
 
 2022-05-16 - version 0.9.0
 ==========================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,19 @@ All notable changes to the ``orix`` project are documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_, and
 this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+Unreleased
+==========
+
+Added
+-----
+- Support for type hints has been introduced and a section on this topic has been added
+  to the contributing guide.
+
+Deprecated
+----------
+- Python 3.6 has been deprecated and the minimum supported version in ``orix`` is now
+  Python 3.7.
+
 2022-05-16 - version 0.9.0
 ==========================
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -81,6 +81,39 @@ Package imports should be structured into three blocks with blank lines between 
 (descending order): standard library (like ``os`` and ``typing``), third party packages
 (like ``numpy`` and ``matplotlib``) and finally ``orix`` imports.
 
+As of ``orix`` version 0.9, the code base is being transitioned to use type hints. New
+changes should be implemented using type hints in the function definition and without 
+type duplication in the function docstring, for example::
+
+    def my_new_function(
+            arg1: int, arg2: Optional[bool] = None
+        ) -> Tuple[float, np.ndarray]:
+        """This is a new function.
+
+        Parameters
+        ----------
+        arg1
+            Explanation about argument 1.
+        arg2
+            Explanation about flag argument 2. Default is None.
+
+        Returns
+        -------
+        values
+            Explanation about returned values.
+        """
+
+When working with classes in ``orix``, often a method argument will require another
+instance of the class. An example of this is :meth:`orix.vector.Vector3d.dot`, where the
+first argument to this function ``other`` is another instance of ``Vector3d``. In this
+case, to allow for the correct type hinting behaviour, the following import is required
+at the top of the file::
+
+    from __future__ import annotations
+
+Type hints for various built-in classes are available from the ``typing`` module.
+``np.ndarray`` should be used for arrays.
+
 Make changes
 ============
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -85,9 +85,7 @@ As of ``orix`` version 0.9, the code base is being transitioned to use type hint
 changes should be implemented using type hints in the function definition and without 
 type duplication in the function docstring, for example::
 
-    def my_new_function(
-            arg1: int, arg2: Optional[bool] = None
-        ) -> Tuple[float, np.ndarray]:
+    def my_function(arg1: int, arg2: Optional[bool] = None) -> Tuple[float, np.ndarray]:
         """This is a new function.
 
         Parameters

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -4,7 +4,7 @@ Installation
 
 orix can be installed from `Anaconda <https://anaconda.org/conda-forge/orix>`_, the
 `Python Package Index <https://pypi.org/project/orix/>`_ (``pip``), or from source, and
-supports Python >= 3.6.
+supports Python >= 3.7.
 
 We recommend you install it in a `conda environment
 <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
     long_description_content_type="text/x-rst",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
#### Description of the change
As discussed in #343 Python 3.6 is deprecated, but currently used in CI as the oldest supported version. This is preventing implementation of type hinting (as discussed in #338) into the code base as `annotations` from `__future__` is only available in Python 3.7+.

In this PR the oldest Python version used in CI is bumped to 3.7. A guide for implementing type hints is introduced into the contributing guide.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [n/a] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [x] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.