### PR TITLE
Add `black` automatic formatting to Jupyter notebooks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
 
+      - name: Check code style of Jupyter notebooks
+        run: |
+          pip install black[jupyter]
+          black doc/*.ipynb
+
   # Make sure all necessary files will be included in a release
   manifest:
     name: check manifest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
 
-      - name: Check code style of Jupyter notebooks
-        run: |
-          pip install black[jupyter]
-          black doc/*.ipynb
+      - name: Install Black with Jupyter extension
+        run: pip install black[jupyter]
 
+      - name: Check code style of Jupyter notebooks
+        run: black doc/*.ipynb
   # Make sure all necessary files will be included in a release
   manifest:
     name: check manifest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,4 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
+      - id: black-jupyter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,5 +2,4 @@ repos:
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
-      - id: black
       - id: black-jupyter

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -227,12 +227,18 @@ files by `nbsphinx <https://nbsphinx.readthedocs.io/en/latest/>`_:
   Cell output should only be stored in notebooks which are too computationally intensive
   for the Read the Docs server to handle, which has a limit of 15 minutes and 3 GB of
   memory per `documentation build <https://docs.readthedocs.io/en/stable/builds.html>`_.
-- We use the also use ``black`` to format notebooks cells. To prevent ``black`` from
-  automatically formatting regions of your code, please wrap these code blocks with the
-  following::
+- We also use ``black`` to format notebooks cells. To run the ``black`` formatter on
+  your notebook(s) locally please specify the notebook(s), ie.
+  ``black my_notebook.ipynb`` or ``black *.ipynb``, as ``black .`` will not format 
+  ``.ipynb`` files without explicit consent. To prevent ``black`` from automatically
+  formatting regions of your code, please wrap these code blocks with the following::
+
       # fmt: off
       python_code_block = not_to_be_formatted
       # fmt: on
+
+  Please see the `black documentation <https://black.readthedocs.io/en/stable/index.html>`_
+  for more details.
     
 In general, we run all notebooks every time the documentation is built with Sphinx, to
 ensure that all notebooks are compatible with the current API at all times. This is

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -227,7 +227,13 @@ files by `nbsphinx <https://nbsphinx.readthedocs.io/en/latest/>`_:
   Cell output should only be stored in notebooks which are too computationally intensive
   for the Read the Docs server to handle, which has a limit of 15 minutes and 3 GB of
   memory per `documentation build <https://docs.readthedocs.io/en/stable/builds.html>`_.
-
+- We use the also use ``black`` to format notebooks cells. To prevent ``black`` from
+  automatically formatting regions of your code, please wrap these code blocks with the
+  following::
+      # fmt: off
+      python_code_block = not_to_be_formatted
+      # fmt: on
+    
 In general, we run all notebooks every time the documentation is built with Sphinx, to
 ensure that all notebooks are compatible with the current API at all times. This is
 important! For computationally expensive notebooks however, we store the cell outputs so

--- a/doc/clustering_across_fundamental_region_boundaries.ipynb
+++ b/doc/clustering_across_fundamental_region_boundaries.ipynb
@@ -178,9 +178,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dbscan = DBSCAN(\n",
-    "    eps=np.deg2rad(17), min_samples=20, metric=\"precomputed\"\n",
-    ").fit(D2.astype(np.float32))\n",
+    "dbscan = DBSCAN(eps=np.deg2rad(17), min_samples=20, metric=\"precomputed\").fit(\n",
+    "    D2.astype(np.float32)\n",
+    ")\n",
     "print(\"Labels:\", np.unique(dbscan.labels_))"
    ]
   },
@@ -268,7 +268,8 @@
     "    fig.axes[1].view_init(15, angle)\n",
     "    plt.draw()\n",
     "\n",
-    "ani = animation.FuncAnimation(fig, animate, np.linspace(75, 360+74, 720), interval=25)"
+    "\n",
+    "ani = animation.FuncAnimation(fig, animate, np.linspace(75, 360 + 74, 720), interval=25)"
    ]
   }
  ],

--- a/doc/clustering_misorientations.ipynb
+++ b/doc/clustering_misorientations.ipynb
@@ -156,7 +156,9 @@
     "titles = [\"X\", \"Y\"]\n",
     "for i in range(len(ax)):\n",
     "    ckey.direction = Vector3d(directions[i])\n",
-    "    ax[i].imshow(ckey.orientation2color(~ori))  # Invert because orix assumes lab2crystal when coloring orientations\n",
+    "    ax[i].imshow(\n",
+    "        ckey.orientation2color(~ori)\n",
+    "    )  # Invert because orix assumes lab2crystal when coloring orientations\n",
     "    ax[i].set_title(f\"IPF-{titles[i]}\")\n",
     "    ax[i].axis(\"off\")\n",
     "fig.tight_layout()"
@@ -289,11 +291,7 @@
    "outputs": [],
    "source": [
     "# Compute clusters\n",
-    "dbscan = DBSCAN(\n",
-    "    eps=0.05,\n",
-    "    min_samples=10,\n",
-    "    metric=\"precomputed\"\n",
-    ").fit(D)\n",
+    "dbscan = DBSCAN(eps=0.05, min_samples=10, metric=\"precomputed\").fit(D)\n",
     "\n",
     "unique_labels, all_cluster_sizes = np.unique(dbscan.labels_, return_counts=True)\n",
     "print(\"Labels:\", unique_labels)\n",
@@ -391,7 +389,7 @@
     "        (1, 0, 0),  # sigma13a\n",
     "        (2, 1, 0),  # sigma13b\n",
     "    ],\n",
-    "    angles=np.deg2rad([64.40, 34.96, 85.03, 76.89, 57.22])\n",
+    "    angles=np.deg2rad([64.40, 34.96, 85.03, 76.89, 57.22]),\n",
     ")"
    ]
   },
@@ -468,9 +466,7 @@
     "cluster_sizes_scaled = 1000 * cluster_sizes / cluster_sizes.max()\n",
     "\n",
     "fig, ax = plt.subplots(figsize=(5, 5), subplot_kw=dict(projection=\"ipf\", symmetry=D6))\n",
-    "ax.scatter(\n",
-    "    cluster_means.axis, c=colors, s=cluster_sizes_scaled, alpha=0.5, ec=\"k\"\n",
-    ")"
+    "ax.scatter(cluster_means.axis, c=colors, s=cluster_sizes_scaled, alpha=0.5, ec=\"k\")"
    ]
   },
   {
@@ -517,7 +513,7 @@
     "    numpoints=1,\n",
     "    labelspacing=0.15,\n",
     "    columnspacing=0.15,\n",
-    "    handletextpad=0.05\n",
+    "    handletextpad=0.05,\n",
     ");"
    ]
   },
@@ -558,7 +554,10 @@
    "outputs": [],
    "source": [
     "mapping = np.ones(mori_all.shape + (3,))\n",
-    "new_mask = np.where(boundary_mask)[0][~small_mask], np.where(boundary_mask)[1][~small_mask]\n",
+    "new_mask = (\n",
+    "    np.where(boundary_mask)[0][~small_mask],\n",
+    "    np.where(boundary_mask)[1][~small_mask],\n",
+    ")\n",
     "mapping[new_mask] = labels_rgb"
    ]
   },

--- a/doc/clustering_orientations.ipynb
+++ b/doc/clustering_orientations.ipynb
@@ -44,16 +44,16 @@
     "from matplotlib.lines import Line2D\n",
     "from skimage.color import label2rgb\n",
     "\n",
-    "# Import orix classes \n",
+    "# Import orix classes\n",
     "from orix import data, plot\n",
     "from orix.quaternion import Orientation, OrientationRegion, Rotation\n",
     "from orix.quaternion.symmetry import D6\n",
     "from orix.vector import AxAngle, Vector3d\n",
     "\n",
     "\n",
-    "plt.rcParams.update({\n",
-    "    \"font.size\": 20, \"figure.figsize\": (10, 10), \"figure.facecolor\": \"w\"\n",
-    "})"
+    "plt.rcParams.update(\n",
+    "    {\"font.size\": 20, \"figure.figsize\": (10, 10), \"figure.facecolor\": \"w\"}\n",
+    ")"
    ]
   },
   {
@@ -196,7 +196,9 @@
     "titles = [\"X\", \"Y\"]\n",
     "for i in range(len(ax)):\n",
     "    ckey.direction = Vector3d(directions[i])\n",
-    "    ax[i].imshow(ckey.orientation2color(~ori))  # Invert because orix assumes lab2crystal when coloring orientations\n",
+    "    ax[i].imshow(\n",
+    "        ckey.orientation2color(~ori)\n",
+    "    )  # Invert because orix assumes lab2crystal when coloring orientations\n",
     "    ax[i].set_title(f\"IPF-{titles[i]}\")\n",
     "    ax[i].axis(\"off\")\n",
     "fig.tight_layout()"
@@ -287,7 +289,7 @@
     "dbscan = DBSCAN(\n",
     "    eps=0.05,  # Max. distance between two samples in radians\n",
     "    min_samples=40,\n",
-    "    metric=\"precomputed\"\n",
+    "    metric=\"precomputed\",\n",
     ").fit(D)\n",
     "\n",
     "unique_labels, all_cluster_sizes = np.unique(dbscan.labels_, return_counts=True)\n",
@@ -501,9 +503,7 @@
    "source": [
     "cluster_sizes_scaled = 5000 * cluster_sizes / cluster_sizes.max()\n",
     "fig, ax = plt.subplots(figsize=(5, 5), subplot_kw=dict(projection=\"ipf\", symmetry=D6))\n",
-    "ax.scatter(\n",
-    "    cluster_means.axis, c=colors, s=cluster_sizes_scaled, alpha=0.5, ec=\"k\"\n",
-    ")"
+    "ax.scatter(cluster_means.axis, c=colors, s=cluster_sizes_scaled, alpha=0.5, ec=\"k\")"
    ]
   },
   {
@@ -545,7 +545,7 @@
     "    wireframe_kwargs=wireframe_kwargs,\n",
     "    c=labels_rgb.reshape(-1, 3),\n",
     "    s=1,\n",
-    "    return_figure=True\n",
+    "    return_figure=True,\n",
     ")\n",
     "ax = fig.axes[0]\n",
     "ax.view_init(elev=90, azim=-30)\n",
@@ -563,7 +563,7 @@
     "    numpoints=1,\n",
     "    labelspacing=0.15,\n",
     "    columnspacing=0.15,\n",
-    "    handletextpad=0.05\n",
+    "    handletextpad=0.05,\n",
     ");"
    ]
   },

--- a/doc/crystal_directions.ipynb
+++ b/doc/crystal_directions.ipynb
@@ -48,13 +48,15 @@
     "from orix.vector import AxAngle, Miller, Vector3d\n",
     "\n",
     "\n",
-    "plt.rcParams.update({\n",
-    "    \"figure.figsize\": (7, 7),\n",
-    "    \"font.size\": 20,\n",
-    "    \"axes.grid\": True,\n",
-    "    \"lines.markersize\": 10,\n",
-    "    \"lines.linewidth\": 2,\n",
-    "})"
+    "plt.rcParams.update(\n",
+    "    {\n",
+    "        \"figure.figsize\": (7, 7),\n",
+    "        \"font.size\": 20,\n",
+    "        \"axes.grid\": True,\n",
+    "        \"lines.markersize\": 10,\n",
+    "        \"lines.linewidth\": 2,\n",
+    "    }\n",
+    ")"
    ]
   },
   {
@@ -75,8 +77,7 @@
    "outputs": [],
    "source": [
     "tetragonal = Phase(\n",
-    "    point_group=\"4\",\n",
-    "    structure=Structure(lattice=Lattice(0.5, 0.5, 1, 90, 90, 90))\n",
+    "    point_group=\"4\", structure=Structure(lattice=Lattice(0.5, 0.5, 1, 90, 90, 90))\n",
     ")\n",
     "print(tetragonal)\n",
     "print(tetragonal.structure.lattice)"
@@ -432,8 +433,7 @@
    "outputs": [],
    "source": [
     "trigonal = Phase(\n",
-    "    point_group=\"321\",\n",
-    "    structure=Structure(lattice=Lattice(4.9, 4.9, 5.4, 90, 90, 120))\n",
+    "    point_group=\"321\", structure=Structure(lattice=Lattice(4.9, 4.9, 5.4, 90, 90, 120))\n",
     ")\n",
     "trigonal"
    ]
@@ -564,7 +564,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m7 = Miller(uvw=[1, 0, 0] , phase=cubic)\n",
+    "m7 = Miller(uvw=[1, 0, 0], phase=cubic)\n",
     "m7.symmetrise(unique=True)"
    ]
   },
@@ -988,8 +988,8 @@
    "source": [
     "vz = Vector3d.zvector()\n",
     "v111 = Vector3d([1, 1, 1])\n",
-    "r1 = Rotation.from_neo_euler(AxAngle.from_axes_angles(\n",
-    "    v111.cross(vz), v111.angle_with(vz).data)\n",
+    "r1 = Rotation.from_neo_euler(\n",
+    "    AxAngle.from_axes_angles(v111.cross(vz), v111.angle_with(vz).data)\n",
     ")\n",
     "r2 = Rotation.from_neo_euler(AxAngle.from_axes_angles(vz, np.deg2rad(-15)))\n",
     "md5 = r2 * r1 * md4"

--- a/doc/crystal_map.ipynb
+++ b/doc/crystal_map.ipynb
@@ -153,12 +153,12 @@
     "    Structure(\n",
     "        title=\"austenite\",\n",
     "        atoms=[Atom(\"fe\", [0] * 3)],\n",
-    "        lattice=Lattice(0.360, 0.360, 0.360, 90, 90, 90)\n",
+    "        lattice=Lattice(0.360, 0.360, 0.360, 90, 90, 90),\n",
     "    ),\n",
     "    Structure(\n",
     "        title=\"ferrite\",\n",
     "        atoms=[Atom(\"fe\", [0] * 3)],\n",
-    "        lattice=Lattice(0.287, 0.287, 0.287, 90, 90, 90)\n",
+    "        lattice=Lattice(0.287, 0.287, 0.287, 90, 90, 90),\n",
     "    ),\n",
     "]\n",
     "phase_list = PhaseList(\n",
@@ -236,11 +236,7 @@
    "outputs": [],
    "source": [
     "fname_ang1 = \"sdss_dp_ci.ang\"\n",
-    "io.save(\n",
-    "    filename=tempdir + fname_ang1,\n",
-    "    object2write=xmap,\n",
-    "    confidence_index_prop=\"dp\"\n",
-    ")\n",
+    "io.save(filename=tempdir + fname_ang1, object2write=xmap, confidence_index_prop=\"dp\")\n",
     "\n",
     "xmap_reload1 = io.load(tempdir + fname_ang1)\n",
     "print(xmap_reload1)\n",
@@ -769,20 +765,20 @@
    "outputs": [],
    "source": [
     "PhaseList(\n",
-    "    names=['al', 'cu'],\n",
+    "    names=[\"al\", \"cu\"],\n",
     "    space_groups=[225, 225],\n",
-    "    colors=['lime', 'xkcd:violet'],\n",
+    "    colors=[\"lime\", \"xkcd:violet\"],\n",
     "    ids=[0, 1],\n",
     "    structures=[\n",
     "        Structure(\n",
     "            atoms=[Atom(\"al\", [0] * 3)],\n",
-    "            lattice=Lattice(0.405, 0.405, 0.405, 90, 90, 90)\n",
+    "            lattice=Lattice(0.405, 0.405, 0.405, 90, 90, 90),\n",
     "        ),\n",
     "        Structure(\n",
     "            atoms=[Atom(\"cu\", [0] * 3)],\n",
-    "            lattice=Lattice(0.361, 0.361, 0.361, 90, 90, 90)\n",
-    "        )\n",
-    "    ]\n",
+    "            lattice=Lattice(0.361, 0.361, 0.361, 90, 90, 90),\n",
+    "        ),\n",
+    "    ],\n",
     ")"
    ]
   },
@@ -802,13 +798,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "al = Phase(name='al', space_group=225, color=\"C0\")\n",
+    "al = Phase(name=\"al\", space_group=225, color=\"C0\")\n",
     "cu = Phase(\n",
     "    color=\"C1\",\n",
-    "    structure=Structure(\n",
-    "        title=\"cu\",\n",
-    "        lattice=Lattice(0.361, 0.361, 0.361, 90, 90, 90)\n",
-    "    )\n",
+    "    structure=Structure(title=\"cu\", lattice=Lattice(0.361, 0.361, 0.361, 90, 90, 90)),\n",
     ")\n",
     "\n",
     "PhaseList([al, cu])"
@@ -921,7 +914,9 @@
    "outputs": [],
    "source": [
     "r_austenite = xmap[\"austenite\"].rotations\n",
-    "o_austenite2 = Orientation(r_austenite, symmetry=xmap[\"austenite\"].phases[1].point_group)"
+    "o_austenite2 = Orientation(\n",
+    "    r_austenite, symmetry=xmap[\"austenite\"].phases[1].point_group\n",
+    ")"
    ]
   },
   {
@@ -1278,8 +1273,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
-    "#im = ax.plot_map(xmap)"
+    "# fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
+    "# im = ax.plot_map(xmap)"
    ]
   },
   {
@@ -1308,7 +1303,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ckey_m3m = plot.IPFColorKeyTSL(xmap.phases[\"austenite\"].point_group, direction=Vector3d.zvector())\n",
+    "ckey_m3m = plot.IPFColorKeyTSL(\n",
+    "    xmap.phases[\"austenite\"].point_group, direction=Vector3d.zvector()\n",
+    ")\n",
     "rgb_au = ckey_m3m.orientation2color(xmap[\"austenite\"].orientations)\n",
     "rgb_fe = ckey_m3m.orientation2color(xmap[\"ferrite\"].orientations)"
    ]
@@ -1482,8 +1479,10 @@
    "outputs": [],
    "source": [
     "plt.imsave(\n",
-    "    tempdir + 'phase_map_no_fluff.png',\n",
-    "    arr=ax.images[0].get_array()  # 2D NumPy array, possibly with an RGB tuple in each element\n",
+    "    tempdir + \"phase_map_no_fluff.png\",\n",
+    "    arr=ax.images[\n",
+    "        0\n",
+    "    ].get_array(),  # 2D NumPy array, possibly with an RGB tuple in each element\n",
     ")"
    ]
   },
@@ -1507,7 +1506,7 @@
     "    cmap=\"inferno\",\n",
     "    colorbar=True,\n",
     "    colorbar_label=\"Dottproduct\",\n",
-    "    return_figure=True\n",
+    "    return_figure=True,\n",
     ")"
    ]
   },
@@ -1563,7 +1562,7 @@
     "    vmax=angles.max() - 10,\n",
     "    overlay=xmap.iq,\n",
     "    colorbar=True,\n",
-    "    colorbar_label=\"Rotation angle\"\n",
+    "    colorbar_label=\"Rotation angle\",\n",
     ")"
    ]
   },
@@ -1586,7 +1585,7 @@
    "source": [
     "xmap[\"austenite\"].plot(\n",
     "    scalebar_properties=dict(location=\"upper left\", frameon=False, sep=6),\n",
-    "    legend_properties=dict(framealpha=1, handlelength=1.5, handletextpad=0.1)\n",
+    "    legend_properties=dict(framealpha=1, handlelength=1.5, handletextpad=0.1),\n",
     ")"
    ]
   },
@@ -1625,10 +1624,14 @@
    "outputs": [],
    "source": [
     "# Conditional slicing\n",
-    "xmap[xmap.dp > 0.81].plot(\"iq\", cmap=\"gray\", colorbar=True, colorbar_label=\"Image quality\")\n",
+    "xmap[xmap.dp > 0.81].plot(\n",
+    "    \"iq\", cmap=\"gray\", colorbar=True, colorbar_label=\"Image quality\"\n",
+    ")\n",
     "\n",
     "# Chained conditional slicing\n",
-    "xmap[(xmap.dp > 0.81) & (xmap.phase_id == 1)].plot(\"dp\", cmap=\"viridis\", colorbar=True, colorbar_label=\"Dot product\")"
+    "xmap[(xmap.dp > 0.81) & (xmap.phase_id == 1)].plot(\n",
+    "    \"dp\", cmap=\"viridis\", colorbar=True, colorbar_label=\"Dot product\"\n",
+    ")"
    ]
   },
   {
@@ -1647,7 +1650,7 @@
    "outputs": [],
    "source": [
     "# Property of interest\n",
-    "this_prop = 'dp'\n",
+    "this_prop = \"dp\"\n",
     "\n",
     "# Plot phase map again to see color changes\n",
     "xmap.plot(overlay=this_prop, remove_padding=True)\n",
@@ -1665,18 +1668,11 @@
     "    # Accessing the property dictionary directlyhttps://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.legend.html\n",
     "    data.append(xmap[p.name].prop[this_prop])\n",
     "    # or indirectly\n",
-    "    #data.append(xmap[p.name].dp)\n",
+    "    # data.append(xmap[p.name].dp)\n",
     "\n",
     "# Nice bar plot with property histogram per phase\n",
     "fig, ax = plt.subplots()\n",
-    "ax.hist(\n",
-    "    data,\n",
-    "    bins=20,\n",
-    "    histtype='bar',\n",
-    "    density=True,\n",
-    "    label=labels,\n",
-    "    color=colors\n",
-    ")\n",
+    "ax.hist(data, bins=20, histtype=\"bar\", density=True, label=labels, color=colors)\n",
     "ax.set_xlabel(this_prop)\n",
     "ax.set_ylabel(\"Frequency\")\n",
     "ax.legend();"
@@ -1693,11 +1689,12 @@
    "source": [
     "# Remove files written to disk in this user guide\n",
     "import os\n",
+    "\n",
     "for f in [\n",
     "    tempdir + \"sdss_ferrite_austenite2.h5\",\n",
     "    tempdir + \"sdss_dp_ci.ang\",\n",
-    "    tempdir + 'phase_map.png',\n",
-    "    tempdir + 'phase_map_no_fluff.png'\n",
+    "    tempdir + \"phase_map.png\",\n",
+    "    tempdir + \"phase_map_no_fluff.png\",\n",
     "]:\n",
     "    os.remove(f)\n",
     "os.rmdir(tempdir)"

--- a/doc/crystal_map.ipynb
+++ b/doc/crystal_map.ipynb
@@ -1478,12 +1478,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.imsave(\n",
-    "    tempdir + \"phase_map_no_fluff.png\",\n",
-    "    arr=ax.images[\n",
-    "        0\n",
-    "    ].get_array(),  # 2D NumPy array, possibly with an RGB tuple in each element\n",
-    ")"
+    "# 2D NumPy array, possibly with an RGB tuple in each element\n",
+    "plt.imsave(tempdir + \"phase_map_no_fluff.png\", arr=ax.images[0].get_array())"
    ]
   },
   {

--- a/doc/crystal_reference_frame.ipynb
+++ b/doc/crystal_reference_frame.ipynb
@@ -37,13 +37,15 @@
     "from orix.vector import Miller\n",
     "\n",
     "\n",
-    "plt.rcParams.update({\n",
-    "    \"figure.figsize\": (10, 5),\n",
-    "    \"font.size\": 20,\n",
-    "    \"axes.grid\": True,\n",
-    "    \"lines.markersize\": 10,\n",
-    "    \"lines.linewidth\": 3,\n",
-    "})"
+    "plt.rcParams.update(\n",
+    "    {\n",
+    "        \"figure.figsize\": (10, 5),\n",
+    "        \"font.size\": 20,\n",
+    "        \"axes.grid\": True,\n",
+    "        \"lines.markersize\": 10,\n",
+    "        \"lines.linewidth\": 3,\n",
+    "    }\n",
+    ")"
    ]
   },
   {
@@ -234,7 +236,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = abc.scatter(c=[\"r\", \"g\", \"b\"], marker=\"o\", return_figure=True, axes_labels=[\"e1\", \"e2\"], hemisphere=\"both\")\n",
+    "fig = abc.scatter(\n",
+    "    c=[\"r\", \"g\", \"b\"],\n",
+    "    marker=\"o\",\n",
+    "    return_figure=True,\n",
+    "    axes_labels=[\"e1\", \"e2\"],\n",
+    "    hemisphere=\"both\",\n",
+    ")\n",
     "abcr.scatter(c=[\"r\", \"g\", \"b\"], marker=\"x\", s=300, figure=fig)"
    ]
   },
@@ -311,10 +319,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.allclose(\n",
-    "    abc.data,  # (x, y, z)\n",
-    "    np.dot(abc.uvw, phase.structure.lattice.base)\n",
-    ")"
+    "np.allclose(abc.data, np.dot(abc.uvw, phase.structure.lattice.base))  # (x, y, z)"
    ]
   },
   {
@@ -326,7 +331,7 @@
    "source": [
     "np.allclose(\n",
     "    abcr.data,  # (x, y, z)\n",
-    "    np.dot(abcr.hkl, np.linalg.inv(phase.structure.lattice.base).T)\n",
+    "    np.dot(abcr.hkl, np.linalg.inv(phase.structure.lattice.base).T),\n",
     ")"
    ]
   }

--- a/doc/point_groups.ipynb
+++ b/doc/point_groups.ipynb
@@ -23,6 +23,23 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "from matplotlib import pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "from orix import plot\n",
+    "from orix.quaternion import Rotation, symmetry\n",
+    "from orix.vector import Vector3d\n",
+    "\n",
+    "plt.rcParams.update({\"font.size\": 15})"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -42,11 +59,6 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
-    "\n",
-    "from orix.quaternion import symmetry\n",
-    "\n",
-    "\n",
     "symmetry.O.plot()"
    ]
   },
@@ -63,56 +75,64 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from matplotlib import pyplot as plt\n",
-    "import numpy as np\n",
-    "\n",
-    "from orix import plot\n",
-    "from orix.quaternion import Rotation\n",
-    "from orix.vector import Vector3d\n",
-    "\n",
-    "schoenflies = ['C1', 'Ci', 'C2x', 'C2y', 'C2z', 'Csx', 'Csy', 'Csz', 'C2h', 'D2', 'C2v', 'D2h', 'C4', 'S4', 'C4h', 'D4', 'C4v', 'D2d', 'D4h', 'C3', 'S6', 'D3x', 'D3y', 'D3', 'C3v', 'D3d', 'C6', 'C3h', 'C6h', 'D6', 'C6v', 'D3h', 'D6h', 'T', 'Th', 'O', 'Td', 'Oh']\n",
+    "# fmt: off\n",
+    "schoenflies = [\n",
+    "    \"C1\", \"Ci\",                                          # triclinic,\n",
+    "    \"C2x\", \"C2y\", \"C2z\", \"Csx\", \"Csy\", \"Csz\", \"C2h\",     # monoclinic\n",
+    "    \"D2\", \"C2v\", \"D2h\",                                  # orthorhombic\n",
+    "    \"C4\", \"S4\", \"C4h\", \"D4\", \"C4v\", \"D2d\", \"D4h\",        # tetragonal\n",
+    "    \"C3\", \"S6\", \"D3x\", \"D3y\", \"D3\", \"C3v\", \"D3d\", \"C6\",  # trigonal\n",
+    "    \"C3h\", \"C6h\", \"D6\", \"C6v\", \"D3h\", \"D6h\",             # hexagonal\n",
+    "    \"T\", \"Th\", \"O\", \"Td\", \"Oh\",                          # cubic\n",
+    "]\n",
+    "# fmt: on\n",
     "\n",
     "assert len(symmetry._groups) == len(schoenflies)\n",
     "\n",
-    "schoenflies = [s for s in schoenflies if not (s.endswith('x') or s.endswith('y'))]\n",
+    "schoenflies = [s for s in schoenflies if not (s.endswith(\"x\") or s.endswith(\"y\"))]\n",
     "\n",
     "assert len(schoenflies) == 32\n",
     "\n",
     "orientation = Rotation.from_axes_angles((-1, 8, 1), np.deg2rad(65))\n",
     "\n",
-    "fig, ax = plt.subplots(nrows=8, ncols=4, figsize=(10, 20), subplot_kw=dict(projection='stereographic'))\n",
+    "fig, ax = plt.subplots(\n",
+    "    nrows=8, ncols=4, figsize=(10, 20), subplot_kw=dict(projection=\"stereographic\")\n",
+    ")\n",
     "ax = ax.ravel()\n",
     "\n",
     "for i, s in enumerate(schoenflies):\n",
     "    sym = getattr(symmetry, s)\n",
     "\n",
     "    ori_sym = sym.outer(orientation)\n",
-    "    v = (ori_sym * Vector3d.zvector())\n",
-    "    \n",
+    "    v = ori_sym * Vector3d.zvector()\n",
+    "\n",
     "    # reflection in the projection plane (x-y) is performed internally in\n",
     "    # Symmetry.plot() or when using the `reproject=True` argument for\n",
     "    # Vector3d.scatter()\n",
     "    v_reproject = Vector3d(v.data.copy())\n",
     "    v_reproject.z *= -1\n",
-    "    \n",
+    "\n",
     "    # the Symmetry marker formatting for vectors on the upper and lower hemisphere\n",
     "    # can be set using `kwargs` and `reproject_scatter_kwargs`, respectively, for\n",
-    "    # Symmetry.plot() \n",
-    "    \n",
+    "    # Symmetry.plot()\n",
+    "\n",
     "    # vectors on the upper hemisphere are shown as open circles\n",
-    "    ax[i].scatter(v, marker='o', fc='None', ec='k', s=150)\n",
+    "    ax[i].scatter(v, marker=\"o\", fc=\"None\", ec=\"k\", s=150)\n",
     "    # vectors on the lower hemisphere are reprojected onto the upper hemisphere and\n",
     "    # shown as crosses\n",
-    "    ax[i].scatter(v_reproject, marker='+', ec='C0', s=150)\n",
+    "    ax[i].scatter(v_reproject, marker=\"+\", ec=\"C0\", s=150)\n",
     "\n",
-    "    ax[i].set_title(f'${s}$ $({sym.name})$')\n",
-    "    ax[i].set_labels('a', 'b', None)\n",
+    "    ax[i].set_title(f\"${s}$ $({sym.name})$\")\n",
+    "    ax[i].set_labels(\"a\", \"b\", None)\n",
     "\n",
     "fig.tight_layout()"
    ]
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "4396f389b93e7269692bd3bea4c62813bbe379469bde939b058805f538feec11"
+  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
@@ -128,7 +148,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/doc/stereographic_projection.ipynb
+++ b/doc/stereographic_projection.ipynb
@@ -55,17 +55,21 @@
     "import tempfile\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "from orix import plot  # Must be imported for Matplotlib to register orix' projections like \"stereographic\"\n",
+    "from orix import (\n",
+    "    plot,\n",
+    ")  # Must be imported for Matplotlib to register orix' projections like \"stereographic\"\n",
     "from orix.vector import Vector3d\n",
     "\n",
     "\n",
     "# We'll want our plots to look a bit larger than the default size\n",
-    "plt.rcParams.update({\n",
-    "    \"figure.figsize\": (10, 5),\n",
-    "    \"lines.markersize\": 10,\n",
-    "    \"font.size\": 20,\n",
-    "    \"axes.grid\": False,\n",
-    "})"
+    "plt.rcParams.update(\n",
+    "    {\n",
+    "        \"figure.figsize\": (10, 5),\n",
+    "        \"lines.markersize\": 10,\n",
+    "        \"font.size\": 20,\n",
+    "        \"axes.grid\": False,\n",
+    "    }\n",
+    ")"
    ]
   },
   {
@@ -204,12 +208,12 @@
     "labels = [\"x\", \"y\", None]\n",
     "v2.scatter(\n",
     "    axes_labels=labels, show_hemisphere_label=True, figure_kwargs=fig_kwargs\n",
-    ")  # \"upper\" default\n",
+    ")  # default hemisphere is \"upper\"\n",
     "v2.scatter(\n",
     "    hemisphere=\"lower\",\n",
     "    axes_labels=labels,\n",
     "    show_hemisphere_label=True,\n",
-    "    figure_kwargs=fig_kwargs\n",
+    "    figure_kwargs=fig_kwargs,\n",
     ")\n",
     "v2.scatter(hemisphere=\"both\", axes_labels=labels, c=[\"C0\", \"C1\"])"
    ]
@@ -230,7 +234,13 @@
    "outputs": [],
    "source": [
     "reproject_scatter_kwargs = dict(marker=\"o\", fc=\"None\", ec=\"r\", s=150)\n",
-    "v2.scatter(axes_labels=labels, show_hemisphere_label=True, figure_kwargs=fig_kwargs, reproject=True, reproject_scatter_kwargs=reproject_scatter_kwargs)"
+    "v2.scatter(\n",
+    "    axes_labels=labels,\n",
+    "    show_hemisphere_label=True,\n",
+    "    figure_kwargs=fig_kwargs,\n",
+    "    reproject=True,\n",
+    "    reproject_scatter_kwargs=reproject_scatter_kwargs,\n",
+    ")"
    ]
   },
   {
@@ -384,7 +394,7 @@
     "v4.scatter(\n",
     "    hemisphere=\"both\",\n",
     "    vector_labels=[str(vi).replace(\" \", \"\") for vi in v4.data],\n",
-    "    text_kwargs=dict(size=15)\n",
+    "    text_kwargs=dict(size=15),\n",
     ")"
    ]
   },
@@ -412,7 +422,7 @@
     "ax[0].show_hemisphere_label()\n",
     "for vi in v4:\n",
     "    ax[0].text(vi, s=format_vector(vi), size=15)\n",
-    "    \n",
+    "\n",
     "ax[1].hemisphere = \"lower\"\n",
     "ax[1].scatter(v4)\n",
     "ax[1].show_hemisphere_label()\n",
@@ -440,9 +450,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(\n",
-    "    figsize=(5, 5), subplot_kw=dict(projection=\"stereographic\")\n",
-    ")\n",
+    "fig, ax = plt.subplots(figsize=(5, 5), subplot_kw=dict(projection=\"stereographic\"))\n",
     "azimuth = np.deg2rad([0, 60, 180])\n",
     "polar = np.deg2rad([0, 60, 60])\n",
     "ax.scatter(azimuth, polar, c=[\"C0\", \"C1\", \"C2\"], s=200)\n",
@@ -474,7 +482,7 @@
     "    show_hemisphere_label=True,\n",
     "    figure_kwargs=dict(figsize=(5, 5)),\n",
     "    c=[\"C0\", \"C1\", \"C2\"],\n",
-    "    s=200\n",
+    "    s=200,\n",
     ")"
    ]
   },
@@ -496,7 +504,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "v6 = Vector3d.from_polar(azimuth=np.deg2rad([0, 60, 180]), polar=np.deg2rad([0, 60, 60]))\n",
+    "v6 = Vector3d.from_polar(\n",
+    "    azimuth=np.deg2rad([0, 60, 180]), polar=np.deg2rad([0, 60, 60])\n",
+    ")\n",
     "\n",
     "colors = [\"C0\", \"C1\", \"C2\"]\n",
     "fig6 = v6.scatter(\n",
@@ -504,7 +514,7 @@
     "    s=200,\n",
     "    axes_labels=[\"RD\", \"TD\", None],\n",
     "    show_hemisphere_label=True,\n",
-    "    return_figure=True\n",
+    "    return_figure=True,\n",
     ")\n",
     "v6.draw_circle(color=colors, linewidth=2, figure=fig6)"
    ]
@@ -561,9 +571,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(\n",
-    "    figsize=(5, 5), subplot_kw=dict(projection=\"stereographic\")\n",
-    ")\n",
+    "fig, ax = plt.subplots(figsize=(5, 5), subplot_kw=dict(projection=\"stereographic\"))\n",
     "colors = [\"C0\", \"C1\", \"C2\"]\n",
     "azimuth = np.deg2rad([0, 60, 180])\n",
     "polar = np.deg2rad([0, 60, 60])\n",
@@ -578,11 +586,7 @@
     "v7 = v6[0].cross(v6[1])\n",
     "ax.scatter(v7, c=\"xkcd:pink\", marker=\"p\", s=250)\n",
     "ax.draw_circle(\n",
-    "    v7,\n",
-    "    color=\"xkcd:pink\",\n",
-    "    linestyle=\"--\",\n",
-    "    linewidth=3,\n",
-    "    opening_angle=0.25 * np.pi\n",
+    "    v7, color=\"xkcd:pink\", linestyle=\"--\", linewidth=3, opening_angle=0.25 * np.pi\n",
     ")"
    ]
   },
@@ -604,7 +608,9 @@
    "source": [
     "v8 = Vector3d([(1, 1, 1), (-1, 1, 1)])\n",
     "fig = v8.scatter(axes_labels=[\"X\", \"Y\"], return_figure=True, c=[\"C0\", \"C1\"])\n",
-    "v8.draw_circle(reproject=True, figure=fig, color=[\"C0\", \"C1\"], opening_angle=np.deg2rad([90, 45]))"
+    "v8.draw_circle(\n",
+    "    reproject=True, figure=fig, color=[\"C0\", \"C1\"], opening_angle=np.deg2rad([90, 45])\n",
+    ")"
    ]
   },
   {
@@ -641,7 +647,7 @@
     "ax.draw_circle(v_left, steps=steps, **kwargs)\n",
     "ax.draw_circle(v010, opening_angle=polar, steps=steps, **kwargs)\n",
     "ax.draw_circle(v010_opposite, opening_angle=polar, steps=steps, **kwargs)\n",
-    "for label, azimuth in zip([\"B\", \"M''\", \"A\", \"M'\"], np.array([0, 0.5, 1, 1.5]) * np. pi):\n",
+    "for label, azimuth in zip([\"B\", \"M''\", \"A\", \"M'\"], np.array([0, 0.5, 1, 1.5]) * np.pi):\n",
     "    ax.text(azimuth, 0.5 * np.pi, s=label, c=\"C1\")"
    ]
   },
@@ -677,25 +683,27 @@
     "ax[0].symmetry_marker(v3fold, fold=3, c=\"C3\", s=marker_size)\n",
     "ax[0].draw_circle(v3fold, color=\"C3\")\n",
     "# 2-fold\n",
-    "v2fold = Vector3d([\n",
-    "    [1, 0, 1],\n",
-    "    [0, 1, 1],\n",
-    "    [-1, 0, 1],\n",
-    "    [0, -1, 1],\n",
-    "    [1, 1, 0],\n",
-    "    [-1, -1, 0],\n",
-    "    [-1, 1, 0],\n",
-    "    [1, -1, 0],\n",
-    "])\n",
+    "# fmt: off\n",
+    "v2fold = Vector3d(\n",
+    "    [\n",
+    "        [ 1,  0, 1],\n",
+    "        [ 0,  1, 1],\n",
+    "        [-1,  0, 1],\n",
+    "        [ 0, -1, 1],\n",
+    "        [ 1,  1, 0],\n",
+    "        [-1, -1, 0],\n",
+    "        [-1,  1, 0],\n",
+    "        [ 1, -1, 0],\n",
+    "    ]\n",
+    ")\n",
+    "# fmt: on\n",
     "ax[0].symmetry_marker(v2fold, fold=2, c=\"C2\", s=marker_size)\n",
     "ax[0].draw_circle(v2fold, color=\"C2\")\n",
     "\n",
     "ax[1].stereographic_grid(False)\n",
     "ax[1].set_title(\"222\", pad=20)\n",
     "# 2-fold\n",
-    "v2fold = Vector3d([\n",
-    "    [0, 0, 1], [1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0]\n",
-    "])\n",
+    "v2fold = Vector3d([[0, 0, 1], [1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0]])\n",
     "ax[1].symmetry_marker(v2fold, fold=2, c=\"C2\", s=800)\n",
     "ax[1].draw_circle(v2fold, color=\"C2\")"
    ]
@@ -711,6 +719,7 @@
    "source": [
     "# Remove files written to disk in this user guide\n",
     "import os\n",
+    "\n",
     "os.remove(vector_file)\n",
     "os.rmdir(temp_dir)"
    ]

--- a/doc/uniform_sampling_of_orientation_space.ipynb
+++ b/doc/uniform_sampling_of_orientation_space.ipynb
@@ -101,12 +101,14 @@
     "from orix.vector import Vector3d\n",
     "\n",
     "\n",
-    "plt.rcParams.update({\n",
-    "    \"axes.grid\": True,\n",
-    "    \"figure.figsize\": (15, 5),\n",
-    "    \"font.size\": 20,\n",
-    "    \"lines.linewidth\": 2,\n",
-    "})"
+    "plt.rcParams.update(\n",
+    "    {\n",
+    "        \"axes.grid\": True,\n",
+    "        \"figure.figsize\": (15, 5),\n",
+    "        \"font.size\": 20,\n",
+    "        \"lines.linewidth\": 2,\n",
+    "    }\n",
+    ")"
    ]
   },
   {
@@ -139,7 +141,7 @@
    "outputs": [],
    "source": [
     "rot_cube = get_sample_fundamental(resolution2, point_group=pg432, method=\"cubochoric\")\n",
-    "#rot_cube = get_sample_fundamental(point_group=pg432, method=\"cubochoric\", semi_edge_steps=67)  # Gives identical results\n",
+    "# rot_cube = get_sample_fundamental(point_group=pg432, method=\"cubochoric\", semi_edge_steps=67)  # Gives identical results\n",
     "rot_cube"
    ]
   },

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ extra_feature_requirements = {
     "tests": ["pytest >= 5.4", "pytest-cov >= 2.8.1", "coverage >= 5.0"],
 }
 extra_feature_requirements["dev"] = [
-    "black",
+    "black[jupyter]",
     "manifix",
     "outdated",
     "pre-commit >= 1.16",


### PR DESCRIPTION
#### Description of the change
As discussed in #349, we already use `black` for code formatting, and we can extend this to Jupyter notebooks. When installing `black` with `pip`, there is the option `black[jupyter]` (and `black-jupyter` package on `conda`). By default `black` does not format notebooks, but will if `.ipynb` files are passed to it.

In this PR `black-jupyter` is added as a `pre-commit` hook, the optional dependencies, ie. `black[jupyter]`, are added to `setup.py`, a note has been added to the contributing guide on this topic, and the existing notebooks have been formatted.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)


#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [n/a] New functions are imported in corresponding `__init__.py`.
- [n/a] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [x] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.