### PR TITLE
Ax ipf plot

### DIFF
--- a/orix/plot/direction_color_keys/direction_color_key_tsl.py
+++ b/orix/plot/direction_color_keys/direction_color_key_tsl.py
@@ -143,26 +143,14 @@ class DirectionColorKeyTSL(DirectionColorKey):
 
         Returns
         -------
-        figure : matplotlib.figure.Figure
+        figure
             Color key figure, returned if `return_figure` is True.
         """
         from orix.plot.inverse_pole_figure_plot import _setup_inverse_pole_figure_plot
 
-        laue_group = self.symmetry
-
-        rgb_grid, (x_min, x_max), (y_min, y_max) = self._create_rgb_grid(
-            return_min_max=True
-        )
-
-        fig, axes = _setup_inverse_pole_figure_plot(laue_group)
+        fig, axes = _setup_inverse_pole_figure_plot(self.symmetry)
         ax = axes[0]
-        for loc in ["left", "center", "right"]:
-            title = ax.get_title(loc)
-            if title != "":
-                ax.set_title(laue_group.name, loc=loc, fontweight="bold")
-        ax.stereographic_grid(False)
-        ax._edge_patch.set_linewidth(1.5)
-        ax.imshow(rgb_grid, extent=(x_min, x_max, y_min, y_max), zorder=0)
+        ax.plot_ipf_color_key()
 
         if return_figure:
             return fig

--- a/orix/plot/inverse_pole_figure_plot.py
+++ b/orix/plot/inverse_pole_figure_plot.py
@@ -232,7 +232,7 @@ class InversePoleFigurePlot(StereographicPlot):
         return v.in_fundamental_sector(self._symmetry)
 
     def plot_ipf_color_key(self) -> None:
-        """Plot an IPF color key code on an axis."""
+        """Plot an IPF color key code on this axis."""
         symmetry = self._symmetry
         direction_color_key = DirectionColorKeyTSL(symmetry)
 
@@ -253,8 +253,7 @@ class InversePoleFigurePlot(StereographicPlot):
             if any(is_close) and plt.rcParams["axes.titley"] is None:
                 loc = "left"
 
-        self.set_title(_get_ipf_title(self._direction), loc=loc, fontweight="bold")
-        self.set_title(symmetry.name, fontweight="bold")
+        self.set_title(symmetry.name, loc=loc, fontweight="bold")
         self.stereographic_grid(False)
         self._edge_patch.set_linewidth(1.5)
         self.imshow(rgb_grid, extent=(x_min, x_max, y_min, y_max), zorder=0)

--- a/orix/plot/orientation_color_keys/ipf_color_key_tsl.py
+++ b/orix/plot/orientation_color_keys/ipf_color_key_tsl.py
@@ -16,8 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Optional
+
+from matplotlib.figure import Figure
+import numpy as np
+
 from orix.plot.orientation_color_keys import IPFColorKey
 from orix.plot.direction_color_keys import DirectionColorKeyTSL
+from orix.quaternion import Orientation, Symmetry
+from orix.vector.vector3d import Vector3d
 
 
 class IPFColorKeyTSL(IPFColorKey):
@@ -28,7 +35,9 @@ class IPFColorKeyTSL(IPFColorKey):
     This is based on the TSL color key implemented in MTEX.
     """
 
-    def __init__(self, symmetry, direction=None):
+    def __init__(
+        self, symmetry: Symmetry, direction: Optional[Vector3d] = None
+    ) -> None:
         """Create an inverse pole figure (IPF) color key to color
         orientations according a sample direction and a Laue symmetry's
         fundamental sector (IPF).
@@ -45,10 +54,10 @@ class IPFColorKeyTSL(IPFColorKey):
         super().__init__(symmetry.laue, direction=direction)
 
     @property
-    def direction_color_key(self):
+    def direction_color_key(self) -> DirectionColorKeyTSL:
         return DirectionColorKeyTSL(self.symmetry)
 
-    def orientation2color(self, orientation):
+    def orientation2color(self, orientation: Orientation) -> np.ndarray:
         """Return an RGB color per orientation given a Laue symmetry
         and a sample direction.
 
@@ -65,22 +74,22 @@ class IPFColorKeyTSL(IPFColorKey):
             Color array of shape `orientation.shape` + (3,).
         """
         # TODO: Take crystal axes into account, by using Miller instead
-        #  of Vector3d
+        # of Vector3d
         m = orientation * self.direction
         rgb = self.direction_color_key.direction2color(m)
         return rgb
 
-    def plot(self, return_figure=False):
+    def plot(self, return_figure: bool = False) -> Optional[Figure]:
         """Plot the inverse pole figure color key.
 
         Parameters
         ----------
-        return_figure : bool, optional
+        return_figure
             Whether to return the figure. Default is False.
 
         Returns
         -------
-        figure : matplotlib.figure.Figure
+        figure
             Color key figure, returned if `return_figure` is True.
         """
         return self.direction_color_key.plot(return_figure=return_figure)


### PR DESCRIPTION
#### Description of the change
As raised by @maclariz in #352.

At the moment it is difficult to display an IPF colour key on a custom figure, which would be very useful behaviour for users when presenting their data. In this PR the `IPFColorKeyTSL.plot()` code is refactored such that the same functionality can be called from `InversePoleFigurePlot` through a new `plot_ipf_color_key()` method.

This feature has also been discussed in #332.

NB. this is a continuation of #353 as I had messed up the commit history.

#### Progress of the PR
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Unit tests with pytest for all lines
- [ ] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
# old behaviour
from orix.plot.orientation_color_keys import IPFColorKeyTSL
from orix.quaternion import symmetry, Orientation
from orix import plot
from orix.vector import Vector3d

ipfkey = IPFColorKeyTSL(symmetry=symmetry.Oh)
ipfkey.plot()
```
<img width="285" alt="de5d449c-8036-4c52-81b4-3c9bf2475b16" src="https://user-images.githubusercontent.com/16853829/169868824-b2cd3f32-b5f3-4ede-8110-b61d98564de9.png">

```python
# new behaviour from this PR
from matplotlib import pyplot as plt
fig, ax = plt.subplots(subplot_kw=dict(projection='stereographic'))
o = Orientation.random(10000)
c = ipfkey.orientation2color(o)
ax.scatter(o * Vector3d.zvector(), s=2, c=c)

ax2 = fig.add_axes([0.8, 0.8, 0.2, 0.2], projection='ipf', symmetry=symmetry.Oh)
ax2.plot_ipf_colour_key()
```
<img width="340" alt="a54590b3-e275-4303-b99f-b33f00b088c8" src="https://user-images.githubusercontent.com/16853829/169868968-ce281dc3-33b0-46d5-a93c-0af246320176.png">


#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.