### PR TITLE
Add `isort` dependency and pre-commit hook

### DIFF
--- a/.github/workflows/perhaps_make_tagged_release_draft.py
+++ b/.github/workflows/perhaps_make_tagged_release_draft.py
@@ -15,11 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with orix. If not, see <http://www.gnu.org/licenses/>.
 
-from packaging.version import Version
 import re
 
 from outdated import check_outdated
-
+from packaging.version import Version
 
 with open("../../orix/__init__.py") as fid:
     for line in fid:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,15 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black-jupyter
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)
+        args:
+          [
+            "--profile",
+            "black",
+            "--filter-files",
+            "--force-sort-within-sections",
+          ]

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -61,9 +61,10 @@ Code style
 
 The code making up orix is formatted closely following the `Style Guide for Python Code
 <https://www.python.org/dev/peps/pep-0008/>`_ with `The Black Code style
-<https://black.readthedocs.io/en/stable/the_black_code_style/index.html>`_. We use
-`pre-commit <https://pre-commit.com>`_ to run ``black`` automatically prior to each
-local commit. Please install it in your environment::
+<https://black.readthedocs.io/en/stable/the_black_code_style/index.html>`_ and
+`isort <https://pycqa.github.io/isort/>`_ to handle module imports. We use
+`pre-commit <https://pre-commit.com>`_ to run ``black`` and ``isort`` automatically
+prior to each local commit. Please install it in your environment::
 
     pre-commit install
 
@@ -74,6 +75,11 @@ Note that ``black`` won't format `docstrings
 <https://www.python.org/dev/peps/pep-0257/>`_. We follow the `numpydoc
 <https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_
 standard.
+
+Note that if imports must be sorted in a certain order, for example to avoid recursion,
+then ``isort`` provides `commands
+<https://pycqa.github.io/isort/docs/configuration/action_comments.html>`_ that may be
+used to prevent sorting.
 
 Comment lines should preferably be limited to 72 characters.
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -7,7 +7,7 @@
 from datetime import datetime
 import inspect
 import os
-from os.path import relpath, dirname
+from os.path import dirname, relpath
 import re
 import sys
 

--- a/orix/base/__init__.py
+++ b/orix/base/__init__.py
@@ -23,7 +23,6 @@ Note that this class is not meant to be used directly.
 
 import numpy as np
 
-
 # Lists what will be imported when calling "from orix.base import *"
 __all__ = [
     "check",

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -18,8 +18,8 @@
 
 from collections import OrderedDict
 import copy
-import os
 from itertools import islice
+import os
 import warnings
 
 from diffpy.structure import Structure
@@ -29,13 +29,12 @@ import matplotlib.colors as mcolors
 import numpy as np
 
 from orix.quaternion.symmetry import (
+    Symmetry,
     _groups,
     get_point_group,
-    Symmetry,
     point_group_aliases,
 )
 from orix.vector import Miller, Vector3d
-
 
 # All named Matplotlib colors (tableau and xkcd already lower case hex)
 ALL_COLORS = mcolors.TABLEAU_COLORS

--- a/orix/data/__init__.py
+++ b/orix/data/__init__.py
@@ -38,7 +38,6 @@ from orix import __version__, io
 from orix.data._registry import registry_hashes, registry_urls
 from orix.quaternion import Orientation, symmetry
 
-
 __all__ = [
     "sdss_austenite",
     "sdss_ferrite_austenite",

--- a/orix/io/__init__.py
+++ b/orix/io/__init__.py
@@ -27,7 +27,6 @@ import numpy as np
 from orix.io.plugins import plugin_list
 from orix.io.plugins._h5ebsd import hdf5group2dict
 
-
 extensions = [plugin.file_extensions for plugin in plugin_list if plugin.writes]
 
 

--- a/orix/io/plugins/ang.py
+++ b/orix/io/plugins/ang.py
@@ -26,11 +26,10 @@ import warnings
 from diffpy.structure import Lattice, Structure
 import numpy as np
 
+from orix import __version__
 from orix.crystal_map import CrystalMap, PhaseList, create_coordinate_arrays
 from orix.quaternion.rotation import Rotation
 from orix.quaternion.symmetry import point_group_aliases
-from orix import __version__
-
 
 # MTEX has this format sorted out, check out their readers when fixing
 # issues and adapting to other versions of this file format in the future:

--- a/orix/io/plugins/bruker_h5ebsd.py
+++ b/orix/io/plugins/bruker_h5ebsd.py
@@ -25,7 +25,6 @@ from orix.crystal_map import CrystalMap, Phase, PhaseList
 from orix.io.plugins._h5ebsd import H5ebsdFile
 from orix.quaternion import Rotation
 
-
 __all__ = ["file_reader"]
 
 # Plugin description

--- a/orix/io/plugins/emsoft_h5ebsd.py
+++ b/orix/io/plugins/emsoft_h5ebsd.py
@@ -30,7 +30,6 @@ from orix.crystal_map import CrystalMap, Phase, PhaseList
 from orix.io.plugins._h5ebsd import H5ebsdFile
 from orix.quaternion import Rotation
 
-
 __all__ = ["file_reader"]
 
 # Plugin description

--- a/orix/io/plugins/orix_hdf5.py
+++ b/orix/io/plugins/orix_hdf5.py
@@ -32,7 +32,6 @@ from orix.crystal_map import CrystalMap, Phase, PhaseList
 from orix.io.plugins._h5ebsd import hdf5group2dict
 from orix.quaternion import Rotation
 
-
 __all__ = ["file_reader", "file_writer"]
 
 # Plugin description

--- a/orix/plot/__init__.py
+++ b/orix/plot/__init__.py
@@ -37,8 +37,7 @@ from orix.plot.rotation_plot import AxAnglePlot, RodriguesPlot, RotationPlot
 from orix.plot.stereographic_plot import StereographicPlot
 
 # Must be imported below StereographicPlot since it imports it
-from orix.plot.inverse_pole_figure_plot import InversePoleFigurePlot
-
+from orix.plot.inverse_pole_figure_plot import InversePoleFigurePlot  # isort: skip
 
 # Lists what will be imported when calling "from orix.plot import *"
 __all__ = [

--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -16,12 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-import matplotlib.patches as mpatches
 from matplotlib.axes import Axes
 from matplotlib.image import AxesImage
+import matplotlib.patches as mpatches
 from matplotlib.projections import register_projection
-from mpl_toolkits.axes_grid1 import make_axes_locatable
 from matplotlib_scalebar import dimension, scalebar
+from mpl_toolkits.axes_grid1 import make_axes_locatable
 import numpy as np
 
 

--- a/orix/plot/direction_color_keys/__init__.py
+++ b/orix/plot/direction_color_keys/__init__.py
@@ -21,7 +21,6 @@
 from orix.plot.direction_color_keys.direction_color_key import DirectionColorKey
 from orix.plot.direction_color_keys.direction_color_key_tsl import DirectionColorKeyTSL
 
-
 __all__ = [
     "DirectionColorKeyTSL",
 ]

--- a/orix/plot/inverse_pole_figure_plot.py
+++ b/orix/plot/inverse_pole_figure_plot.py
@@ -23,8 +23,8 @@ rotated by orientations.
 """
 
 import matplotlib.axes as maxes
-import matplotlib.pyplot as plt
 import matplotlib.projections as mprojections
+import matplotlib.pyplot as plt
 import numpy as np
 
 from orix.crystal_map import Phase

--- a/orix/plot/orientation_color_keys/__init__.py
+++ b/orix/plot/orientation_color_keys/__init__.py
@@ -22,7 +22,6 @@ from orix.plot.orientation_color_keys.euler_color_key import EulerColorKey
 from orix.plot.orientation_color_keys.ipf_color_key import IPFColorKey
 from orix.plot.orientation_color_keys.ipf_color_key_tsl import IPFColorKeyTSL
 
-
 __all__ = [
     "EulerColorKey",
     "IPFColorKeyTSL",

--- a/orix/plot/orientation_color_keys/ipf_color_key_tsl.py
+++ b/orix/plot/orientation_color_keys/ipf_color_key_tsl.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-from orix.plot.orientation_color_keys import IPFColorKey
 from orix.plot.direction_color_keys import DirectionColorKeyTSL
+from orix.plot.orientation_color_keys import IPFColorKey
 
 
 class IPFColorKeyTSL(IPFColorKey):

--- a/orix/plot/rotation_plot.py
+++ b/orix/plot/rotation_plot.py
@@ -16,11 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-from packaging import version
-
-from matplotlib import projections, __version__
-from mpl_toolkits.mplot3d import Axes3D
+from matplotlib import __version__, projections
 import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D
+from packaging import version
 
 from orix.vector import AxAngle, Rodrigues
 
@@ -31,7 +30,7 @@ class RotationPlot(Axes3D):
     transformation_class = None
 
     def transform(self, xs, fundamental_zone=None):
-        from orix.quaternion import Rotation, Misorientation, OrientationRegion
+        from orix.quaternion import Misorientation, OrientationRegion, Rotation
 
         # Project rotations into fundamental zone if necessary
         if isinstance(xs, Misorientation):

--- a/orix/plot/stereographic_plot.py
+++ b/orix/plot/stereographic_plot.py
@@ -33,16 +33,19 @@ import matplotlib.pyplot as plt
 import numpy as np
 from scipy.ndimage import gaussian_filter
 
+# fmt: off
+# isort: off
 from orix.plot._symmetry_marker import (
     TwoFoldMarker,
     ThreeFoldMarker,
     FourFoldMarker,
     SixFoldMarker,
 )
+# isort: on
+# fmt: on
 from orix.projections import InverseStereographicProjection, StereographicProjection
 from orix.vector import Vector3d
 from orix.vector.fundamental_sector import _closed_edges_in_hemisphere
-
 
 ZORDER = dict(text=6, scatter=5, symmetry_marker=4, draw_circle=3, mesh=2)
 

--- a/orix/plot/unit_cell_plot.py
+++ b/orix/plot/unit_cell_plot.py
@@ -22,7 +22,7 @@ orientation.
 
 from itertools import combinations, product
 
-from diffpy.structure import Structure, Lattice
+from diffpy.structure import Lattice, Structure
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/orix/projections/stereographic.py
+++ b/orix/projections/stereographic.py
@@ -22,7 +22,6 @@ import numpy as np
 
 from orix.vector import SphericalRegion, Vector3d
 
-
 _UPPER_HEMISPHERE = SphericalRegion([0, 0, 1])
 _LOWER_HEMISPHERE = SphericalRegion([0, 0, -1])
 

--- a/orix/quaternion/__init__.py
+++ b/orix/quaternion/__init__.py
@@ -28,11 +28,11 @@ Unit quaternions are efficient objects for representing rotations, and hence
 orientations.
 """
 
-from orix.quaternion.quaternion import check_quaternion, Quaternion
-from orix.quaternion.rotation import Rotation, von_mises
 from orix.quaternion.orientation import Misorientation, Orientation
-from orix.quaternion.orientation_region import get_proper_groups, OrientationRegion
-from orix.quaternion.symmetry import get_distinguished_points, get_point_group, Symmetry
+from orix.quaternion.orientation_region import OrientationRegion, get_proper_groups
+from orix.quaternion.quaternion import Quaternion, check_quaternion
+from orix.quaternion.rotation import Rotation, von_mises
+from orix.quaternion.symmetry import Symmetry, get_distinguished_points, get_point_group
 
 # Lists what will be imported when calling "from orix.quaternion import *"
 __all__ = [

--- a/orix/quaternion/__init__.py
+++ b/orix/quaternion/__init__.py
@@ -28,9 +28,9 @@ Unit quaternions are efficient objects for representing rotations, and hence
 orientations.
 """
 
+from orix.quaternion.quaternion import Quaternion, check_quaternion  # isort: skip
 from orix.quaternion.orientation import Misorientation, Orientation
 from orix.quaternion.orientation_region import OrientationRegion, get_proper_groups
-from orix.quaternion.quaternion import Quaternion, check_quaternion
 from orix.quaternion.rotation import Rotation, von_mises
 from orix.quaternion.symmetry import Symmetry, get_distinguished_points, get_point_group
 

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -38,8 +38,8 @@ reference. However, because the square has fourfold symmetry, it is
 indistinguishable in both cases, and hence has the same orientation.
 """
 
-from itertools import product as iproduct
 from itertools import combinations_with_replacement as icombinations
+from itertools import product as iproduct
 import warnings
 
 import dask.array as da
@@ -47,11 +47,11 @@ from dask.diagnostics import ProgressBar
 import numpy as np
 from tqdm import tqdm
 
+from orix._util import deprecated
 from orix.quaternion.orientation_region import OrientationRegion
 from orix.quaternion.rotation import Rotation
 from orix.quaternion.symmetry import C1, Symmetry, _get_unique_symmetry_elements
 from orix.vector import AxAngle
-from orix._util import deprecated
 
 
 def _distance(misorientation, verbose, split_size=100):

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -23,7 +23,7 @@ from dask.diagnostics import ProgressBar
 import numpy as np
 import quaternion
 
-from orix.base import check, Object3d
+from orix.base import Object3d, check
 from orix.vector import Miller, Vector3d
 
 

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -47,9 +47,9 @@ from dask.diagnostics import ProgressBar
 import numpy as np
 from scipy.special import hyp0f1
 
+from orix._util import deprecated_argument
 from orix.quaternion import Quaternion
 from orix.vector import AxAngle, Vector3d
-from orix._util import deprecated_argument
 
 # Used to round values below 1e-16 to zero
 _FLOAT_EPS = np.finfo(float).eps

--- a/orix/sampling/S2_sampling.py
+++ b/orix/sampling/S2_sampling.py
@@ -18,17 +18,17 @@
 
 """Generation of spherical grids in *S2*."""
 
-from typing import Callable, List, Mapping, Optional, Tuple
 from functools import partial
+from typing import Callable, List, Mapping, Optional, Tuple
 
 import numpy as np
 
 from orix.sampling._polyhedral_sampling import (
-    _sample_length_equidistant,
-    _edge_grid_normalized_cube,
-    _edge_grid_spherified_edge_cube,
-    _edge_grid_spherified_corner_cube,
     _compose_from_faces,
+    _edge_grid_normalized_cube,
+    _edge_grid_spherified_corner_cube,
+    _edge_grid_spherified_edge_cube,
+    _sample_length_equidistant,
 )
 from orix.vector import Vector3d
 

--- a/orix/sampling/__init__.py
+++ b/orix/sampling/__init__.py
@@ -18,8 +18,6 @@
 
 """Generation of grids on *S2* (vectors) or *SO(3)* (rotations)."""
 
-from orix.sampling.sample_generators import get_sample_fundamental, get_sample_local
-from orix.sampling.SO3_sampling import uniform_SO3_sample
 from orix.sampling.S2_sampling import (
     sample_S2,
     sample_S2_cube_mesh,
@@ -28,9 +26,10 @@ from orix.sampling.S2_sampling import (
     sample_S2_icosahedral_mesh,
     sample_S2_random_mesh,
     sample_S2_uv_mesh,
-    sampling_methods as sample_S2_methods,
 )
-
+from orix.sampling.S2_sampling import sampling_methods as sample_S2_methods
+from orix.sampling.SO3_sampling import uniform_SO3_sample
+from orix.sampling.sample_generators import get_sample_fundamental, get_sample_local
 
 # Lists what will be imported when calling "from orix.sampling import *"
 __all__ = [

--- a/orix/sampling/_cubochoric_sampling.py
+++ b/orix/sampling/_cubochoric_sampling.py
@@ -30,11 +30,7 @@ import numba as nb
 import numpy as np
 
 from orix.quaternion import Rotation
-from orix.quaternion._conversions import (
-    ax2qu_single,
-    cu2ro_single,
-    ro2ax_single,
-)
+from orix.quaternion._conversions import ax2qu_single, cu2ro_single, ro2ax_single
 
 
 def cubochoric_sampling(semi_edge_steps=None, resolution=None):

--- a/orix/sampling/_polyhedral_sampling.py
+++ b/orix/sampling/_polyhedral_sampling.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Tuple, List
+from typing import List, Tuple
 
 import numpy as np
 from scipy.spatial import cKDTree

--- a/orix/sampling/sample_generators.py
+++ b/orix/sampling/sample_generators.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from orix.quaternion import OrientationRegion
 from orix.quaternion.symmetry import get_point_group
-from orix.sampling.SO3_sampling import uniform_SO3_sample, _three_uniform_samples_method
+from orix.sampling.SO3_sampling import _three_uniform_samples_method, uniform_SO3_sample
 from orix.sampling._cubochoric_sampling import cubochoric_sampling
 
 

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -25,7 +25,7 @@ from h5py import File
 import numpy as np
 import pytest
 
-from orix.crystal_map import CrystalMap, create_coordinate_arrays, PhaseList
+from orix.crystal_map import CrystalMap, PhaseList, create_coordinate_arrays
 from orix.quaternion import Rotation
 
 

--- a/orix/tests/io/test_ang.py
+++ b/orix/tests/io/test_ang.py
@@ -16,22 +16,22 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-import pytest
 import numpy as np
+import pytest
 
 from orix.crystal_map import CrystalMap, Phase
 from orix.io import load, loadang, save
 from orix.io.plugins.ang import (
+    _get_column_width,
     _get_header,
+    _get_nrows_ncols_step_sizes,
     _get_phases_from_header,
     _get_vendor_columns,
-    _get_nrows_ncols_step_sizes,
-    _get_column_width,
 )
 from orix.tests.conftest import (
-    ANGFILE_TSL_HEADER,
     ANGFILE_ASTAR_HEADER,
     ANGFILE_EMSOFT_HEADER,
+    ANGFILE_TSL_HEADER,
 )
 
 

--- a/orix/tests/io/test_emsoft_h5ebsd.py
+++ b/orix/tests/io/test_emsoft_h5ebsd.py
@@ -17,8 +17,8 @@
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
 from diffpy.structure import Lattice, Structure
-import pytest
 import numpy as np
+import pytest
 
 from orix.io import load
 

--- a/orix/tests/io/test_io.py
+++ b/orix/tests/io/test_io.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-from contextlib import contextmanager
 from collections import OrderedDict
+from contextlib import contextmanager
 from io import StringIO
 from numbers import Number
 import os
@@ -25,17 +25,11 @@ import sys
 
 from diffpy.structure import Structure
 from h5py import File
-import pytest
 import numpy as np
+import pytest
 
 from orix.crystal_map import Phase, PhaseList
-from orix.io import (
-    load,
-    save,
-    loadctf,
-    _plugin_from_manufacturer,
-    _overwrite_or_not,
-)
+from orix.io import _overwrite_or_not, _plugin_from_manufacturer, load, loadctf, save
 from orix.io.plugins import bruker_h5ebsd, emsoft_h5ebsd, orix_hdf5
 from orix.quaternion.rotation import Rotation
 

--- a/orix/tests/io/test_orix_hdf5.py
+++ b/orix/tests/io/test_orix_hdf5.py
@@ -18,26 +18,26 @@
 
 from diffpy.structure.spacegroups import GetSpaceGroup
 from h5py import File
-import pytest
 import numpy as np
+import pytest
 
 from orix import __version__ as orix_version
 from orix.crystal_map import CrystalMap, Phase
 from orix.io import load, save
 from orix.io.plugins.orix_hdf5 import (
-    dict2crystalmap,
-    dict2phaselist,
-    dict2phase,
-    dict2structure,
-    dict2lattice,
-    dict2atom,
-    dict2hdf5group,
-    crystalmap2dict,
-    phaselist2dict,
-    phase2dict,
-    structure2dict,
-    lattice2dict,
     atom2dict,
+    crystalmap2dict,
+    dict2atom,
+    dict2crystalmap,
+    dict2hdf5group,
+    dict2lattice,
+    dict2phase,
+    dict2phaselist,
+    dict2structure,
+    lattice2dict,
+    phase2dict,
+    phaselist2dict,
+    structure2dict,
 )
 from orix.tests.io.test_io import assert_dictionaries_are_equal
 

--- a/orix/tests/plot/test_crystal_map_plot.py
+++ b/orix/tests/plot/test_crystal_map_plot.py
@@ -18,14 +18,14 @@
 
 import copy
 
-import numpy as np
-import matplotlib.pyplot as plt
 import matplotlib.colorbar as mbar
+import matplotlib.pyplot as plt
 from matplotlib_scalebar import scalebar
+import numpy as np
 import pytest
 
-from orix.plot import CrystalMapPlot
 from orix.crystal_map import CrystalMap, PhaseList
+from orix.plot import CrystalMapPlot
 
 # Can be easily changed in the future
 PLOT_MAP = "plot_map"

--- a/orix/tests/plot/test_rotation_plot.py
+++ b/orix/tests/plot/test_rotation_plot.py
@@ -16,17 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-from packaging import version
-
 from matplotlib import __version__ as _MPL_VERSION
 from matplotlib import pyplot as plt
 import numpy as np
+from packaging import version
 import pytest
 
-from orix.plot import RodriguesPlot, AxAnglePlot, RotationPlot
+from orix.plot import AxAnglePlot, RodriguesPlot, RotationPlot
 from orix.quaternion import Misorientation, Orientation, OrientationRegion
 from orix.quaternion.symmetry import C1, D6
-
 
 # TODO: Remove when the oldest supported version of Matplotlib
 # increases from 3.3 to 3.4.

--- a/orix/tests/plot/test_stereographic_plot.py
+++ b/orix/tests/plot/test_stereographic_plot.py
@@ -23,16 +23,20 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
+from orix import plot
+
+# fmt: off
+# isort: off
 from orix.plot.stereographic_plot import (
     TwoFoldMarker,
     ThreeFoldMarker,
     FourFoldMarker,
     SixFoldMarker,
 )
-from orix import plot
+# isort: on
+# fmt: on
 from orix.quaternion.symmetry import C1, C6, Oh
 from orix.vector import Vector3d
-
 
 plt.rcParams["axes.grid"] = True
 PROJ_NAME = "stereographic"

--- a/orix/tests/plot/test_unit_cell_plot.py
+++ b/orix/tests/plot/test_unit_cell_plot.py
@@ -16,12 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-from packaging import version
-
 from diffpy.structure import Lattice, Structure
 from matplotlib import __version__ as _MPL_VERSION
 from matplotlib import pyplot as plt
 import numpy as np
+from packaging import version
 import pytest
 
 from orix.plot._util import Arrow3D

--- a/orix/tests/quaternion/test_conversions.py
+++ b/orix/tests/quaternion/test_conversions.py
@@ -21,22 +21,22 @@ import pytest
 
 from orix.quaternion import Rotation
 from orix.quaternion._conversions import (
-    ax2qu_single,
     ax2qu,
-    ax2ro_single,
+    ax2qu_single,
     ax2ro,
-    cu2ho_single,
+    ax2ro_single,
     cu2ho,
-    cu2ro_single,
+    cu2ho_single,
     cu2ro,
+    cu2ro_single,
     eu2qu_single,
-    ho2ax_single,
-    ho2ax,
-    ho2ro_single,
-    ho2ro,
     get_pyramid_single,
-    ro2ax_single,
+    ho2ax,
+    ho2ax_single,
+    ho2ro,
+    ho2ro_single,
     ro2ax,
+    ro2ax_single,
 )
 
 

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -30,9 +30,9 @@ from orix.quaternion.symmetry import (
     D2,
     D3,
     D6,
-    T,
     O,
     Oh,
+    T,
     _groups,
     _proper_groups,
 )

--- a/orix/tests/quaternion/test_orientation_region.py
+++ b/orix/tests/quaternion/test_orientation_region.py
@@ -18,13 +18,13 @@
 
 import pytest
 
-from orix.quaternion.symmetry import *
 from orix.quaternion.orientation import Orientation
 from orix.quaternion.orientation_region import (
+    OrientationRegion,
     _get_large_cell_normals,
     get_proper_groups,
-    OrientationRegion,
 )
+from orix.quaternion.symmetry import *
 from orix.quaternion.symmetry import get_distinguished_points
 
 

--- a/orix/tests/quaternion/test_rotation.py
+++ b/orix/tests/quaternion/test_rotation.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-from math import cos, sin, tan, pi
+from math import cos, pi, sin, tan
 
 from diffpy.structure.spacegroups import sg225
 import numpy as np
@@ -24,7 +24,6 @@ import pytest
 
 from orix.quaternion import Quaternion, Rotation
 from orix.vector import AxAngle, Vector3d
-
 
 rotations = [
     (0.707, 0.0, 0.0, 0.707),

--- a/orix/tests/quaternion/test_symmetry.py
+++ b/orix/tests/quaternion/test_symmetry.py
@@ -23,7 +23,10 @@ from matplotlib import pyplot as plt
 import numpy as np
 import pytest
 
+from orix.quaternion import Rotation, Symmetry, get_point_group
+
 # fmt: off
+# isort: off
 from orix.quaternion.symmetry import (
     C1, Ci,  # triclinic
     C2x, C2y, C2z, Csx, Csy, Csz, Cs, C2, C2h,  # monoclinic
@@ -34,8 +37,8 @@ from orix.quaternion.symmetry import (
     T, Th, O, Td, Oh,  # cubic
     spacegroup2pointgroup_dict, _groups, _get_unique_symmetry_elements
 )
+# isort: on
 # fmt: on
-from orix.quaternion import get_point_group, Rotation, Symmetry
 from orix.vector import Vector3d
 
 

--- a/orix/tests/sampling/test_cubochoric_sampling.py
+++ b/orix/tests/sampling/test_cubochoric_sampling.py
@@ -20,12 +20,12 @@ import numpy as np
 import pytest
 
 from orix.quaternion.rotation import Rotation
-from orix.quaternion.symmetry import C1, C2, D2, C4, D4, C3, D3, C6, D6, T, O
+from orix.quaternion.symmetry import C1, C2, C3, C4, C6, D2, D3, D4, D6, O, T
 from orix.sampling import get_sample_fundamental, get_sample_local
 from orix.sampling._cubochoric_sampling import (
+    _cubochoric_sampling_loop,
     cubochoric_sampling,
     resolution_to_semi_edge_steps,
-    _cubochoric_sampling_loop,
 )
 
 

--- a/orix/tests/sampling/test_sampling.py
+++ b/orix/tests/sampling/test_sampling.py
@@ -16,14 +16,13 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-import pytest
-
 import numpy as np
+import pytest
 
 from orix.quaternion.rotation import Rotation
 from orix.quaternion.symmetry import C2, C6, D6, get_point_group
-from orix.sampling.SO3_sampling import uniform_SO3_sample, _resolution_to_num_steps
 from orix.sampling import get_sample_fundamental, get_sample_local
+from orix.sampling.SO3_sampling import _resolution_to_num_steps, uniform_SO3_sample
 from orix.sampling._polyhedral_sampling import (
     _get_angles_between_nn_gridpoints,
     _get_first_nearest_neighbors,

--- a/orix/tests/test_axangle.py
+++ b/orix/tests/test_axangle.py
@@ -20,9 +20,8 @@ import itertools
 import numpy as np
 import pytest
 
-from orix.vector import AxAngle, Vector3d
 from orix.quaternion import Rotation
-
+from orix.vector import AxAngle, Vector3d
 
 axes = [
     (1, 0, 0),

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -26,7 +26,6 @@ from orix.plot import CrystalMapPlot
 from orix.quaternion import Orientation, Rotation
 from orix.quaternion.symmetry import C2, C3, C4, O
 
-
 # Note that many parts of the CrystalMap() class are tested while
 # testing IO and the Phase() and PhaseList() classes
 

--- a/orix/tests/test_miller.py
+++ b/orix/tests/test_miller.py
@@ -23,8 +23,7 @@ import pytest
 from orix.crystal_map import Phase
 from orix.quaternion import Orientation, symmetry
 from orix.vector import Miller
-from orix.vector.miller import _round_indices, _uvw2UVTW, _UVTW2uvw, _transform_space
-
+from orix.vector.miller import _round_indices, _transform_space, _UVTW2uvw, _uvw2UVTW
 
 TRIGONAL_PHASE = Phase(
     point_group="321", structure=Structure(lattice=Lattice(4.9, 4.9, 5.4, 90, 90, 120))

--- a/orix/tests/test_neoeuler.py
+++ b/orix/tests/test_neoeuler.py
@@ -19,9 +19,8 @@
 import numpy as np
 import pytest
 
-from orix.vector import Homochoric, Rodrigues
 from orix.quaternion import Rotation
-
+from orix.vector import Homochoric, Rodrigues
 
 # Rodrigues
 

--- a/orix/tests/test_phase_list.py
+++ b/orix/tests/test_phase_list.py
@@ -25,7 +25,7 @@ import pytest
 
 from orix.crystal_map import Phase, PhaseList
 from orix.crystal_map.phase_list import _new_structure_matrix_from_alignment
-from orix.quaternion.symmetry import Symmetry, O
+from orix.quaternion.symmetry import O, Symmetry
 
 
 class TestPhase:

--- a/orix/tests/test_spherical_region.py
+++ b/orix/tests/test_spherical_region.py
@@ -19,7 +19,7 @@
 import numpy as np
 import pytest
 
-from orix.vector import Vector3d, SphericalRegion
+from orix.vector import SphericalRegion, Vector3d
 
 
 @pytest.fixture(params=[(0, 0, 1)])

--- a/orix/tests/test_vector3d.py
+++ b/orix/tests/test_vector3d.py
@@ -24,7 +24,6 @@ import pytest
 from orix.quaternion import Orientation, symmetry
 from orix.vector import Vector3d, check_vector
 
-
 vectors = [
     (1, 0, 0),
     (0, 0, 1),

--- a/orix/vector/__init__.py
+++ b/orix/vector/__init__.py
@@ -26,12 +26,15 @@ of a spherical region.
 """
 
 # Must be imported first
-from orix.vector.vector3d import check_vector, Vector3d
+# fmt: off
+# isort: off
 from orix.vector.spherical_region import SphericalRegion
-
+# isort: on
+# fmt: on
 from orix.vector.fundamental_sector import FundamentalSector
 from orix.vector.miller import Miller
 from orix.vector.neo_euler import AxAngle, Homochoric, NeoEuler, Rodrigues
+from orix.vector.vector3d import Vector3d, check_vector
 
 # Lists what will be imported when calling "from orix.vector import *"
 __all__ = [

--- a/orix/vector/__init__.py
+++ b/orix/vector/__init__.py
@@ -25,16 +25,11 @@ the rotation axis of a quaternion or the normal to the bounding planes
 of a spherical region.
 """
 
-# Must be imported first
-# fmt: off
-# isort: off
-from orix.vector.spherical_region import SphericalRegion
-# isort: on
-# fmt: on
+from orix.vector.vector3d import Vector3d, check_vector  # isort: skip
+from orix.vector.spherical_region import SphericalRegion  # isort: skip
 from orix.vector.fundamental_sector import FundamentalSector
 from orix.vector.miller import Miller
 from orix.vector.neo_euler import AxAngle, Homochoric, NeoEuler, Rodrigues
-from orix.vector.vector3d import Vector3d, check_vector
 
 # Lists what will be imported when calling "from orix.vector import *"
 __all__ = [

--- a/orix/vector/__init__.py
+++ b/orix/vector/__init__.py
@@ -25,8 +25,12 @@ the rotation axis of a quaternion or the normal to the bounding planes
 of a spherical region.
 """
 
-from orix.vector.vector3d import Vector3d, check_vector  # isort: skip
-from orix.vector.spherical_region import SphericalRegion  # isort: skip
+# fmt: off
+# isort: off
+from orix.vector.vector3d import Vector3d, check_vector
+from orix.vector.spherical_region import SphericalRegion
+# isort: on
+# fmt: on
 from orix.vector.fundamental_sector import FundamentalSector
 from orix.vector.miller import Miller
 from orix.vector.neo_euler import AxAngle, Homochoric, NeoEuler, Rodrigues

--- a/orix/vector/fundamental_sector.py
+++ b/orix/vector/fundamental_sector.py
@@ -24,7 +24,6 @@ import numpy as np
 
 from orix.vector import SphericalRegion, Vector3d
 
-
 _EDGE_STEPS = 1000
 
 

--- a/orix/vector/neo_euler.py
+++ b/orix/vector/neo_euler.py
@@ -30,6 +30,7 @@ about a fixed axis.
 import abc
 
 import numpy as np
+
 from orix.vector import Vector3d
 
 

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -17,6 +17,7 @@
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import annotations
+
 from copy import deepcopy
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
@@ -26,7 +27,7 @@ from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 import numpy as np
 
-from orix.base import check, Object3d
+from orix.base import Object3d, check
 
 
 def check_vector(obj: Any) -> bool:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 from itertools import chain
-from setuptools import setup, find_packages
 
-from orix import __name__, __version__, __author__, __author_email__, __description__
+from setuptools import find_packages, setup
+
+from orix import __author__, __author_email__, __description__, __name__, __version__
 
 # Projects with optional features for building the documentation and running
 # tests. From setuptools:
@@ -22,6 +23,7 @@ extra_feature_requirements = {
 }
 extra_feature_requirements["dev"] = [
     "black[jupyter]",
+    "isort >= 5.10",
     "manifix",
     "outdated",
     "pre-commit >= 1.16",


### PR DESCRIPTION
#### Description of the change
As discussed with @hakonanes and @din14970 in https://github.com/pyxem/orix/pull/334#discussion_r873160646, `isort` is a package that may be used to automatically sort imports. It also hooks into pre-commit to allow for formatting before code submission.

We could consider adding `isort` as a dependency to `orix` to handle import formatting. In `pre-commit-config.yaml` I have added the [standard pre-commit config](https://pycqa.github.io/isort/docs/configuration/pre-commit.html) along with the `black` profile and also with the `"--force-sort-within-sections"` [flag](https://pycqa.github.io/isort/docs/configuration/options.html#sort-relative-in-force-sorted-sections) which groups imports by modules (as we currently do) rather than sorting straight `import`s before `from`-style imports. 


#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.