### PR TITLE
Add n-dimensional support to private rotation conversion functions

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -26,6 +26,11 @@
       "orcid": "0000-0002-6402-9879"
     },
     {
+      "name": "Austin Gerlt",
+      "orcid": "0000-0002-2204-2055",
+      "affiliation": "The Ohio State University"
+    },
+    {
       "name": "Simon Høgås"
     }
   ]

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -312,6 +312,14 @@ prints a nice report in the terminal. For an even nicer presentation, you can us
 Then, you can open the created ``htmlcov/index.html`` in the browser and inspect the
 coverage in more detail.
 
+Tips for writing tests of Numba decorated functions:
+
+- A Numba decorated function ``numba_func()`` is only covered if it is called in the
+  test as ``numba_func.py_func()``.
+- Always test a Numba decorated function calling ``numba_func()`` directly, in addition
+  to ``numba_func.py_func()``, because the machine code function might give different
+  results on different OS with the same Python code.
+
 .. _adding-data-to-data-module:
 
 Adding data to the data module

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -11,5 +11,6 @@ __credits__ = [
     "Paddy Harrison",
     "Duncan Johnstone",
     "Niels Cautaerts",
+    "Austin Gerlt",
     "Simon Høgås",
 ]

--- a/orix/quaternion/_conversions.py
+++ b/orix/quaternion/_conversions.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Conversions of orientations between many common representations from
+"""Conversions of rotations between many common representations from
 :cite:`rowenhorst2015consistent`, accelerated with Numba.
 
 This module and documentation is only relevant for orix developers, not
@@ -203,7 +203,7 @@ def cu2ho_2d(cu):
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
     """
-    ho = np.zeros_like(cu)
+    ho = np.zeros_like(cu, dtype=np.float64)
     for i in nb.prange(cu.shape[0]):
         ho[i] = cu2ho_single(cu[i])
     return ho
@@ -361,7 +361,7 @@ def ax2ro_2d(ax):
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
     """
-    ro = np.zeros_like(ax)
+    ro = np.zeros_like(ax, dtype=np.float64)
     for i in nb.prange(ax.shape[0]):
         ro[i] = ax2ro_single(ax[i])
     return ro

--- a/orix/quaternion/_conversions.py
+++ b/orix/quaternion/_conversions.py
@@ -80,7 +80,7 @@ def get_pyramid_2d(xyz):
     Returns
     -------
     pyramids : numpy.ndarray
-        1D array of 2hich pyramids ``xyz`` belong to as 64-bit integers.
+        1D array of pyramids as 64-bit integers.
 
     Notes
     -----
@@ -95,11 +95,11 @@ def get_pyramid_2d(xyz):
 
 
 def get_pyramid(xyz):
-    """n-dimensional wrapper for get_pyramid_2d, see the docstring of that
-    function.
+    """n-dimensional wrapper for get_pyramid_2d, see the docstring of
+    that function.
     """
     n_xyz = np.prod(xyz.shape[:-1])
-    xyz2d = xyz.reshape(n_xyz, 3)
+    xyz2d = xyz.astype(np.float64).reshape(n_xyz, 3)
     pyramids = get_pyramid_2d(xyz2d).reshape(n_xyz)
     return pyramids
 
@@ -214,7 +214,7 @@ def cu2ho(cu):
     function.
     """
     n_cu = np.prod(cu.shape[:-1])
-    cu2d = cu.reshape(n_cu, 3)
+    cu2d = cu.astype(np.float64).reshape(n_cu, 3)
     ho = cu2ho_2d(cu2d).reshape(cu.shape)
     return ho
 
@@ -282,8 +282,8 @@ def ho2ax_2d(ho):
 
     Returns
     -------
-    ho : numpy.ndarray
-        2D array of n (x, y, z) as 64-bit floats.
+    ax : numpy.ndarray
+        2D array of n (x, y, z, angle) as 64-bit floats.
 
     Notes
     -----
@@ -302,7 +302,7 @@ def ho2ax(ho):
     function.
     """
     n_ho = np.prod(ho.shape[:-1])
-    ho2d = ho.reshape(n_ho, 3)
+    ho2d = ho.astype(np.float64).reshape(n_ho, 3)
     ho = ho2ax_2d(ho2d).reshape(ho.shape[:-1] + (4,))
     return ho
 
@@ -372,7 +372,7 @@ def ax2ro(ax):
     function.
     """
     n_ax = np.prod(ax.shape[:-1])
-    ax2d = ax.reshape(n_ax, 4)
+    ax2d = ax.astype(np.float64).reshape(n_ax, 4)
     ro = ax2ro_2d(ax2d).reshape(ax.shape)
     return ro
 
@@ -438,7 +438,7 @@ def ro2ax(ro):
     function.
     """
     n_ro = np.prod(ro.shape[:-1])
-    ro2d = ro.reshape(n_ro, 4)
+    ro2d = ro.astype(np.float64).reshape(n_ro, 4)
     ax = ro2ax_2d(ro2d).reshape(ro.shape)
     return ax
 
@@ -503,7 +503,7 @@ def ax2qu(ax):
     function.
     """
     n_ax = np.prod(ax.shape[:-1])
-    ax2d = ax.reshape(n_ax, 4)
+    ax2d = ax.astype(np.float64).reshape(n_ax, 4)
     qu = ax2qu_2d(ax2d).reshape(ax.shape)
     return qu
 
@@ -563,7 +563,7 @@ def ho2ro(ho):
     function.
     """
     n_ho = np.prod(ho.shape[:-1])
-    ho2d = ho.reshape(n_ho, 3)
+    ho2d = ho.astype(np.float64).reshape(n_ho, 3)
     ro = ho2ro_2d(ho2d).reshape(ho.shape[:-1] + (4,))
     return ro
 
@@ -626,7 +626,7 @@ def cu2ro(cu):
     function.
     """
     n_cu = np.prod(cu.shape[:-1])
-    cu2d = cu.reshape(n_cu, 3)
+    cu2d = cu.astype(np.float64).reshape(n_cu, 3)
     ro = cu2ro_2d(cu2d).reshape(cu.shape[:-1] + (4,))
     return ro
 
@@ -639,8 +639,8 @@ def eu2qu_single(eu):
     Parameters
     ----------
     eu : numpy.ndarray
-        1D array of (alpha, beta, gamma) Euler angles given in radians in the
-        Bunge convention (ie, passive Z-X-Z) as 64-bit floats.
+        1D array of (alpha, beta, gamma) Euler angles given in radians
+        in the Bunge convention (ie, passive Z-X-Z) as 64-bit floats.
 
     Returns
     -------
@@ -703,6 +703,6 @@ def eu2qu(eu):
     function.
     """
     n_eu = np.prod(eu.shape[:-1])
-    eu2d = eu.reshape(n_eu, 3)
+    eu2d = eu.astype(np.float64).reshape(n_eu, 3)
     qu = eu2qu_2d(eu2d).reshape(eu.shape[:-1] + (4,))
     return qu

--- a/orix/quaternion/_conversions.py
+++ b/orix/quaternion/_conversions.py
@@ -79,7 +79,7 @@ def get_pyramid2d(xyz):
 
     Returns
     -------
-    pyramid : int
+    pyramids : numpy.ndarray
         1D array of length n.
         Which pyramid `xyz` belongs to as a 64-bit integer.
 
@@ -209,7 +209,9 @@ def cu2ho2d(cu):
 
 
 def cu2ho(cu):
-    """n-dimensional wrapper for cu2ho2d"""
+    """N-dimensional wrapper for cu2ho_2d, see the docstring of that
+    function.
+    """
     n_cu = np.prod(cu.shape[:-1])
     cu2d = cu.reshape(n_cu, 3)
     ho = cu2ho2d(cu2d).reshape(cu.shape)
@@ -295,7 +297,9 @@ def ho2ax2d(ho):
 
 
 def ho2ax(ho):
-    """n-dimensional wrapper for ho2ax2d"""
+    """N-dimensional wrapper for ho2ax_2d, see the docstring of that
+    function.
+    """
     n_ho = np.prod(ho.shape[:-1])
     ho2d = ho.reshape(n_ho, 3)
     ho = ho2ax2d(ho2d).reshape(ho.shape[:-1] + (4,))
@@ -363,7 +367,9 @@ def ax2ro2d(ax):
 
 
 def ax2ro(ax):
-    """n-dimensional wrapper for ax2ro2d"""
+    """N-dimensional wrapper for ax2ro_2d, see the docstring of that
+    function.
+    """
     n_ax = np.prod(ax.shape[:-1])
     ax2d = ax.reshape(n_ax, 4)
     ro = ax2ro2d(ax2d).reshape(ax.shape)
@@ -427,6 +433,9 @@ def ro2ax2d(ro):
 
 
 def ro2ax(ro):
+    """N-dimensional wrapper for ro2ax_2d, see the docstring of that
+    function.
+    """
     n_ro = np.prod(ro.shape[:-1])
     ro2d = ro.reshape(n_ro, 4)
     ax = ro2ax2d(ro2d).reshape(ro.shape)
@@ -489,7 +498,9 @@ def ax2qu2d(ax):
 
 
 def ax2qu(ax):
-    """n-dimensional wrapper for ax2qu2d"""
+    """N-dimensional wrapper for ax2qu_2d, see the docstring of that
+    function.
+    """
     n_ax = np.prod(ax.shape[:-1])
     ax2d = ax.reshape(n_ax, 4)
     qu = ax2qu2d(ax2d).reshape(ax.shape)
@@ -547,7 +558,9 @@ def ho2ro2d(ho):
 
 
 def ho2ro(ho):
-    """n-dimensional wrapper for ho2ro2d"""
+    """N-dimensional wrapper for ho2ro_2d, see the docstring of that
+    function.
+    """
     n_ho = np.prod(ho.shape[:-1])
     ho2d = ho.reshape(n_ho, 3)
     ro = ho2ro2d(ho2d).reshape(ho.shape[:-1] + (4,))
@@ -608,7 +621,9 @@ def cu2ro2d(cu):
 
 
 def cu2ro(cu):
-    """n-dimensional wrapper for cu2ro2d"""
+    """N-dimensional wrapper for cu2ro_2d, see the docstring of that
+    function.
+    """
     n_cu = np.prod(cu.shape[:-1])
     cu2d = cu.reshape(n_cu, 3)
     ro = cu2ro2d(cu2d).reshape(cu.shape[:-1] + (4,))
@@ -668,7 +683,7 @@ def eu2qu2d(eu):
     Returns
     -------
     qu : numpy.ndarray
-        2D array of n (qo, q1, q2, q3) quaternions as 64-bit floats.
+        2D array of n (q0, q1, q2, q3) quaternions as 64-bit floats.
 
     Notes
     -----
@@ -683,7 +698,9 @@ def eu2qu2d(eu):
 
 
 def eu2qu(eu):
-    """n-dimensional wrapper for eu2qu2d"""
+    """N-dimensional wrapper for eu2qu_2d, see the docstring of that
+    function.
+    """
     n_eu = np.prod(eu.shape[:-1])
     eu2d = eu.reshape(n_eu, 3)
     qu = eu2qu2d(eu2d).reshape(eu.shape[:-1] + (4,))

--- a/orix/quaternion/_conversions.py
+++ b/orix/quaternion/_conversions.py
@@ -44,7 +44,7 @@ def get_pyramid_single(xyz):
     Returns
     -------
     pyramid : int
-        Which pyramid `xyz` belongs to as a 64-bit integer.
+        Which pyramid ``xyz`` belongs to as a 64-bit integer.
 
     Notes
     -----
@@ -68,7 +68,7 @@ def get_pyramid_single(xyz):
 
 
 @nb.jit("int64[:](float64[:, :])", cache=True, nogil=True, nopython=True)
-def get_pyramid2d(xyz):
+def get_pyramid_2d(xyz):
     """Determine to which out of six pyramids in the cube a 2D array of
     (x, y, z) coordinates belongs.
 
@@ -80,8 +80,7 @@ def get_pyramid2d(xyz):
     Returns
     -------
     pyramids : numpy.ndarray
-        1D array of length n.
-        Which pyramid `xyz` belongs to as a 64-bit integer.
+        1D array of 2hich pyramids ``xyz`` belong to as 64-bit integers.
 
     Notes
     -----
@@ -96,10 +95,12 @@ def get_pyramid2d(xyz):
 
 
 def get_pyramid(xyz):
-    """n-dimensional wrapper for get_pyramid2d"""
+    """n-dimensional wrapper for get_pyramid_2d, see the docstring of that
+    function.
+    """
     n_xyz = np.prod(xyz.shape[:-1])
     xyz2d = xyz.reshape(n_xyz, 3)
-    pyramids = get_pyramid2d(xyz2d).reshape(n_xyz)
+    pyramids = get_pyramid_2d(xyz2d).reshape(n_xyz)
     return pyramids
 
 
@@ -183,7 +184,7 @@ def cu2ho_single(cu):
 
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
-def cu2ho2d(cu):
+def cu2ho_2d(cu):
     """Conversion from multiple cubochoric coordinates to un-normalized
     homochoric coordinates :cite:`singh2016orientation`.
 
@@ -214,7 +215,7 @@ def cu2ho(cu):
     """
     n_cu = np.prod(cu.shape[:-1])
     cu2d = cu.reshape(n_cu, 3)
-    ho = cu2ho2d(cu2d).reshape(cu.shape)
+    ho = cu2ho_2d(cu2d).reshape(cu.shape)
     return ho
 
 
@@ -270,7 +271,7 @@ def ho2ax_single(ho):
 
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
-def ho2ax2d(ho):
+def ho2ax_2d(ho):
     """Conversion from multiple homochoric coordinates to un-normalized
     axis-angle pairs :cite:`rowenhorst2015consistent`.
 
@@ -302,7 +303,7 @@ def ho2ax(ho):
     """
     n_ho = np.prod(ho.shape[:-1])
     ho2d = ho.reshape(n_ho, 3)
-    ho = ho2ax2d(ho2d).reshape(ho.shape[:-1] + (4,))
+    ho = ho2ax_2d(ho2d).reshape(ho.shape[:-1] + (4,))
     return ho
 
 
@@ -341,7 +342,7 @@ def ax2ro_single(ax):
 
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
-def ax2ro2d(ax):
+def ax2ro_2d(ax):
     """Conversion from multiple axis-angle pairs to un-normalized
     Rodrigues vectors :cite:`rowenhorst2015consistent`.
 
@@ -372,7 +373,7 @@ def ax2ro(ax):
     """
     n_ax = np.prod(ax.shape[:-1])
     ax2d = ax.reshape(n_ax, 4)
-    ro = ax2ro2d(ax2d).reshape(ax.shape)
+    ro = ax2ro_2d(ax2d).reshape(ax.shape)
     return ro
 
 
@@ -406,7 +407,7 @@ def ro2ax_single(ro):
 
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
-def ro2ax2d(ro):
+def ro2ax_2d(ro):
     """Conversion from multiple Rodrigues vectors to un-normalized
     axis-angle pairs :cite:`rowenhorst2015consistent`.
 
@@ -438,7 +439,7 @@ def ro2ax(ro):
     """
     n_ro = np.prod(ro.shape[:-1])
     ro2d = ro.reshape(n_ro, 4)
-    ax = ro2ax2d(ro2d).reshape(ro.shape)
+    ax = ro2ax_2d(ro2d).reshape(ro.shape)
     return ax
 
 
@@ -471,7 +472,7 @@ def ax2qu_single(ax):
 
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
-def ax2qu2d(ax):
+def ax2qu_2d(ax):
     """Conversion from multiple axis-angle pairs to un-normalized
     quaternions :cite:`rowenhorst2015consistent`.
 
@@ -503,7 +504,7 @@ def ax2qu(ax):
     """
     n_ax = np.prod(ax.shape[:-1])
     ax2d = ax.reshape(n_ax, 4)
-    qu = ax2qu2d(ax2d).reshape(ax.shape)
+    qu = ax2qu_2d(ax2d).reshape(ax.shape)
     return qu
 
 
@@ -531,7 +532,7 @@ def ho2ro_single(ho):
 
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
-def ho2ro2d(ho):
+def ho2ro_2d(ho):
     """Conversion from multiple homochoric coordinates to un-normalized
     Rodrigues vectors :cite:`rowenhorst2015consistent`.
 
@@ -563,7 +564,7 @@ def ho2ro(ho):
     """
     n_ho = np.prod(ho.shape[:-1])
     ho2d = ho.reshape(n_ho, 3)
-    ro = ho2ro2d(ho2d).reshape(ho.shape[:-1] + (4,))
+    ro = ho2ro_2d(ho2d).reshape(ho.shape[:-1] + (4,))
     return ro
 
 
@@ -594,7 +595,7 @@ def cu2ro_single(cu):
 
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
-def cu2ro2d(cu):
+def cu2ro_2d(cu):
     """Conversion from multiple cubochoric coordinates to un-normalized
     Rodrigues vectors :cite:`rowenhorst2015consistent`.
 
@@ -626,7 +627,7 @@ def cu2ro(cu):
     """
     n_cu = np.prod(cu.shape[:-1])
     cu2d = cu.reshape(n_cu, 3)
-    ro = cu2ro2d(cu2d).reshape(cu.shape[:-1] + (4,))
+    ro = cu2ro_2d(cu2d).reshape(cu.shape[:-1] + (4,))
     return ro
 
 
@@ -637,9 +638,9 @@ def eu2qu_single(eu):
 
     Parameters
     ----------
-    alpha, beta, gamma : float
-        Euler angles in the Bunge convention in radians as 64-bit
-        floats.
+    eu : numpy.ndarray
+        1D array of (alpha, beta, gamma) Euler angles given in radians in the
+        Bunge convention (ie, passive Z-X-Z) as 64-bit floats.
 
     Returns
     -------
@@ -671,7 +672,7 @@ def eu2qu_single(eu):
 
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
-def eu2qu2d(eu):
+def eu2qu_2d(eu):
     """Conversion from multiple Euler angles (alpha, beta, gamma) to unit
     quaternions
 
@@ -703,5 +704,5 @@ def eu2qu(eu):
     """
     n_eu = np.prod(eu.shape[:-1])
     eu2d = eu.reshape(n_eu, 3)
-    qu = eu2qu2d(eu2d).reshape(eu.shape[:-1] + (4,))
+    qu = eu2qu_2d(eu2d).reshape(eu.shape[:-1] + (4,))
     return qu

--- a/orix/quaternion/_conversions.py
+++ b/orix/quaternion/_conversions.py
@@ -209,7 +209,7 @@ def cu2ho2d(cu):
 
 
 def cu2ho(cu):
-    """ n-dimensional wrapper for cu2ho2d"""
+    """n-dimensional wrapper for cu2ho2d"""
     n_cu = np.prod(cu.shape[:-1])
     cu2d = cu.reshape(n_cu, 3)
     ho = cu2ho2d(cu2d).reshape(cu.shape)
@@ -295,10 +295,10 @@ def ho2ax2d(ho):
 
 
 def ho2ax(ho):
-    """ n-dimensional wrapper for ho2ax2d"""
+    """n-dimensional wrapper for ho2ax2d"""
     n_ho = np.prod(ho.shape[:-1])
     ho2d = ho.reshape(n_ho, 3)
-    ho = ho2ax2d(ho2d).reshape(ho.shape[:-1]+(4,))
+    ho = ho2ax2d(ho2d).reshape(ho.shape[:-1] + (4,))
     return ho
 
 
@@ -363,7 +363,7 @@ def ax2ro2d(ax):
 
 
 def ax2ro(ax):
-    """ n-dimensional wrapper for ax2ro2d"""
+    """n-dimensional wrapper for ax2ro2d"""
     n_ax = np.prod(ax.shape[:-1])
     ax2d = ax.reshape(n_ax, 4)
     ro = ax2ro2d(ax2d).reshape(ax.shape)
@@ -489,7 +489,7 @@ def ax2qu2d(ax):
 
 
 def ax2qu(ax):
-    """ n-dimensional wrapper for ax2qu2d"""
+    """n-dimensional wrapper for ax2qu2d"""
     n_ax = np.prod(ax.shape[:-1])
     ax2d = ax.reshape(n_ax, 4)
     qu = ax2qu2d(ax2d).reshape(ax.shape)
@@ -547,10 +547,10 @@ def ho2ro2d(ho):
 
 
 def ho2ro(ho):
-    """ n-dimensional wrapper for ho2ro2d"""
+    """n-dimensional wrapper for ho2ro2d"""
     n_ho = np.prod(ho.shape[:-1])
     ho2d = ho.reshape(n_ho, 3)
-    ro = ho2ro2d(ho2d).reshape(ho.shape[:-1]+(4,))
+    ro = ho2ro2d(ho2d).reshape(ho.shape[:-1] + (4,))
     return ro
 
 
@@ -608,10 +608,10 @@ def cu2ro2d(cu):
 
 
 def cu2ro(cu):
-    """ n-dimensional wrapper for cu2ro2d"""
+    """n-dimensional wrapper for cu2ro2d"""
     n_cu = np.prod(cu.shape[:-1])
     cu2d = cu.reshape(n_cu, 3)
-    ro = cu2ro2d(cu2d).reshape(cu.shape[:-1]+(4,))
+    ro = cu2ro2d(cu2d).reshape(cu.shape[:-1] + (4,))
     return ro
 
 
@@ -683,8 +683,8 @@ def eu2qu2d(eu):
 
 
 def eu2qu(eu):
-    """ n-dimensional wrapper for eu2qu2d"""
+    """n-dimensional wrapper for eu2qu2d"""
     n_eu = np.prod(eu.shape[:-1])
     eu2d = eu.reshape(n_eu, 3)
-    qu = eu2qu2d(eu2d).reshape(eu.shape[:-1]+(4,))
+    qu = eu2qu2d(eu2d).reshape(eu.shape[:-1] + (4,))
     return qu

--- a/orix/quaternion/_conversions.py
+++ b/orix/quaternion/_conversions.py
@@ -68,7 +68,7 @@ def get_pyramid_single(xyz):
 
 
 @nb.jit("int64[:](float64[:, :])", cache=True, nogil=True, nopython=True)
-def get_pyramid(xyz):
+def get_pyramid2d(xyz):
     """Determine to which out of six pyramids in the cube a 2D array of
     (x, y, z) coordinates belongs.
 
@@ -92,6 +92,14 @@ def get_pyramid(xyz):
     pyramids = np.zeros(n_scalars, dtype=np.int64)
     for i in nb.prange(n_scalars):
         pyramids[i] = get_pyramid_single(xyz[i])
+    return pyramids
+
+
+def get_pyramid(xyz):
+    """n-dimensional wrapper for get_pyramid2d"""
+    n_xyz = np.prod(xyz.shape[:-1])
+    xyz2d = xyz.reshape(n_xyz, 3)
+    pyramids = get_pyramid2d(xyz2d).reshape(n_xyz)
     return pyramids
 
 
@@ -175,7 +183,7 @@ def cu2ho_single(cu):
 
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
-def cu2ho(cu):
+def cu2ho2d(cu):
     """Conversion from multiple cubochoric coordinates to un-normalized
     homochoric coordinates :cite:`singh2016orientation`.
 
@@ -197,6 +205,14 @@ def cu2ho(cu):
     ho = np.zeros_like(cu)
     for i in nb.prange(cu.shape[0]):
         ho[i] = cu2ho_single(cu[i])
+    return ho
+
+
+def cu2ho(cu):
+    """ n-dimensional wrapper for cu2ho2d"""
+    n_cu = np.prod(cu.shape[:-1])
+    cu2d = cu.reshape(n_cu, 3)
+    ho = cu2ho2d(cu2d).reshape(cu.shape)
     return ho
 
 
@@ -252,7 +268,7 @@ def ho2ax_single(ho):
 
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
-def ho2ax(ho):
+def ho2ax2d(ho):
     """Conversion from multiple homochoric coordinates to un-normalized
     axis-angle pairs :cite:`rowenhorst2015consistent`.
 
@@ -276,6 +292,14 @@ def ho2ax(ho):
     for i in nb.prange(n_vectors):
         ax[i] = ho2ax_single(ho[i])
     return ax
+
+
+def ho2ax(ho):
+    """ n-dimensional wrapper for ho2ax2d"""
+    n_ho = np.prod(ho.shape[:-1])
+    ho2d = ho.reshape(n_ho, 3)
+    ho = ho2ax2d(ho2d).reshape(ho.shape[:-1]+(4,))
+    return ho
 
 
 @nb.jit("float64[:](float64[:])", cache=True, nogil=True, nopython=True)
@@ -313,7 +337,7 @@ def ax2ro_single(ax):
 
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
-def ax2ro(ax):
+def ax2ro2d(ax):
     """Conversion from multiple axis-angle pairs to un-normalized
     Rodrigues vectors :cite:`rowenhorst2015consistent`.
 
@@ -335,6 +359,14 @@ def ax2ro(ax):
     ro = np.zeros_like(ax)
     for i in nb.prange(ax.shape[0]):
         ro[i] = ax2ro_single(ax[i])
+    return ro
+
+
+def ax2ro(ax):
+    """ n-dimensional wrapper for ax2ro2d"""
+    n_ax = np.prod(ax.shape[:-1])
+    ax2d = ax.reshape(n_ax, 4)
+    ro = ax2ro2d(ax2d).reshape(ax.shape)
     return ro
 
 
@@ -368,7 +400,7 @@ def ro2ax_single(ro):
 
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
-def ro2ax(ro):
+def ro2ax2d(ro):
     """Conversion from multiple Rodrigues vectors to un-normalized
     axis-angle pairs :cite:`rowenhorst2015consistent`.
 
@@ -391,6 +423,13 @@ def ro2ax(ro):
     ax = np.zeros((n_vectors, 4), dtype=np.float64)
     for i in nb.prange(n_vectors):
         ax[i] = ro2ax_single(ro[i])
+    return ax
+
+
+def ro2ax(ro):
+    n_ro = np.prod(ro.shape[:-1])
+    ro2d = ro.reshape(n_ro, 4)
+    ax = ro2ax2d(ro2d).reshape(ro.shape)
     return ax
 
 
@@ -423,7 +462,7 @@ def ax2qu_single(ax):
 
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
-def ax2qu(ax):
+def ax2qu2d(ax):
     """Conversion from multiple axis-angle pairs to un-normalized
     quaternions :cite:`rowenhorst2015consistent`.
 
@@ -446,6 +485,14 @@ def ax2qu(ax):
     qu = np.zeros((n_vectors, 4), dtype=np.float64)
     for i in nb.prange(n_vectors):
         qu[i] = ax2qu_single(ax[i])
+    return qu
+
+
+def ax2qu(ax):
+    """ n-dimensional wrapper for ax2qu2d"""
+    n_ax = np.prod(ax.shape[:-1])
+    ax2d = ax.reshape(n_ax, 4)
+    qu = ax2qu2d(ax2d).reshape(ax.shape)
     return qu
 
 
@@ -473,7 +520,7 @@ def ho2ro_single(ho):
 
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
-def ho2ro(ho):
+def ho2ro2d(ho):
     """Conversion from multiple homochoric coordinates to un-normalized
     Rodrigues vectors :cite:`rowenhorst2015consistent`.
 
@@ -496,6 +543,14 @@ def ho2ro(ho):
     ro = np.zeros((n_vectors, 4), dtype=np.float64)
     for i in nb.prange(n_vectors):
         ro[i] = ho2ro_single(ho[i])
+    return ro
+
+
+def ho2ro(ho):
+    """ n-dimensional wrapper for ho2ro2d"""
+    n_ho = np.prod(ho.shape[:-1])
+    ho2d = ho.reshape(n_ho, 3)
+    ro = ho2ro2d(ho2d).reshape(ho.shape[:-1]+(4,))
     return ro
 
 
@@ -526,7 +581,7 @@ def cu2ro_single(cu):
 
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
-def cu2ro(cu):
+def cu2ro2d(cu):
     """Conversion from multiple cubochoric coordinates to un-normalized
     Rodrigues vectors :cite:`rowenhorst2015consistent`.
 
@@ -552,8 +607,16 @@ def cu2ro(cu):
     return ro
 
 
-@nb.jit("float64[:](float64, float64, float64)", cache=True, nogil=True, nopython=True)
-def eu2qu_single(alpha, beta, gamma):
+def cu2ro(cu):
+    """ n-dimensional wrapper for cu2ro2d"""
+    n_cu = np.prod(cu.shape[:-1])
+    cu2d = cu.reshape(n_cu, 3)
+    ro = cu2ro2d(cu2d).reshape(cu.shape[:-1]+(4,))
+    return ro
+
+
+@nb.jit("float64[:](float64[:])", cache=True, nogil=True, nopython=True)
+def eu2qu_single(eu):
     """Convert three Euler angles (alpha, beta, gamma) to a unit
     quaternion.
 
@@ -575,16 +638,16 @@ def eu2qu_single(alpha, beta, gamma):
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
     """
-    sigma = 0.5 * np.add(alpha, gamma)
-    delta = 0.5 * np.subtract(alpha, gamma)
-    c = np.cos(beta / 2)
-    s = np.sin(beta / 2)
+    sigma = 0.5 * np.add(eu[0], eu[2])
+    delta = 0.5 * np.subtract(eu[0], eu[2])
+    c = np.cos(eu[1] / 2)
+    s = np.sin(eu[1] / 2)
 
     qu = np.zeros(4, dtype=np.float64)
-    qu[0] = c * np.cos(sigma)
-    qu[1] = -s * np.cos(delta)
-    qu[2] = -s * np.sin(delta)
-    qu[3] = -c * np.sin(sigma)
+    qu[0] = np.array(c * np.cos(sigma), dtype=np.float64)
+    qu[1] = np.array(-s * np.cos(delta), dtype=np.float64)
+    qu[2] = np.array(-s * np.sin(delta), dtype=np.float64)
+    qu[3] = np.array(-c * np.sin(sigma), dtype=np.float64)
 
     if qu[0] < 0:
         qu = -qu
@@ -593,7 +656,7 @@ def eu2qu_single(alpha, beta, gamma):
 
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
-def eu2qu(eu):
+def eu2qu2d(eu):
     """Conversion from multiple Euler angles (alpha, beta, gamma) to unit
     quaternions
 
@@ -615,5 +678,13 @@ def eu2qu(eu):
     n_vectors = eu.shape[0]
     qu = np.zeros((n_vectors, 4), dtype=np.float64)
     for i in nb.prange(n_vectors):
-        qu[i] = eu2qu_single(eu[i, 0], eu[i, 1], eu[i, 2])
+        qu[i] = eu2qu_single(eu[i])
+    return qu
+
+
+def eu2qu(eu):
+    """ n-dimensional wrapper for eu2qu2d"""
+    n_eu = np.prod(eu.shape[:-1])
+    eu2d = eu.reshape(n_eu, 3)
+    qu = eu2qu2d(eu2d).reshape(eu.shape[:-1]+(4,))
     return qu

--- a/orix/tests/quaternion/test_conversions.py
+++ b/orix/tests/quaternion/test_conversions.py
@@ -143,15 +143,15 @@ def quaternions_conversions():
 
 class TestRotationConversions:
     def test_rotation_from_euler(self):
-        eulers = np.arange(30).reshape(10, 3) / 30
-        rot_np = Rotation.from_euler(eulers[0]).data
+        eulers = np.arange(30).reshape(10, 3)/30
+        eulers[0] = [1, 2, 3]
         rots_np = Rotation.from_euler(eulers).data
         # single
-        assert np.allclose(rot_np, eu2qu_single.py_func(eulers[0]))
+        assert np.allclose(rots_np[0], eu2qu_single.py_func(eulers[0]))
         # 2d
-        assert np.allclose(rots_np, eu2qu_2d.py_func(eulers))
+        assert np.allclose(rots_np, eu2qu_2d.py_func(eulers), atol=1e-40)
         # nd
-        assert np.allclose(rots_np, eu2qu(eulers))
+        assert np.allclose(rots_np, eu2qu(eulers), atol=1e-40)
 
     def test_get_pyramid(self, cubochoric_coordinates):
         pyramid = [3, 1, 1, 1, 2, 3, 4, 5, 6]
@@ -173,6 +173,10 @@ class TestRotationConversions:
         )
         # nd
         assert np.allclose(cu2ho(cubochoric_coordinates), homochoric_vectors, atol=1e-4)
+        # nd_float32
+        cu_32 = cubochoric_coordinates.astype((np.float32))
+        ho_32 = homochoric_vectors.astype((np.float32))
+        assert np.allclose(cu2ho(cu_32), ho_32, atol=1e-4)
 
     def test_ho2ax(self, homochoric_vectors, axis_angle_pairs):
         # single
@@ -184,6 +188,10 @@ class TestRotationConversions:
         )
         # nd
         assert np.allclose(ho2ax(homochoric_vectors), axis_angle_pairs, atol=1e-4)
+        # nd_float32
+        axang_32 = axis_angle_pairs.astype((np.float32))
+        ho_32 = homochoric_vectors.astype((np.float32))
+        assert np.allclose(ho2ax(ho_32), axang_32, atol=1e-4)
 
     def test_ax2ro(self, axis_angle_pairs, rodrigues_vectors):
         # single
@@ -191,11 +199,15 @@ class TestRotationConversions:
             assert np.allclose(ax2ro_single.py_func(ax), ro, atol=1e-4)
         # 2d
         assert np.isinf(ax2ro_single.py_func(np.array([0, 0, 0, np.pi]))[3])
-        # nd
         assert np.allclose(
             ax2ro_2d.py_func(axis_angle_pairs), rodrigues_vectors, atol=1e-4
         )
+        # nd
         assert np.allclose(ax2ro(axis_angle_pairs), rodrigues_vectors, atol=1e-4)
+        # nd_float32
+        axang_32 = axis_angle_pairs.astype((np.float32))
+        rod_32 = rodrigues_vectors.astype((np.float32))
+        assert np.allclose(ax2ro(axang_32), rod_32, atol=1e-4)
 
     def test_ro2ax(self, rodrigues_vectors, axis_angle_pairs):
         # single
@@ -208,6 +220,10 @@ class TestRotationConversions:
         )
         # nd
         assert np.allclose(ro2ax(rodrigues_vectors), axis_angle_pairs, atol=1e-4)
+        # nd_float32
+        axang_32 = axis_angle_pairs.astype((np.float32))
+        rod_32 = rodrigues_vectors.astype((np.float32))
+        assert np.allclose(ro2ax(rod_32), axang_32, atol=1e-4)
 
     def test_ax2qu(self, axis_angle_pairs, quaternions_conversions):
         # single
@@ -219,6 +235,10 @@ class TestRotationConversions:
         )
         # nd
         assert np.allclose(ax2qu(axis_angle_pairs), quaternions_conversions, atol=1e-4)
+        # nd_float32
+        axang_32 = axis_angle_pairs.astype((np.float32))
+        qu_32 = quaternions_conversions.astype((np.float32))
+        assert np.allclose(ax2qu(axang_32), qu_32, atol=1e-4)
 
     def test_ho2ro(self, homochoric_vectors, rodrigues_vectors):
         # single
@@ -230,6 +250,10 @@ class TestRotationConversions:
         )
         # nd
         assert np.allclose(ho2ro(homochoric_vectors), rodrigues_vectors, atol=1e-4)
+        # nd_float32
+        ho_32 = homochoric_vectors.astype((np.float32))
+        rod_32 = rodrigues_vectors.astype((np.float32))
+        assert np.allclose(ho2ro(ho_32), rod_32, atol=1e-4)
 
     def test_cu2ro(self, cubochoric_coordinates, rodrigues_vectors):
         # single
@@ -241,3 +265,7 @@ class TestRotationConversions:
         )
         # nd
         assert np.allclose(cu2ro(cubochoric_coordinates), rodrigues_vectors, atol=1e-4)
+        # nd_float32
+        cub_32 = cubochoric_coordinates.astype((np.float32))
+        rod_32 = rodrigues_vectors.astype((np.float32))
+        assert np.allclose(cu2ro(cub_32), rod_32, atol=1e-4)

--- a/orix/tests/quaternion/test_conversions.py
+++ b/orix/tests/quaternion/test_conversions.py
@@ -169,11 +169,11 @@ class TestRotationConversions:
         for cu, ho in zip(cubochoric_coordinates, homochoric_vectors):
             assert np.allclose(cu2ho_single.py_func(cu), ho, atol=1e-4)
         # 2d
-        assert np.allclose(cu2ho2d.py_func(
-            cubochoric_coordinates), homochoric_vectors, atol=1e-4)
-        # nd
         assert np.allclose(
-            cu2ho(cubochoric_coordinates), homochoric_vectors, atol=1e-4)
+            cu2ho2d.py_func(cubochoric_coordinates), homochoric_vectors, atol=1e-4
+        )
+        # nd
+        assert np.allclose(cu2ho(cubochoric_coordinates), homochoric_vectors, atol=1e-4)
 
     def test_ho2ax(self, homochoric_vectors, axis_angle_pairs):
         # single
@@ -181,10 +181,10 @@ class TestRotationConversions:
             assert np.allclose(ho2ax_single.py_func(ho), ax, atol=1e-4)
         # 2d
         assert np.allclose(
-            ho2ax2d.py_func(homochoric_vectors), axis_angle_pairs, atol=1e-4)
+            ho2ax2d.py_func(homochoric_vectors), axis_angle_pairs, atol=1e-4
+        )
         # nd
-        assert np.allclose(
-            ho2ax(homochoric_vectors), axis_angle_pairs, atol=1e-4)
+        assert np.allclose(ho2ax(homochoric_vectors), axis_angle_pairs, atol=1e-4)
 
     def test_ax2ro(self, axis_angle_pairs, rodrigues_vectors):
         # single
@@ -195,10 +195,8 @@ class TestRotationConversions:
         # nd
         assert np.allclose(
             ax2ro2d.py_func(axis_angle_pairs), rodrigues_vectors, atol=1e-4
-            )
-        assert np.allclose(
-            ax2ro(axis_angle_pairs), rodrigues_vectors, atol=1e-4
-            )
+        )
+        assert np.allclose(ax2ro(axis_angle_pairs), rodrigues_vectors, atol=1e-4)
 
     def test_ro2ax(self, rodrigues_vectors, axis_angle_pairs):
         # single
@@ -210,9 +208,7 @@ class TestRotationConversions:
             ro2ax2d.py_func(rodrigues_vectors), axis_angle_pairs, atol=1e-4
         )
         # nd
-        assert np.allclose(
-            ro2ax(rodrigues_vectors), axis_angle_pairs, atol=1e-4
-        )
+        assert np.allclose(ro2ax(rodrigues_vectors), axis_angle_pairs, atol=1e-4)
 
     def test_ax2qu(self, axis_angle_pairs, quaternions_conversions):
         # single
@@ -220,13 +216,10 @@ class TestRotationConversions:
             assert np.allclose(ax2qu_single.py_func(ax), qu, atol=1e-4)
         # 2d
         assert np.allclose(
-            ax2qu2d.py_func(axis_angle_pairs),
-            quaternions_conversions, atol=1e-4
-            )
+            ax2qu2d.py_func(axis_angle_pairs), quaternions_conversions, atol=1e-4
+        )
         # nd
-        assert np.allclose(
-            ax2qu(axis_angle_pairs), quaternions_conversions, atol=1e-4
-            )
+        assert np.allclose(ax2qu(axis_angle_pairs), quaternions_conversions, atol=1e-4)
 
     def test_ho2ro(self, homochoric_vectors, rodrigues_vectors):
         # single
@@ -237,9 +230,7 @@ class TestRotationConversions:
             ho2ro2d.py_func(homochoric_vectors), rodrigues_vectors, atol=1e-4
         )
         # nd
-        assert np.allclose(
-            ho2ro(homochoric_vectors), rodrigues_vectors, atol=1e-4
-        )
+        assert np.allclose(ho2ro(homochoric_vectors), rodrigues_vectors, atol=1e-4)
 
     def test_cu2ro(self, cubochoric_coordinates, rodrigues_vectors):
         # single
@@ -247,11 +238,7 @@ class TestRotationConversions:
             assert np.allclose(cu2ro_single.py_func(cu), ro, atol=1e-4)
         # 2d
         assert np.allclose(
-            cu2ro2d.py_func(cubochoric_coordinates),
-            rodrigues_vectors, atol=1e-4
-            )
+            cu2ro2d.py_func(cubochoric_coordinates), rodrigues_vectors, atol=1e-4
+        )
         # nd
-        assert np.allclose(
-            cu2ro(cubochoric_coordinates),
-            rodrigues_vectors, atol=1e-4
-            )
+        assert np.allclose(cu2ro(cubochoric_coordinates), rodrigues_vectors, atol=1e-4)

--- a/orix/tests/quaternion/test_conversions.py
+++ b/orix/tests/quaternion/test_conversions.py
@@ -143,7 +143,7 @@ def quaternions_conversions():
 
 class TestRotationConversions:
     def test_rotation_from_euler(self):
-        eulers = np.arange(30).reshape(10, 3)/30
+        eulers = np.arange(30).reshape(10, 3) / 30
         eulers[0] = [1, 2, 3]
         rots_np = Rotation.from_euler(eulers).data
         # single

--- a/orix/tests/quaternion/test_conversions.py
+++ b/orix/tests/quaternion/test_conversions.py
@@ -22,20 +22,31 @@ import pytest
 from orix.quaternion import Rotation
 from orix.quaternion._conversions import (
     ax2qu,
+    ax2qu2d,
     ax2qu_single,
     ax2ro,
+    ax2ro2d,
     ax2ro_single,
     cu2ho,
+    cu2ho2d,
     cu2ho_single,
     cu2ro,
+    cu2ro2d,
     cu2ro_single,
+    eu2qu,
+    eu2qu2d,
     eu2qu_single,
+    get_pyramid,
+    get_pyramid2d,
     get_pyramid_single,
     ho2ax,
+    ho2ax2d,
     ho2ax_single,
     ho2ro,
+    ho2ro2d,
     ho2ro_single,
     ro2ax,
+    ro2ax2d,
     ro2ax_single,
 )
 
@@ -133,75 +144,114 @@ def quaternions_conversions():
 class TestRotationConversions:
     def test_rotation_from_euler(self):
         euler = np.array([1, 2, 3])
+        eulers = np.arange(1, 2.5, 0.05).reshape(10, 3)
         rot_np = Rotation.from_euler(euler).data
-        assert np.allclose(rot_np, eu2qu_single.py_func(*euler))
+        rots_np = Rotation.from_euler(eulers).data
+        # single
+        assert np.allclose(rot_np, eu2qu_single.py_func(euler))
+        # 2d
+        assert np.allclose(rots_np, eu2qu2d.py_func(eulers))
+        # nd
+        assert np.allclose(rots_np, eu2qu(eulers))
 
-    def test_get_pyramid_single(self, cubochoric_coordinates):
+    def test_get_pyramid(self, cubochoric_coordinates):
         pyramid = [3, 1, 1, 1, 2, 3, 4, 5, 6]
+        # single
         for xyz, p in zip(cubochoric_coordinates, pyramid):
             assert get_pyramid_single.py_func(xyz) == p
-
-    def test_cu2ho_single(self, cubochoric_coordinates, homochoric_vectors):
-        for cu, ho in zip(cubochoric_coordinates, homochoric_vectors):
-            assert np.allclose(cu2ho_single.py_func(cu), ho, atol=1e-4)
+        # 2d
+        assert all(get_pyramid2d.py_func(cubochoric_coordinates) == pyramid)
+        # nd
+        assert all(get_pyramid(cubochoric_coordinates) == pyramid)
 
     def test_cu2ho(self, cubochoric_coordinates, homochoric_vectors):
+        # single
+        for cu, ho in zip(cubochoric_coordinates, homochoric_vectors):
+            assert np.allclose(cu2ho_single.py_func(cu), ho, atol=1e-4)
+        # 2d
+        assert np.allclose(cu2ho2d.py_func(
+            cubochoric_coordinates), homochoric_vectors, atol=1e-4)
+        # nd
         assert np.allclose(
-            cu2ho.py_func(cubochoric_coordinates), homochoric_vectors, atol=1e-4
-        )
-
-    def test_ho2ax_single(self, homochoric_vectors, axis_angle_pairs):
-        for ho, ax in zip(homochoric_vectors, axis_angle_pairs):
-            assert np.allclose(ho2ax_single.py_func(ho), ax, atol=1e-4)
+            cu2ho(cubochoric_coordinates), homochoric_vectors, atol=1e-4)
 
     def test_ho2ax(self, homochoric_vectors, axis_angle_pairs):
+        # single
+        for ho, ax in zip(homochoric_vectors, axis_angle_pairs):
+            assert np.allclose(ho2ax_single.py_func(ho), ax, atol=1e-4)
+        # 2d
         assert np.allclose(
-            ho2ax.py_func(homochoric_vectors), axis_angle_pairs, atol=1e-4
-        )
-
-    def test_ax2ro_single(self, axis_angle_pairs, rodrigues_vectors):
-        for ax, ro in zip(axis_angle_pairs, rodrigues_vectors):
-            assert np.allclose(ax2ro_single.py_func(ax), ro, atol=1e-4)
-        assert np.isinf(ax2ro_single.py_func(np.array([0, 0, 0, np.pi]))[3])
+            ho2ax2d.py_func(homochoric_vectors), axis_angle_pairs, atol=1e-4)
+        # nd
+        assert np.allclose(
+            ho2ax(homochoric_vectors), axis_angle_pairs, atol=1e-4)
 
     def test_ax2ro(self, axis_angle_pairs, rodrigues_vectors):
+        # single
+        for ax, ro in zip(axis_angle_pairs, rodrigues_vectors):
+            assert np.allclose(ax2ro_single.py_func(ax), ro, atol=1e-4)
+        # 2d
+        assert np.isinf(ax2ro_single.py_func(np.array([0, 0, 0, np.pi]))[3])
+        # nd
         assert np.allclose(
-            ax2ro.py_func(axis_angle_pairs), rodrigues_vectors, atol=1e-4
-        )
+            ax2ro2d.py_func(axis_angle_pairs), rodrigues_vectors, atol=1e-4
+            )
+        assert np.allclose(
+            ax2ro(axis_angle_pairs), rodrigues_vectors, atol=1e-4
+            )
 
-    def test_ro2ax_single(self, rodrigues_vectors, axis_angle_pairs):
+    def test_ro2ax(self, rodrigues_vectors, axis_angle_pairs):
+        # single
         for ro, ax in zip(rodrigues_vectors, axis_angle_pairs):
             assert np.allclose(ro2ax_single.py_func(ro), ax, atol=1e-4)
         assert ro2ax_single.py_func(np.array([0, 0, 0, np.inf]))[3] == np.pi
-
-    def test_ro2ax(self, rodrigues_vectors, axis_angle_pairs):
+        # 2d
         assert np.allclose(
-            ro2ax.py_func(rodrigues_vectors), axis_angle_pairs, atol=1e-4
+            ro2ax2d.py_func(rodrigues_vectors), axis_angle_pairs, atol=1e-4
         )
-
-    def test_ax2qu_single(self, axis_angle_pairs, quaternions_conversions):
-        for ax, qu in zip(axis_angle_pairs, quaternions_conversions):
-            assert np.allclose(ax2qu_single.py_func(ax), qu, atol=1e-4)
+        # nd
+        assert np.allclose(
+            ro2ax(rodrigues_vectors), axis_angle_pairs, atol=1e-4
+        )
 
     def test_ax2qu(self, axis_angle_pairs, quaternions_conversions):
+        # single
+        for ax, qu in zip(axis_angle_pairs, quaternions_conversions):
+            assert np.allclose(ax2qu_single.py_func(ax), qu, atol=1e-4)
+        # 2d
         assert np.allclose(
-            ax2qu.py_func(axis_angle_pairs), quaternions_conversions, atol=1e-4
-        )
-
-    def test_ho2ro_single(self, homochoric_vectors, rodrigues_vectors):
-        for ho, ro in zip(homochoric_vectors, rodrigues_vectors):
-            assert np.allclose(ho2ro_single.py_func(ho), ro, atol=1e-4)
+            ax2qu2d.py_func(axis_angle_pairs),
+            quaternions_conversions, atol=1e-4
+            )
+        # nd
+        assert np.allclose(
+            ax2qu(axis_angle_pairs), quaternions_conversions, atol=1e-4
+            )
 
     def test_ho2ro(self, homochoric_vectors, rodrigues_vectors):
+        # single
+        for ho, ro in zip(homochoric_vectors, rodrigues_vectors):
+            assert np.allclose(ho2ro_single.py_func(ho), ro, atol=1e-4)
+        # 2d
         assert np.allclose(
-            ho2ro.py_func(homochoric_vectors), rodrigues_vectors, atol=1e-4
+            ho2ro2d.py_func(homochoric_vectors), rodrigues_vectors, atol=1e-4
         )
-
-    def test_cu2ro_single(self, cubochoric_coordinates, rodrigues_vectors):
-        for cu, ro in zip(cubochoric_coordinates, rodrigues_vectors):
-            assert np.allclose(cu2ro_single.py_func(cu), ro, atol=1e-4)
+        # nd
+        assert np.allclose(
+            ho2ro(homochoric_vectors), rodrigues_vectors, atol=1e-4
+        )
 
     def test_cu2ro(self, cubochoric_coordinates, rodrigues_vectors):
+        # single
+        for cu, ro in zip(cubochoric_coordinates, rodrigues_vectors):
+            assert np.allclose(cu2ro_single.py_func(cu), ro, atol=1e-4)
+        # 2d
         assert np.allclose(
-            cu2ro.py_func(cubochoric_coordinates), rodrigues_vectors, atol=1e-4
-        )
+            cu2ro2d.py_func(cubochoric_coordinates),
+            rodrigues_vectors, atol=1e-4
+            )
+        # nd
+        assert np.allclose(
+            cu2ro(cubochoric_coordinates),
+            rodrigues_vectors, atol=1e-4
+            )

--- a/orix/tests/quaternion/test_conversions.py
+++ b/orix/tests/quaternion/test_conversions.py
@@ -22,31 +22,31 @@ import pytest
 from orix.quaternion import Rotation
 from orix.quaternion._conversions import (
     ax2qu,
-    ax2qu2d,
+    ax2qu_2d,
     ax2qu_single,
     ax2ro,
-    ax2ro2d,
+    ax2ro_2d,
     ax2ro_single,
     cu2ho,
-    cu2ho2d,
+    cu2ho_2d,
     cu2ho_single,
     cu2ro,
-    cu2ro2d,
+    cu2ro_2d,
     cu2ro_single,
     eu2qu,
-    eu2qu2d,
+    eu2qu_2d,
     eu2qu_single,
     get_pyramid,
-    get_pyramid2d,
+    get_pyramid_2d,
     get_pyramid_single,
     ho2ax,
-    ho2ax2d,
+    ho2ax_2d,
     ho2ax_single,
     ho2ro,
-    ho2ro2d,
+    ho2ro_2d,
     ho2ro_single,
     ro2ax,
-    ro2ax2d,
+    ro2ax_2d,
     ro2ax_single,
 )
 
@@ -143,14 +143,13 @@ def quaternions_conversions():
 
 class TestRotationConversions:
     def test_rotation_from_euler(self):
-        euler = np.array([1, 2, 3])
-        eulers = np.arange(1, 2.5, 0.05).reshape(10, 3)
-        rot_np = Rotation.from_euler(euler).data
+        eulers = np.arange(30).reshape(10, 3) / 30
+        rot_np = Rotation.from_euler(eulers[0]).data
         rots_np = Rotation.from_euler(eulers).data
         # single
-        assert np.allclose(rot_np, eu2qu_single.py_func(euler))
+        assert np.allclose(rot_np, eu2qu_single.py_func(eulers[0]))
         # 2d
-        assert np.allclose(rots_np, eu2qu2d.py_func(eulers))
+        assert np.allclose(rots_np, eu2qu_2d.py_func(eulers))
         # nd
         assert np.allclose(rots_np, eu2qu(eulers))
 
@@ -160,7 +159,7 @@ class TestRotationConversions:
         for xyz, p in zip(cubochoric_coordinates, pyramid):
             assert get_pyramid_single.py_func(xyz) == p
         # 2d
-        assert all(get_pyramid2d.py_func(cubochoric_coordinates) == pyramid)
+        assert all(get_pyramid_2d.py_func(cubochoric_coordinates) == pyramid)
         # nd
         assert all(get_pyramid(cubochoric_coordinates) == pyramid)
 
@@ -170,7 +169,7 @@ class TestRotationConversions:
             assert np.allclose(cu2ho_single.py_func(cu), ho, atol=1e-4)
         # 2d
         assert np.allclose(
-            cu2ho2d.py_func(cubochoric_coordinates), homochoric_vectors, atol=1e-4
+            cu2ho_2d.py_func(cubochoric_coordinates), homochoric_vectors, atol=1e-4
         )
         # nd
         assert np.allclose(cu2ho(cubochoric_coordinates), homochoric_vectors, atol=1e-4)
@@ -181,7 +180,7 @@ class TestRotationConversions:
             assert np.allclose(ho2ax_single.py_func(ho), ax, atol=1e-4)
         # 2d
         assert np.allclose(
-            ho2ax2d.py_func(homochoric_vectors), axis_angle_pairs, atol=1e-4
+            ho2ax_2d.py_func(homochoric_vectors), axis_angle_pairs, atol=1e-4
         )
         # nd
         assert np.allclose(ho2ax(homochoric_vectors), axis_angle_pairs, atol=1e-4)
@@ -194,7 +193,7 @@ class TestRotationConversions:
         assert np.isinf(ax2ro_single.py_func(np.array([0, 0, 0, np.pi]))[3])
         # nd
         assert np.allclose(
-            ax2ro2d.py_func(axis_angle_pairs), rodrigues_vectors, atol=1e-4
+            ax2ro_2d.py_func(axis_angle_pairs), rodrigues_vectors, atol=1e-4
         )
         assert np.allclose(ax2ro(axis_angle_pairs), rodrigues_vectors, atol=1e-4)
 
@@ -205,7 +204,7 @@ class TestRotationConversions:
         assert ro2ax_single.py_func(np.array([0, 0, 0, np.inf]))[3] == np.pi
         # 2d
         assert np.allclose(
-            ro2ax2d.py_func(rodrigues_vectors), axis_angle_pairs, atol=1e-4
+            ro2ax_2d.py_func(rodrigues_vectors), axis_angle_pairs, atol=1e-4
         )
         # nd
         assert np.allclose(ro2ax(rodrigues_vectors), axis_angle_pairs, atol=1e-4)
@@ -216,7 +215,7 @@ class TestRotationConversions:
             assert np.allclose(ax2qu_single.py_func(ax), qu, atol=1e-4)
         # 2d
         assert np.allclose(
-            ax2qu2d.py_func(axis_angle_pairs), quaternions_conversions, atol=1e-4
+            ax2qu_2d.py_func(axis_angle_pairs), quaternions_conversions, atol=1e-4
         )
         # nd
         assert np.allclose(ax2qu(axis_angle_pairs), quaternions_conversions, atol=1e-4)
@@ -227,7 +226,7 @@ class TestRotationConversions:
             assert np.allclose(ho2ro_single.py_func(ho), ro, atol=1e-4)
         # 2d
         assert np.allclose(
-            ho2ro2d.py_func(homochoric_vectors), rodrigues_vectors, atol=1e-4
+            ho2ro_2d.py_func(homochoric_vectors), rodrigues_vectors, atol=1e-4
         )
         # nd
         assert np.allclose(ho2ro(homochoric_vectors), rodrigues_vectors, atol=1e-4)
@@ -238,7 +237,7 @@ class TestRotationConversions:
             assert np.allclose(cu2ro_single.py_func(cu), ro, atol=1e-4)
         # 2d
         assert np.allclose(
-            cu2ro2d.py_func(cubochoric_coordinates), rodrigues_vectors, atol=1e-4
+            cu2ro_2d.py_func(cubochoric_coordinates), rodrigues_vectors, atol=1e-4
         )
         # nd
         assert np.allclose(cu2ro(cubochoric_coordinates), rodrigues_vectors, atol=1e-4)

--- a/orix/tests/quaternion/test_conversions.py
+++ b/orix/tests/quaternion/test_conversions.py
@@ -142,18 +142,25 @@ def quaternions_conversions():
 
 
 class TestRotationConversions:
-    def test_rotation_from_euler(self):
+    """Tests of conversions between rotation representations.
+
+    Functions are accelerated with Numba, so both the Numba and Python
+    versions of the function are tested.
+    """
+
+    def test_eu2qu(self):
         eulers = np.arange(30).reshape(10, 3) / 30
-        eulers[0] = [1, 2, 3]
+        eulers[0] = [1, 2, 3]  # Covers case where q0 < 0
         rots_np = Rotation.from_euler(eulers).data
         # single
         assert np.allclose(rots_np[0], eu2qu_single.py_func(eulers[0]))
         # 2d
-        assert np.allclose(rots_np, eu2qu_2d.py_func(eulers), atol=1e-40)
+        assert np.allclose(rots_np, eu2qu_2d.py_func(eulers), atol=1e-4)
         # nd
-        assert np.allclose(rots_np, eu2qu(eulers), atol=1e-40)
+        assert np.allclose(rots_np, eu2qu(eulers), atol=1e-4)
 
     def test_get_pyramid(self, cubochoric_coordinates):
+        """Cubochoric coordinates situated in expected pyramid."""
         pyramid = [3, 1, 1, 1, 2, 3, 4, 5, 6]
         # single
         for xyz, p in zip(cubochoric_coordinates, pyramid):
@@ -174,8 +181,8 @@ class TestRotationConversions:
         # nd
         assert np.allclose(cu2ho(cubochoric_coordinates), homochoric_vectors, atol=1e-4)
         # nd_float32
-        cu_32 = cubochoric_coordinates.astype((np.float32))
-        ho_32 = homochoric_vectors.astype((np.float32))
+        cu_32 = cubochoric_coordinates.astype(np.float32)
+        ho_32 = homochoric_vectors.astype(np.float32)
         assert np.allclose(cu2ho(cu_32), ho_32, atol=1e-4)
 
     def test_ho2ax(self, homochoric_vectors, axis_angle_pairs):
@@ -189,8 +196,8 @@ class TestRotationConversions:
         # nd
         assert np.allclose(ho2ax(homochoric_vectors), axis_angle_pairs, atol=1e-4)
         # nd_float32
-        axang_32 = axis_angle_pairs.astype((np.float32))
-        ho_32 = homochoric_vectors.astype((np.float32))
+        axang_32 = axis_angle_pairs.astype(np.float32)
+        ho_32 = homochoric_vectors.astype(np.float32)
         assert np.allclose(ho2ax(ho_32), axang_32, atol=1e-4)
 
     def test_ax2ro(self, axis_angle_pairs, rodrigues_vectors):
@@ -205,8 +212,8 @@ class TestRotationConversions:
         # nd
         assert np.allclose(ax2ro(axis_angle_pairs), rodrigues_vectors, atol=1e-4)
         # nd_float32
-        axang_32 = axis_angle_pairs.astype((np.float32))
-        rod_32 = rodrigues_vectors.astype((np.float32))
+        axang_32 = axis_angle_pairs.astype(np.float32)
+        rod_32 = rodrigues_vectors.astype(np.float32)
         assert np.allclose(ax2ro(axang_32), rod_32, atol=1e-4)
 
     def test_ro2ax(self, rodrigues_vectors, axis_angle_pairs):
@@ -221,8 +228,8 @@ class TestRotationConversions:
         # nd
         assert np.allclose(ro2ax(rodrigues_vectors), axis_angle_pairs, atol=1e-4)
         # nd_float32
-        axang_32 = axis_angle_pairs.astype((np.float32))
-        rod_32 = rodrigues_vectors.astype((np.float32))
+        axang_32 = axis_angle_pairs.astype(np.float32)
+        rod_32 = rodrigues_vectors.astype(np.float32)
         assert np.allclose(ro2ax(rod_32), axang_32, atol=1e-4)
 
     def test_ax2qu(self, axis_angle_pairs, quaternions_conversions):
@@ -236,8 +243,8 @@ class TestRotationConversions:
         # nd
         assert np.allclose(ax2qu(axis_angle_pairs), quaternions_conversions, atol=1e-4)
         # nd_float32
-        axang_32 = axis_angle_pairs.astype((np.float32))
-        qu_32 = quaternions_conversions.astype((np.float32))
+        axang_32 = axis_angle_pairs.astype(np.float32)
+        qu_32 = quaternions_conversions.astype(np.float32)
         assert np.allclose(ax2qu(axang_32), qu_32, atol=1e-4)
 
     def test_ho2ro(self, homochoric_vectors, rodrigues_vectors):
@@ -251,8 +258,8 @@ class TestRotationConversions:
         # nd
         assert np.allclose(ho2ro(homochoric_vectors), rodrigues_vectors, atol=1e-4)
         # nd_float32
-        ho_32 = homochoric_vectors.astype((np.float32))
-        rod_32 = rodrigues_vectors.astype((np.float32))
+        ho_32 = homochoric_vectors.astype(np.float32)
+        rod_32 = rodrigues_vectors.astype(np.float32)
         assert np.allclose(ho2ro(ho_32), rod_32, atol=1e-4)
 
     def test_cu2ro(self, cubochoric_coordinates, rodrigues_vectors):
@@ -266,6 +273,6 @@ class TestRotationConversions:
         # nd
         assert np.allclose(cu2ro(cubochoric_coordinates), rodrigues_vectors, atol=1e-4)
         # nd_float32
-        cub_32 = cubochoric_coordinates.astype((np.float32))
-        rod_32 = rodrigues_vectors.astype((np.float32))
+        cub_32 = cubochoric_coordinates.astype(np.float32)
+        rod_32 = rodrigues_vectors.astype(np.float32)
         assert np.allclose(cu2ro(cub_32), rod_32, atol=1e-4)


### PR DESCRIPTION
#### Description of the change

By default, Rotation objects can contain n-dimensional arrays of Rotation data. However, _conversions.py is written to only accept 2D arrays, since the functions use jit for acceleration. This adds wrappers to the jit functions to allow input and output of any dimensional array of Rotations.

Reasons for this:
1) This makes it possible to add to/from functions for Euler, Rodrigues, homochoric, cubochoric, and axis-angle functions into either Rotations or Quaternions. without losing the n-dimensional object support.
2) all the to/from functions will be able to use the jit-accelerated conversion functions copied directly from the Rowenhorst paper. 
3) Orix contains repeated to/from conversion functions, which adds some bloat and gives more room for errors. Wrapping these functions makes it easier to replace this repeated functionality with the jit-accelerated ones.

4)  This update makes it easier to take care of issues 
  #374
  #373 
  #346
  #345  and 
   #254

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
The test cases verify the new functions produce identical results to the old 2d versions, but here is some code I used to verify this new code can, in fact, accept n-dimensional arrays of Rotations, and does not slow down the execution of the code by a meaningful amount.

```python
import numpy as np
import time
from orix.quaternion._conversions import ro2ax, ro2ax2d

tocA = 0
tocB = 0
tocC = 0

# Run 10 times to get a good average
for i in np.arange(10):
    rod = np.random.rand(1000000, 4)

    # Convert Rod to axangle the old way using the original function
    tic = time.time()
    out_old = ro2ax2d(rod)
    toc = time.time() - tic
    tocA += toc

    # Do it using the new n-dimensional wrapper
    tic = time.time()
    out_new = ro2ax(rod)
    toc = time.time() - tic
    tocB += toc

    # verify they are identical
    assert np.all(out_new == out_old)

    # Do it using the new n-dimensional wrapper on a weird shaped dataset
    rod_weird = rod.reshape(2, 5, 10, 1, 100, 10, 10, 4)
    tic = time.time()
    out_weird = ro2ax(rod_weird).reshape(rod.shape)
    toc = time.time() - tic
    tocC += toc

    # verify they are identical
    assert np.all(out_old == out_weird)

# check out how long each method took
print("old way:{0:0.04f}".format(tocA))
print("new way:{0:0.04f}".format(tocB))
print("new way weird shape:{0:0.04f}".format(tocC))
```

Heres the output I got:
old way:6.9345
new way:6.9778
new way weird shape:6.9356

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [n/a] New functions are imported in corresponding `__init__.py`.
- [n/a] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [x] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.