### PR TITLE
Make custom Arrow3D compatible with Matplotlib 3.6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,11 @@ Removed
 - Support for Python 3.6 has been removed. The minimum supported version in ``orix`` is
   now Python 3.7.
 
+Fixed
+-----
+- Plotting of unit cells works with Matplotlib v3.6, at the expense of a warning raised
+  with earlier versions.
+
 2022-05-16 - version 0.9.0
 ==========================
 

--- a/orix/plot/_util.py
+++ b/orix/plot/_util.py
@@ -18,26 +18,22 @@
 
 from matplotlib.patches import FancyArrowPatch
 from mpl_toolkits.mplot3d import proj3d
+import numpy as np
 
 
 class Arrow3D(FancyArrowPatch):
     """Matplotlib arrows in 3D with arrowheads.
 
-    Taken from this Stackoverflow answer by user CT Zhu
+    Initially taken from this Stack Overflow answer by user CT Zhu
     https://stackoverflow.com/a/22867877/12063126.
     """
 
     def __init__(self, xs, ys, zs, *args, **kwargs):
-        FancyArrowPatch.__init__(self, (0, 0), (0, 0), *args, **kwargs)
+        super().__init__((0, 0), (0, 0), *args, **kwargs)
         self._verts3d = xs, ys, zs
 
-    def draw(self, renderer):
+    def do_3d_projection(self, renderer=None):
         xs3d, ys3d, zs3d = self._verts3d
         xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)
         self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
-        FancyArrowPatch.draw(self, renderer)
-        zorder = 1
-        return zorder
-
-    # matplotlib>=3.5 compatibility
-    do_3d_projection = draw
+        return np.min(zs)


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
Fix #381.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
See #381.

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.