### PR TITLE
Updates to develop branch post 0.10.0

### DIFF
--- a/.github/workflows/perhaps_make_a_tagged_release_draft.yml
+++ b/.github/workflows/perhaps_make_a_tagged_release_draft.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install outdated
+        pip install packaging outdated
 
     - name: Check whether a tagged release draft should be made
       run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,27 @@ All notable changes to the ``orix`` project are documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_, and
 this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+Unreleased
+==========
+
+Added
+-----
+
+Changed
+-------
+
+Deprecated
+----------
+
+Removed
+-------
+
+Fixed
+-----
+
+Security
+--------
+
 2022-09-22 - version 0.10.0
 ===========================
 

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -1,5 +1,5 @@
 __name__ = "orix"
-__version__ = "0.10.0"
+__version__ = "0.11.dev0"
 __author__ = "orix developers"
 __author_email__ = "pyxem.team@gmail.com"
 __description__ = "orix is an open-source Python library for handling crystal orientation mapping data."

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ extra_feature_requirements["dev"] = [
     "isort                              >= 5.10",
     "manifix",
     "outdated",
+    "packaging",
     "pre-commit                         >= 1.16",
 ] + list(chain(*list(extra_feature_requirements.values())))
 # fmt: on


### PR DESCRIPTION
#### Description of the change
This is the final PR related to the 0.10.0 release with updates to the version and changelog.

Also installs a missing package used in the workflow that automates creation of release drafts whenever changes to `__version__` are made in `orix/__init__.py` on the `main` branch. This workflow failed this time, so I had to manually write the release notes for 0.10.0. Let's hope it works next time.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [x] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.