### PR TITLE
Fix indexing/slicing into sliced CrystalMap

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@ All notable changes to the ``orix`` project are documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_, and
 this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+2022-09-30 - version 0.10.1
+===========================
+
+Fixed
+-----
+- Indexing/slicing into an already indexed/sliced ``CrystalMap`` now correctly returns
+  the index/slice according to ``CrystalMap.shape`` and not the original shape of the
+  un-sliced map.
+
 2022-09-22 - version 0.10.0
 ===========================
 

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -585,11 +585,8 @@ class CrystalMap:
             If ``str``, it must be a valid phase or ``"not_indexed"`` or
             ``"indexed"``. If ``slice`` or ``tuple``, it must be within
             the map shape. If ``int``, it must be a valid
-            :attr`self.id`. If boolean array, it must be of map shape.
+            :attr:`self.id`. If boolean array, it must be of map shape.
         """
-        # TODO: Crop new map to the extremal spatial values (e.g. if all values in first
-        #  or last row/column are masked out by the key), i.e. not just mask the values
-
         # Initiate a mask to be added to the returned copy of the
         # CrystalMap instance, to ensure that only the unmasked values
         # are in the data of the copy (True in `is_in_data`). First, no
@@ -597,8 +594,8 @@ class CrystalMap:
         # condition in the input key.
         is_in_data = np.zeros(self.size, dtype=bool)
 
-        # The original instance might already have set some points to
-        # not be in the data. If so, `is_in_data` is used to update the
+        # The original mask might already have set some points to not be
+        # in the data. If so, `is_in_data` is used to update the
         # original `is_in_data`. Since `new_is_in_data` is not initiated
         # for all key types, we declare it here and check for it later.
         new_is_in_data = None
@@ -630,12 +627,13 @@ class CrystalMap:
             for i, k in enumerate(key):
                 slices[i] = k
 
-            new_is_in_data = np.zeros(self._original_shape, dtype=bool)  # > 1D
-            new_is_in_data[tuple(slices)] = True
-            # Note that although all points within slice(s) was sought,
-            # points within the slice(s) which are already removed from
-            # the data are still kept out by this boolean multiplication
-            new_is_in_data = new_is_in_data.flatten() * self.is_in_data
+            new_is_in_data_slice = np.zeros(self.shape, dtype=bool)  # > 1D
+            new_is_in_data_slice[tuple(slices)] = True
+
+            # Insert new (sub)mask into old full mask
+            new_is_in_data = self.is_in_data.reshape(self._original_shape).copy()
+            new_is_in_data[self._data_slices_from_coordinates()] = new_is_in_data_slice
+            new_is_in_data = new_is_in_data.ravel()
 
         # Insert the mask into a mask with the full map shape, if not
         # done already

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -429,7 +429,7 @@ class TestCrystalMapGetItem:
         # This also tests `phase_id`
         xmap = CrystalMap(**crystal_map_input)
         if raises:
-            with pytest.raises(IndexError, match=f".* is out of bounds for"):
+            with pytest.raises(IndexError, match=".* is out of bounds for"):
                 _ = xmap[integer_slices]
         else:
             point = xmap[integer_slices]
@@ -437,6 +437,29 @@ class TestCrystalMapGetItem:
 
             assert np.allclose(point.rotations.data, expected_point.rotations.data)
             assert point._coordinates == expected_point._coordinates
+
+    def test_get_twice(self):
+        """Indexing into a CrystalMap cropped twice returns the desired
+        part of the map.
+        """
+        xmap = CrystalMap.empty()
+        xmap2 = xmap[1:4, 4:9]
+
+        assert np.allclose(xmap.id, np.arange(xmap.size))
+        # fmt: off
+        assert np.allclose(
+            xmap2.id,
+            [
+                14, 15, 16, 17, 18,
+                24, 25, 26, 27, 28,
+                34, 35, 36, 37, 38,
+            ]
+        )
+        # fmt: on
+        assert np.allclose(xmap2[1:, 1:4].id, [25, 26, 27, 35, 36, 37])
+        assert np.allclose(xmap2[1, 2].id, 26)
+        assert np.allclose(xmap2[1, 3].id, 27)
+        assert np.allclose(xmap2[2, 2].id, 36)
 
 
 class TestCrystalMapSetAttributes:


### PR DESCRIPTION
#### Description of the change
I discovered a bug where indexing/slicing into an already sliced `CrystalMap` assumed the initial shape (`_original_shape`) and not the current shape.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)
- [ ] Update release version to 0.10.1
- [ ] Merge after #392 and #393 are merged

#### Minimal example of the bug fix or new feature

```python
>>> from orix.crystal_map import CrystalMap
>>> xmap = CrystalMap.empty((4, 5))
>>> xmap.id.reshape(xmap.shape)
array([[ 0,  1,  2,  3,  4],
       [ 5,  6,  7,  8,  9],
       [10, 11, 12, 13, 14],
       [15, 16, 17, 18, 19]])
>>> xmap2 = xmap[1:4, :3]
>>> xmap2._original_shape
(4, 5)
>>> xmap2.id.reshape(xmap2.shape)
array([[ 5,  6,  7],
       [10, 11, 12],
       [15, 16, 17]])
```

Getting some IDs of `xmap2` before this fix

```python
>>> xmap2[1, 1].id
array([11])
>>> xmap2[:2, :2].id
array([5, 6])
```

and after this fix
```python
>>> xmap2[1, 1].id
array([13])
>>> xmap2[:2, :2].id
array([ 5,  6, 10, 11])
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.