### PR TITLE
Deprecate minimal/brittle "3D" functionality for crystal maps

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,16 @@ this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.htm
 2022-09-30 - version 0.10.1
 ===========================
 
+Deprecated
+----------
+- Parameter ``z`` when creating a ``CrystalMap`` and the ``z`` and ``dz`` attributes of
+  the class are deprecated and will be removed in 0.11.0. Support for 3D crystal maps is
+  minimal and brittle, and it was therefore decided to remove it altogether.
+- Passing ``shape`` or ``step_sizes`` of three values to ``create_coordinate_arrays()``
+  is depreacted and will be removed in 0.11.0. See the previous point for the reason.
+- Parameter ``depth`` in ``CrystalMapPlot.plot_map()`` is depreacted and will be removed
+  in 0.11.0. See the top point for the reason.
+
 Fixed
 -----
 - ``StereographicPlot.scatter()`` now accepts both ``c``/``color`` and ``s``/``sizes``

--- a/orix/_util.py
+++ b/orix/_util.py
@@ -98,7 +98,7 @@ class deprecated:
         @functools.wraps(func)
         def wrapped(*args, **kwargs):
             warnings.simplefilter(
-                action="always", category=np.VisibleDeprecationWarning
+                action="always", category=np.VisibleDeprecationWarning, append=True
             )
             func_code = func.__code__
             warnings.warn_explicit(
@@ -151,7 +151,7 @@ class deprecated_argument:
                     msg += f"Use `{self.alternative}` instead. "
                 msg += f"See the documentation of `{func.__name__}()` for more details."
                 warnings.simplefilter(
-                    action="always", category=np.VisibleDeprecationWarning
+                    action="always", category=np.VisibleDeprecationWarning, append=True
                 )
                 func_code = func.__code__
                 warnings.warn_explicit(

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -257,17 +257,6 @@ class CrystalMap:
         self._y = y
         self._z = z
 
-        #        # TODO: Remove after (any) one release after 0.10.1
-        #        if z is not None:
-        #            warn(
-        #                "The CrystalMap.z attribute is deprecated and will be removed in "
-        #                "0.11.0. Support for 3D crystal maps is minimal and brittle, and it was"
-        #                " therefore decided to remove it altogether. If you rely on this "
-        #                "functionality, please report it in an issue at "
-        #                "https://github.com/pyxem/orix/issues",
-        #                np.VisibleDeprecationWarning
-        #            )
-
         # Create phase list
         # Sorted in ascending order
         unique_phase_ids = np.unique(phase_id)

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -18,7 +18,7 @@
 
 import copy
 from typing import Optional, Tuple, Union
-from warnings import warn
+import warnings
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -545,7 +545,11 @@ class CrystalMap:
         """Return the coordinates of points in the data."""
         # TODO: Make this "dynamic"/dependable when enabling specimen
         #  reference frame
-        return {"z": self.z, "y": self.y, "x": self.x}
+
+        # TODO: Remove after (any) one release after 0.10.1
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "Property ", np.VisibleDeprecationWarning)
+            return {"z": self.z, "y": self.y, "x": self.x}
 
     @property
     def _all_coordinates(self) -> dict:
@@ -559,7 +563,11 @@ class CrystalMap:
         """Return the step sizes of dimensions in the data."""
         # TODO: Make this "dynamic"/dependable when enabling specimen
         #  reference frame
-        return {"z": self.dz, "y": self.dy, "x": self.dx}
+
+        # TODO: Remove after (any) one release after 0.10.1
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "Property ", np.VisibleDeprecationWarning)
+            return {"z": self.dz, "y": self.dy, "x": self.dx}
 
     @property
     def _coordinate_axes(self) -> dict:
@@ -1187,7 +1195,7 @@ def create_coordinate_arrays(
 
     # TODO: Remove after (any) one release after 0.10.1
     if ndim == 3:
-        warn(
+        warnings.warn(
             "Returning coordinates for a 3D map is deprecated, and this function will "
             "only support 1D or 2D maps in 0.11.0. Support for 3D crystal maps is "
             "minimal and brittle, and it was therefore decided to remove it altogether."

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -18,10 +18,12 @@
 
 import copy
 from typing import Optional, Tuple, Union
+from warnings import warn
 
 import matplotlib.pyplot as plt
 import numpy as np
 
+from orix._util import deprecated, deprecated_argument
 from orix.crystal_map.crystal_map_properties import CrystalMapProperties
 from orix.crystal_map.phase_list import Phase, PhaseList
 from orix.quaternion import Orientation, Rotation
@@ -53,6 +55,15 @@ class CrystalMap:
     z
         Map z coordinate of each data point. If not given, the map is
         assumed to be 2D or 1D, and it is set to ``None``.
+
+        .. deprecated:: 0.10.1
+
+            Will be removed in 0.11.0. Support for 3D crystal maps is
+            minimal and brittle, and it was therefore decided to remove
+            it altogether. If you rely on this functionality, please
+            report it in an issue at
+            https://github.com/pyxem/orix/issues.
+
     phase_list
         A list of phases in the data with their with names, space
         groups, point groups, and structures. The order in which the
@@ -206,6 +217,7 @@ class CrystalMap:
     Scan unit: um
     """
 
+    @deprecated_argument(name="z", since="0.10.1", removal="0.11.0")
     def __init__(
         self,
         rotations: Rotation,
@@ -244,6 +256,17 @@ class CrystalMap:
         self._x = x
         self._y = y
         self._z = z
+
+        #        # TODO: Remove after (any) one release after 0.10.1
+        #        if z is not None:
+        #            warn(
+        #                "The CrystalMap.z attribute is deprecated and will be removed in "
+        #                "0.11.0. Support for 3D crystal maps is minimal and brittle, and it was"
+        #                " therefore decided to remove it altogether. If you rely on this "
+        #                "functionality, please report it in an issue at "
+        #                "https://github.com/pyxem/orix/issues",
+        #                np.VisibleDeprecationWarning
+        #            )
 
         # Create phase list
         # Sorted in ascending order
@@ -348,6 +371,7 @@ class CrystalMap:
             return self._y[self.is_in_data]
 
     @property
+    @deprecated(since="0.10.1", removal="0.11.0", object_type="property")
     def z(self) -> Union[None, np.ndarray]:
         """Return the z coordinates of points in data."""
         if self._z is None or len(np.unique(self._z)) == 1:
@@ -366,6 +390,7 @@ class CrystalMap:
         return self._step_size_from_coordinates(self._y)
 
     @property
+    @deprecated(since="0.10.1", removal="0.11.0", object_type="property")
     def dz(self) -> float:
         """Return the z coordiante step size."""
         return self._step_size_from_coordinates(self._z)
@@ -736,9 +761,28 @@ class CrystalMap:
         shape
             Map shape. Default is a 2D map of shape (5, 10), i.e. with
             five rows and ten columns.
+
+            .. deprecated:: 0.10.1
+
+            Returning coordinates for a 3D map is deprecated, and this
+            method will only support 1D or 2D maps in 0.11.0. Support
+            for 3D crystal maps is minimal and brittle, and it was
+            therefore decided to remove it altogether. If you rely on
+            this functionality, please report it in an issue at
+            https://github.com/pyxem/orix/issues.
+
         step_sizes
             Map step sizes. If not given, it is set to 1 px in each map
             direction given by ``shape``.
+
+            .. deprecated:: 0.10.1
+
+            Returning coordinates for a 3D map is deprecated, and this
+            method will only support 1D or 2D maps in 0.11.0. Support
+            for 3D crystal maps is minimal and brittle, and it was
+            therefore decided to remove it altogether. If you rely on
+            this functionality, please report it in an issue at
+            https://github.com/pyxem/orix/issues.
 
         Returns
         -------
@@ -819,9 +863,6 @@ class CrystalMap:
         >>> iq.shape
         (100, 117)
         """
-        # TODO: Consider an `axes` argument along which to get map data
-        #  if > 2D
-
         # Get full map shape
         map_shape = self._original_shape
 
@@ -1100,23 +1141,42 @@ def create_coordinate_arrays(
 ) -> Tuple[dict, int]:
     """Create flattened coordinate arrays from a given map shape and
     step sizes, suitable for initializing a
-    :class:`~orix.crystal_map.CrystalMap`. Arrays for 1D, 2D, or 3D maps
-    can be returned.
+    :class:`~orix.crystal_map.CrystalMap`. Arrays for 1D or 2D maps can
+    be returned.
 
     Parameters
     ----------
     shape
         Map shape. Default is a 2D map of shape (5, 10) with five rows
-        and ten columns. Can be up to 3D.
+        and ten columns.
+
+        .. deprecated:: 0.10.1
+
+            Returning coordinates for a 3D map is deprecated, and this
+            method will only support 1D or 2D maps in 0.11.0. Support
+            for 3D crystal maps is minimal and brittle, and it was
+            therefore decided to remove it altogether. If you rely on
+            this functionality, please report it in an issue at
+            https://github.com/pyxem/orix/issues.
+
     step_sizes
         Map step sizes. If not given, it is set to 1 px in each map
         direction given by ``shape``.
 
+        .. deprecated:: 0.10.1
+
+            Returning coordinates for a 3D map is deprecated, and this
+            method will only support 1D or 2D maps in 0.11.0. Support
+            for 3D crystal maps is minimal and brittle, and it was
+            therefore decided to remove it altogether. If you rely on
+            this functionality, please report it in an issue at
+            https://github.com/pyxem/orix/issues.
+
     Returns
     -------
     d
-        Dictionary with keys ``"z"``, ``"y"``, and ``"x"``, depending on
-        the length of ``shape``, with coordinate arrays.
+        Dictionary with keys ``"y"`` and ``"x"``, depending on the
+        length of ``shape``, with coordinate arrays.
     map_size
         Number of map points.
 
@@ -1135,6 +1195,17 @@ def create_coordinate_arrays(
     ndim = len(shape)
     if step_sizes is None:
         step_sizes = (1,) * ndim
+
+    # TODO: Remove after (any) one release after 0.10.1
+    if ndim == 3:
+        warn(
+            "Returning coordinates for a 3D map is deprecated, and this function will "
+            "only support 1D or 2D maps in 0.11.0. Support for 3D crystal maps is "
+            "minimal and brittle, and it was therefore decided to remove it altogether."
+            " If you rely on this functionality, please report it in an issue at "
+            "https://github.com/pyxem/orix/issues",
+            np.VisibleDeprecationWarning,
+        )
 
     # Set up as if a 3D map is to be returned
     dz, dy, dx = (1,) * (3 - ndim) + step_sizes

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -98,7 +98,7 @@ class Phase:
         self,
         name: Optional[str] = None,
         space_group: Union[int, SpaceGroup, None] = None,
-        point_group: Union[str, Symmetry, None] = None,
+        point_group: Union[int, str, Symmetry, None] = None,
         structure: Optional[Structure] = None,
         color: Optional[str] = None,
     ):

--- a/orix/io/__init__.py
+++ b/orix/io/__init__.py
@@ -30,7 +30,8 @@
 """
 
 import os
-from typing import Optional
+from pathlib import Path
+from typing import Optional, Union
 from warnings import warn
 
 from h5py import File, is_hdf5
@@ -91,7 +92,7 @@ def loadctf(file_string: str) -> Rotation:
     return Rotation.from_euler(euler)
 
 
-def load(filename: str, **kwargs) -> CrystalMap:
+def load(filename: Union[str, Path], **kwargs) -> CrystalMap:
     """Load data from a supported file format listed in
     :doc:`orix.io.plugins`.
 
@@ -168,7 +169,10 @@ def _plugin_from_manufacturer(filename: str, plugins: list):
 
 
 def save(
-    filename: str, object2write: CrystalMap, overwrite: Optional[bool] = None, **kwargs
+    filename: Union[str, Path],
+    object2write: CrystalMap,
+    overwrite: Optional[bool] = None,
+    **kwargs,
 ):
     """Write data to a supported file format listed in
     :doc:`orix.io.plugins`.

--- a/orix/io/plugins/orix_hdf5.py
+++ b/orix/io/plugins/orix_hdf5.py
@@ -22,6 +22,7 @@ format.
 
 import copy
 from typing import Optional
+import warnings
 from warnings import warn
 
 from diffpy.structure import Atom, Lattice, Structure
@@ -279,32 +280,34 @@ def crystalmap2dict(crystal_map: CrystalMap, dictionary: Optional[dict] = None) 
     ]
     # Get euler angles phi1, Phi, phi2
     eulers = crystal_map._rotations.to_euler()
-    dictionary.update(
-        {
-            "data": {
-                "z": z,
-                "y": y,
-                "x": x,
-                "phi1": eulers[..., 0],
-                "Phi": eulers[..., 1],
-                "phi2": eulers[..., 2],
-                "phase_id": crystal_map._phase_id,
-                "id": crystal_map._id,
-                "is_in_data": crystal_map.is_in_data,
-            },
-            "header": {
-                "grid_type": "square",
-                "nz": z.size if isinstance(z, np.ndarray) else 1,
-                "ny": y.size if isinstance(y, np.ndarray) else 1,
-                "nx": x.size if isinstance(x, np.ndarray) else 1,
-                "z_step": crystal_map.dz,
-                "y_step": crystal_map.dy,
-                "x_step": crystal_map.dx,
-                "rotations_per_point": crystal_map.rotations_per_point,
-                "scan_unit": crystal_map.scan_unit,
-            },
-        }
-    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "Property `dz`", np.VisibleDeprecationWarning)
+        dictionary.update(
+            {
+                "data": {
+                    "z": z,
+                    "y": y,
+                    "x": x,
+                    "phi1": eulers[..., 0],
+                    "Phi": eulers[..., 1],
+                    "phi2": eulers[..., 2],
+                    "phase_id": crystal_map._phase_id,
+                    "id": crystal_map._id,
+                    "is_in_data": crystal_map.is_in_data,
+                },
+                "header": {
+                    "grid_type": "square",
+                    "nz": z.size if isinstance(z, np.ndarray) else 1,
+                    "ny": y.size if isinstance(y, np.ndarray) else 1,
+                    "nx": x.size if isinstance(x, np.ndarray) else 1,
+                    "z_step": crystal_map.dz,
+                    "y_step": crystal_map.dy,
+                    "x_step": crystal_map.dx,
+                    "rotations_per_point": crystal_map.rotations_per_point,
+                    "scan_unit": crystal_map.scan_unit,
+                },
+            }
+        )
     dictionary["data"].update(crystal_map.prop)
     dictionary["header"].update({"phases": phaselist2dict(crystal_map.phases)})
 

--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -29,11 +29,11 @@ from matplotlib_scalebar.scalebar import ScaleBar
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 import numpy as np
 
+from orix._util import deprecated_argument
+
 
 class CrystalMapPlot(Axes):
-    """2D plotting of :class:`~orix.crystal_map.crystal_map.CrystalMap`
-    objects.
-    """
+    """Plotting of a :class:`~orix.crystal_map.crystal_map.CrystalMap`."""
 
     name = "plot_map"
     _data_axes = None
@@ -42,6 +42,7 @@ class CrystalMapPlot(Axes):
     colorbar = None
     scalebar = None
 
+    @deprecated_argument(name="depth", since="0.10.1", removal="0.11.0")
     def plot_map(
         self,
         crystal_map: "orix.crystal_map.CrystalMap",
@@ -89,6 +90,15 @@ class CrystalMapPlot(Axes):
             Which layer along the third axis to plot if data has more
             than two dimensions. If ``None`` (default), data in the
             first index (layer) is plotted.
+
+            .. deprecated:: 0.10.1
+
+                Will be removed in 0.11.0. Support for 3D crystal maps
+                is minimal and brittle, and it was therefore decided to
+                remove it altogether. If you rely on this functionality,
+                please report it in an issue at
+                https://github.com/pyxem/orix/issues.
+
         override_status_bar
             Whether to display Euler angles and any overlay values in
             the status bar when hovering over the map (default is
@@ -392,6 +402,7 @@ class CrystalMapPlot(Axes):
             right = 1
         self.figure.subplots_adjust(top=1, bottom=0, right=right, left=0)
 
+    # TODO: Remove depth argument after (any) one release after 0.10.0
     def _set_plot_shape(
         self,
         crystal_map: "orix.crystal_map.CrystalMap",

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -553,7 +553,7 @@ def temp_bruker_h5ebsd_file(tmpdir, request):
         rng = np.random.default_rng()
         # Only shuffle within rows (rows are not shuffled)
         map_cols = map_cols.reshape(map_shape)
-        rng.shuffle(map_cols, axis=0)
+        rng.shuffle(map_cols)
         map_cols = map_cols.ravel()
     sem_group.create_dataset("IY", data=map_rows)
     sem_group.create_dataset("IX", data=map_cols)

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -19,6 +19,7 @@
 import gc
 import os
 from tempfile import TemporaryDirectory
+import warnings
 
 from diffpy.structure import Atom, Lattice, Structure
 from h5py import File
@@ -638,7 +639,10 @@ def phase_list(request):
 def crystal_map_input(request, rotations):
     # Unpack parameters
     (nz, ny, nx), (dz, dy, dx), rotations_per_point, unique_phase_ids = request.param
-    d, map_size = create_coordinate_arrays((nz, ny, nx), (dz, dy, dx))
+    # TODO: Remove after (any) one release after 0.10.1
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "Returning coo", np.VisibleDeprecationWarning)
+        d, map_size = create_coordinate_arrays((nz, ny, nx), (dz, dy, dx))
     rot_idx = np.random.choice(
         np.arange(rotations.size), map_size * rotations_per_point
     )
@@ -655,7 +659,10 @@ def crystal_map_input(request, rotations):
 
 @pytest.fixture
 def crystal_map(crystal_map_input):
-    return CrystalMap(**crystal_map_input)
+    # TODO: Remove after (any) one release after 0.10.1
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "Argument `z` ", np.VisibleDeprecationWarning)
+        return CrystalMap(**crystal_map_input)
 
 
 @pytest.fixture

--- a/orix/tests/io/test_ang.py
+++ b/orix/tests/io/test_ang.py
@@ -34,6 +34,8 @@ from orix.tests.conftest import (
     ANGFILE_TSL_HEADER,
 )
 
+# TODO: Remove all pytest.mark.filterwarnings after (any) one release after 0.10.1
+
 
 @pytest.mark.parametrize(
     "angfile_astar, expected_data",
@@ -81,6 +83,7 @@ def test_loadang(angfile_astar, expected_data):
     assert np.allclose(loaded_data.data, expected_data)
 
 
+@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in")
 class TestAngReader:
     @pytest.mark.parametrize(
         "angfile_tsl, map_shape, step_sizes, phase_id, example_rot",
@@ -510,6 +513,7 @@ class TestAngReader:
         assert np.allclose(ids, expected_phase_id)
 
 
+@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in")
 class TestAngWriter:
     def test_write_read_loop(self, crystal_map, tmp_path):
         fname = tmp_path / "test_write_read_loop.ang"

--- a/orix/tests/io/test_io.py
+++ b/orix/tests/io/test_io.py
@@ -33,6 +33,8 @@ from orix.io import _overwrite_or_not, _plugin_from_manufacturer, load, loadctf,
 from orix.io.plugins import bruker_h5ebsd, emsoft_h5ebsd, orix_hdf5
 from orix.quaternion.rotation import Rotation
 
+# TODO: Remove all pytest.mark.filterwarnings after (any) one release after 0.10.1
+
 
 @contextmanager
 def replace_stdin(target):
@@ -67,6 +69,7 @@ def assert_dictionaries_are_equal(input_dict, output_dict):
                 assert input_value == output_value
 
 
+@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in")
 class TestGeneralIO:
     def test_load_no_filename_match(self):
         fname = "what_is_hip.ang"

--- a/orix/tests/io/test_orix_hdf5.py
+++ b/orix/tests/io/test_orix_hdf5.py
@@ -41,12 +41,16 @@ from orix.io.plugins.orix_hdf5 import (
 )
 from orix.tests.io.test_io import assert_dictionaries_are_equal
 
+# TODO: Remove all pytest.mark.filterwarnings after (any) one release after 0.10.1
 
+
+@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in")
+@pytest.mark.filterwarnings("ignore:Property `dz` is deprecated and will be removed in")
 class TestOrixHDF5Plugin:
     def test_file_writer(self, crystal_map, temp_file_path):
         save(filename=temp_file_path, object2write=crystal_map)
 
-        with File(temp_file_path, mode="r") as f:
+        with File(temp_file_path) as f:
             assert f["manufacturer"][()][0].decode() == "orix"
             assert f["version"][()][0].decode() == orix_version
 
@@ -258,7 +262,7 @@ class TestOrixHDF5Plugin:
     def test_write_read_2d(self, temp_file_path, crystal_map_input):
         crystal_map_input["z"] = None
         xmap = CrystalMap(**crystal_map_input)
-        assert xmap._coordinates["z"] == None
+        assert xmap._coordinates["z"] is None
         save(filename=temp_file_path, object2write=xmap)
         xmap2 = load(temp_file_path)
-        assert xmap2._coordinates["z"] == None
+        assert xmap2._coordinates["z"] is None

--- a/orix/tests/plot/test_crystal_map_plot.py
+++ b/orix/tests/plot/test_crystal_map_plot.py
@@ -31,6 +31,11 @@ from orix.plot import CrystalMapPlot
 PLOT_MAP = "plot_map"
 
 
+# TODO: Remove all pytest.mark.filterwarnings after (any) one release after 0.10.1
+
+
+@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in ")
+@pytest.mark.filterwarnings("ignore:Argument `depth` is deprecated and will be removed")
 class TestCrystalMapPlot:
     @pytest.mark.parametrize(
         "crystal_map_input, expected_data_shape",
@@ -171,6 +176,8 @@ class TestCrystalMapPlot:
         plt.close("all")
 
 
+@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in ")
+@pytest.mark.filterwarnings("ignore:Argument `depth` is deprecated and will be removed")
 class TestCrystalMapPlotUtilities:
     def test_init_projection(self):
         # Option 1
@@ -444,6 +451,7 @@ class TestStatusBar:
         plt.close("all")
 
 
+@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in ")
 class TestScalebar:
     @pytest.mark.parametrize(
         "crystal_map_input, scalebar_properties",

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -30,6 +30,11 @@ from orix.quaternion.symmetry import C2, C3, C4, O
 # testing IO and the Phase() and PhaseList() classes
 
 
+# TODO: Remove all pytest.mark.filterwarnings after (any) one release after 0.10.1
+
+
+@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed")
+@pytest.mark.filterwarnings("ignore:Returning coordinates for a 3D map is deprecated")
 class TestCrystalMap:
     def test_minimal_init(self, rotations):
         map_size = 2
@@ -306,6 +311,7 @@ class TestCrystalMap:
             xmap.phases = phase_list
 
 
+@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in ")
 class TestCrystalMapGetItem:
     @pytest.mark.parametrize(
         "crystal_map_input, slice_tuple, expected_shape",
@@ -507,6 +513,7 @@ class TestCrystalMapSetAttributes:
         assert xmap.phases_in_data.names == xmap.phases.names
 
 
+@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in ")
 class TestCrystalMapOrientations:
     def test_orientations(self, crystal_map_input, phase_list):
         x = crystal_map_input["x"]
@@ -614,6 +621,7 @@ class TestCrystalMapProp:
         assert np.allclose(xmap.prop[prop_name], np.ones(xmap.size) * new_prop_value)
 
 
+@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in ")
 class TestCrystalMapMasking:
     def test_getitem_with_masking(self, crystal_map_input):
         x = crystal_map_input["x"]
@@ -626,6 +634,8 @@ class TestCrystalMapMasking:
         assert np.allclose(xmap2.prop.is_in_data, xmap2.is_in_data)
 
 
+@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in")
+@pytest.mark.filterwarnings("ignore:Property `z` is deprecated and will be removed in")
 class TestCrystalMapGetMapData:
     @pytest.mark.parametrize(
         "crystal_map_input, to_get, expected_array",
@@ -643,7 +653,7 @@ class TestCrystalMapGetMapData:
             (
                 ((2, 4, 4), (0.28, 0.5, 1), 2, [0]),
                 "z",
-                np.stack((np.zeros((4, 4)), np.ones((4, 4)) * 0.28), axis=0),
+                np.stack((np.zeros((4, 4)), np.ones((4, 4)) * 0.28)),
             ),
         ],
         indirect=["crystal_map_input"],
@@ -875,6 +885,7 @@ class TestCrystalMapCopying:
         assert np.may_share_memory(xmap2._phase_id, crystal_map._phase_id) is False
 
 
+@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in ")
 class TestCrystalMapShape:
     @pytest.mark.parametrize(
         "crystal_map_input, expected_slices",


### PR DESCRIPTION
#### Description of the change
See #390.

~I have not filtered all the warnings raised by these changes in the tests, because I plan to remove the functionality in the `develop` branch after the changes for 0.10.1 are merged into `develop`, at which point the warnings will be removed as well.~ Ended up doing this so that more important warnings (relating to Matplotlib) are easier to catch.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)
- [x] Filter warnings raised from internal use
- [ ] Merge when #391 and #393 are approved

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.