### PR TITLE
Allow to pass c/color and s/sizes to StereographicPlot.scatter()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@ All notable changes to the ``orix`` project are documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_, and
 this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+2022-09-30 - version 0.10.1
+===========================
+
+Fixed
+-----
+- ``StereographicPlot.scatter()`` now accepts both ``c``/``color`` and ``s``/``sizes``
+  to set the color and sizes of scatter points, in line with
+  ``matplotlib.axes.Axes.scatter()``.
+
 2022-09-22 - version 0.10.0
 ===========================
 

--- a/orix/plot/stereographic_plot.py
+++ b/orix/plot/stereographic_plot.py
@@ -202,10 +202,20 @@ class StereographicPlot(maxes.Axes):
         if x.size == 0:
             return
 
-        # Color(s) and size(s)
-        c = updated_kwargs.pop("c", "C0")
+        # Color(s)
+        if "color" in updated_kwargs.keys():
+            key_color = "color"
+        else:
+            key_color = "c"
+        c = updated_kwargs.pop(key_color, "C0")
         c = _get_array_of_values(value=c, visible=visible)
-        s = updated_kwargs.pop("s", None)
+
+        # Size(s)
+        if "sizes" in updated_kwargs.keys():
+            key_size = "sizes"
+        else:
+            key_size = "s"
+        s = updated_kwargs.pop(key_size, None)
         if s is not None:
             s = _get_array_of_values(value=s, visible=visible)
 
@@ -333,8 +343,6 @@ class StereographicPlot(maxes.Axes):
             sigma=sigma,
             log=log,
             hemisphere=self.hemisphere,
-            symmetry=None,
-            mrd=True,
             weights=weights,
         )
 
@@ -758,7 +766,9 @@ class StereographicPlot(maxes.Axes):
         return x, y, visible, updated_kwargs
 
     def _pretransform_input(
-        self, values: Union[Vector3d, Tuple[np.ndarray, np.ndarray]], sort: bool = False
+        self,
+        values: Union[Vector3d, Tuple[Vector3d], Tuple[np.ndarray, np.ndarray]],
+        sort: bool = False,
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Return arrays of (x, y) from input data.
 

--- a/orix/tests/plot/test_stereographic_plot.py
+++ b/orix/tests/plot/test_stereographic_plot.py
@@ -245,6 +245,30 @@ class TestStereographicPlot:
 
         plt.close("all")
 
+    def test_color_parameter(self):
+        """Pass either ``color`` or ``c`` to color scatter points."""
+        v = Vector3d([[1, 0, 0], [1, 1, 0], [1, 1, 1]])
+
+        colors = [f"C{i}" for i in range(v.size)]
+        colors_rgba = np.array([mcolors.to_rgba(c) for c in colors])
+
+        fig = v.scatter(color=colors, return_figure=True)
+        assert np.allclose(fig.axes[0].collections[0].get_facecolors(), colors_rgba)
+
+        fig2 = v.scatter(c=colors, return_figure=True)
+        assert np.allclose(fig2.axes[0].collections[0].get_facecolors(), colors_rgba)
+
+    def test_size_parameter(self):
+        """Pass either ``sizes`` or ``s`` to set scatter points sizes."""
+        v = Vector3d([[1, 0, 0], [1, 1, 0], [1, 1, 1]])
+        sizes = np.arange(v.size)
+
+        fig = v.scatter(sizes=sizes, return_figure=True)
+        assert np.allclose(fig.axes[0].collections[0].get_sizes(), sizes)
+
+        fig2 = v.scatter(s=sizes, return_figure=True)
+        assert np.allclose(fig2.axes[0].collections[0].get_sizes(), sizes)
+
 
 class TestSymmetryMarker:
     def test_properties(self):


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
Fixes #380.

It is only in `StereographicPlot.scatter()` we hard-coded in passing `c` and `s` to `matplotlib.axes.Axes.scatter()`, so it is only there this is handled.

See #390.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)
- [ ] Merge when #391 and #392 are approved

#### Minimal example of the bug fix or new feature
The following raised errors before, but now works

```python
>>> from orix import vector
>>> v = vector.Vector3d([[1, 1, 1], [1, 0, 0]])
>>> v.scatter(color=["C0", "C1"])  # Equivalent to passing c=["C0", "C1"]
>>> v.scatter(sizes=[10, 20])  # Equivalent to passing s=[10, 20]
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.