### PR TITLE
Add `python_requires>=3.7` packaging metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -32,6 +32,11 @@
     },
     {
       "name": "Simon Høgås"
+    },
+    {
+      "name": "Alexander Clausen",
+      "orcid": "0000-0002-9555-7455",
+      "affiliation": "Jülich Research Centre, Ernst Ruska Centre"
     }
   ]
 }

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -13,4 +13,5 @@ __credits__ = [
     "Niels Cautaerts",
     "Austin Gerlt",
     "Simon Høgås",
+    "Alexander Clausen",
 ]

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Physics",
     ],
+    python_requires=">=3.7",
     packages=find_packages(exclude=["orix/tests"]),
     extras_require=extra_feature_requirements,
     # fmt: off


### PR DESCRIPTION
#### Description of the change

As a follow-up to #347, actually prevent installing on incompatible Python versions when using pip.

Note that currently, in a Python 3.6 environment, `pip install orix` will install an incompatible version (0.10.0) of orix. This is caused by the missing `python_requires` metadata - without it, the package is seen as compatible with any Python version.

Merging and releasing this won't magically fix things for 0.10.0 though - without [yanking that release](https://pypi.org/help/#yanked), installing `orix` in an old Python 3.6 environment will continue to pick 0.10.0 and fail at runtime. But adding this and updating once 3.7 support is dropped means the same issue won't come up again.

I'll leave the decision about yanking to the maintainers, of course.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [n/a] New functions are imported in corresponding `__init__.py`.
- [n/a] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [x] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.