### PR TITLE
Prepare main 0.10.1 release

### DIFF
--- a/.github/workflows/perhaps_make_a_tagged_release_draft.yml
+++ b/.github/workflows/perhaps_make_a_tagged_release_draft.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install outdated
+        pip install packaging outdated
 
     - name: Check whether a tagged release draft should be made
       run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,15 @@ this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.htm
 2022-09-30 - version 0.10.1
 ===========================
 
+Deprecated
+----------
+- Parameter ``z`` when creating a ``CrystalMap`` and the ``z`` and ``dz`` attributes of
+  the class are deprecated and will be removed in 0.11.0. Support for 3D crystal maps is
+  minimal and brittle, and it was therefore decided to remove it altogether.
+- Passing ``shape`` or ``step_sizes`` with three values to ``create_coordinate_arrays()``
+  is depreacted and will raise an error in 0.11.0. See the previous point for the reason.
+- Parameter ``depth`` in ``CrystalMapPlot.plot_map()`` is depreacted and will be removed
+  in 0.11.0. See the top point for the reason.
 
 Fixed
 -----
@@ -19,16 +28,6 @@ Fixed
 - Indexing/slicing into an already indexed/sliced ``CrystalMap`` now correctly returns
   the index/slice according to ``CrystalMap.shape`` and not the original shape of the
   un-sliced map.
-
-Deprecated
-----------
-- Parameter ``z`` when creating a ``CrystalMap`` and the ``z`` and ``dz`` attributes of
-  the class are deprecated and will be removed in 0.11.0. Support for 3D crystal maps is
-  minimal and brittle, and it was therefore decided to remove it altogether.
-- Passing ``shape`` or ``step_sizes`` of three values to ``create_coordinate_arrays()``
-  is depreacted and will be removed in 0.11.0. See the previous point for the reason.
-- Parameter ``depth`` in ``CrystalMapPlot.plot_map()`` is depreacted and will be removed
-  in 0.11.0. See the top point for the reason.
 
 2022-09-22 - version 0.10.0
 ===========================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ All notable changes to the ``orix`` project are documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_, and
 this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
-2022-09-30 - version 0.10.1
+2022-10-03 - version 0.10.1
 ===========================
 
 Deprecated

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -1,5 +1,5 @@
 __name__ = "orix"
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 __author__ = "orix developers"
 __author_email__ = "pyxem.team@gmail.com"
 __description__ = "orix is an open-source Python library for handling crystal orientation mapping data."


### PR DESCRIPTION
#### Description of the change
Bump version from 0.10.0 to 0.10.1 and touch up changelog. Merging this should create a release draft which I'll then publish.

I've given the docs a once over and find nothing to change for this release.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.