### PR TITLE
Change rounding from 12 to 10 decimals when finding unique vectors and rotations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,19 @@ All notable changes to the ``orix`` project are documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_, and
 this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+2022-18-03 - version 0.10.2
+===========================
+
+Fixed
+-----
+- ``Miller.symmetrise(unique=True)`` return the correct number of symmetrically
+  equivalent but unique vectors, by rounding to 10 instead of 12 decimals prior to
+  finding the unique vectors with NumPy.
+
+Changed
+-------
+- Unique rotations and vectors are now found by rounding to 10 instead of 12 decimals.
+
 2022-10-03 - version 0.10.1
 ===========================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ All notable changes to the ``orix`` project are documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_, and
 this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
-2022-18-03 - version 0.10.2
+2022-10-25 - version 0.10.2
 ===========================
 
 Fixed

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -1,5 +1,5 @@
 __name__ = "orix"
-__version__ = "0.10.1"
+__version__ = "0.10.2"
 __author__ = "orix developers"
 __author_email__ = "pyxem.team@gmail.com"
 __description__ = "orix is an open-source Python library for handling crystal orientation mapping data."

--- a/orix/base/__init__.py
+++ b/orix/base/__init__.py
@@ -192,7 +192,7 @@ class Object3d:
             The indices of the (flattened) data in the unique array if
             ``return_inverse=True``.
         """
-        data = self.flatten()._data.round(12)
+        data = self.flatten()._data.round(10)
         data = data[~np.all(np.isclose(data, 0), axis=1)]  # Remove zeros
         _, idx, inv = np.unique(data, axis=0, return_index=True, return_inverse=True)
         obj = self.__class__(data[np.sort(idx), : self.dim])
@@ -284,7 +284,7 @@ class Object3d:
                 + f"{tuple(axes)} does not fit with {self.shape}."
             )
 
-        return self.__class__(self.data.transpose(*axes, -1))
+        return self.__class__(self.data.transpose(*axes + (-1,)))
 
     def get_random_sample(
         self, size: Optional[int] = 1, replace: bool = False, shuffle: bool = False

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -193,7 +193,7 @@ class Rotation(Quaternion):
                     rotation.improper,
                 ],
                 axis=-1,
-            ).round(12)
+            ).round(10)
         _, idx, inv = np.unique(abcd, axis=0, return_index=True, return_inverse=True)
         idx_argsort = np.argsort(idx)
         idx_sort = idx[idx_argsort]
@@ -513,7 +513,10 @@ class Rotation(Quaternion):
     @classmethod
     @deprecated_argument("convention", "0.9", "1.0", "direction")
     def from_euler(
-        cls, euler: np.ndarray, direction: str = "lab2crystal", **kwargs
+        cls,
+        euler: Union[np.ndarray, list, tuple],
+        direction: str = "lab2crystal",
+        **kwargs,
     ) -> Rotation:
         """Create a rotation from an array of Euler angles in radians.
 
@@ -623,7 +626,7 @@ class Rotation(Quaternion):
         return om
 
     @classmethod
-    def from_matrix(cls, matrix: np.ndarray) -> Rotation:
+    def from_matrix(cls, matrix: Union[np.ndarray, list, tuple]) -> Rotation:
         """Return rotations from the orientation matrices
         :cite:`rowenhorst2015consistent`.
 

--- a/orix/tests/test_miller.py
+++ b/orix/tests/test_miller.py
@@ -32,6 +32,10 @@ TETRAGONAL_LATTICE = Lattice(0.5, 0.5, 1, 90, 90, 90)
 TETRAGONAL_PHASE = Phase(
     point_group="4", structure=Structure(lattice=TETRAGONAL_LATTICE)
 )
+HEXAGONAL_PHASE = Phase(
+    point_group="6/mmm",
+    structure=Structure(lattice=Lattice(3.073, 3.073, 10.053, 90, 90, 120)),
+)
 CUBIC_PHASE = Phase(point_group="m-3m")
 
 
@@ -205,6 +209,24 @@ class TestMiller:
             unique=True, return_multiplicity=True, return_index=True
         )
         assert np.allclose(mult2, [6, 12, 8])
+
+        # Test from https://github.com/pyxem/orix/issues/404
+        m3 = Miller(UVTW=[1, -1, 0, 0], phase=HEXAGONAL_PHASE)
+        assert np.allclose(m3.multiplicity, 6)
+        # fmt: off
+        assert np.allclose(
+            m3.symmetrise(unique=True).data,
+            [
+                [ 4.6095, -2.6613, 0],
+                [ 0     ,  5.3226, 0],
+                [-4.6095, -2.6613, 0],
+                [-4.6095,  2.6613, 0],
+                [ 0     , -5.3226, 0],
+                [ 4.6095,  2.6613, 0],
+            ],
+            atol=1e-4,
+        )
+        # fmt: on
 
     def test_unique(self):
         # From the "Crystal geometry" notebook

--- a/orix/vector/miller.py
+++ b/orix/vector/miller.py
@@ -773,7 +773,7 @@ class Miller(Vector3d):
             operations = self.phase.point_group
             n_v = v.size
             v2 = operations.outer(v).flatten().reshape(*(n_v, operations.size))
-            data = v2.data.round(12)
+            data = v2.data.round(10)
             data_sorted = np.zeros_like(data)
             for i in range(n_v):
                 a = data[i]

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -480,7 +480,7 @@ class Vector3d(Object3d):
         angles
             The angle between the vectors, in radians.
         """
-        cosines = np.round(self.dot(other) / self.norm / other.norm, 12)
+        cosines = np.round(self.dot(other) / self.norm / other.norm, 10)
         return np.arccos(cosines)
 
     def rotate(


### PR DESCRIPTION
#### Description of the change
Changing rounding from 12 to ~11~ 10 decimals before finding unique vectors and rotations fixes a case where too many plane normals were returned from `Miller.symmetrise(unique=True)`. This fixes #404 reported @Martin-Rudolph. To be consistent, I changed all rounding in orix where 12 decimals was used.

This PR is aimed at `main`, so that we can release this fix immediately as a v0.10.2 patch. I set the release date in the changelog to Tuesday, 2022-10-25.

I've also made minor changes to type hints and formatting to silence some warnings raised by my code editor.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
The issue reported by @Martin-Rudolph

```python
>>> from diffpy.structure import Lattice, Structure
>>> from orix.crystal_map import Phase
>>> from orix.vector import Miller
>>> lat_hex = Lattice(3.073, 3.073, 10.053, 90, 90, 120)
>>> phase = Phase(point_group="6/mmm", structure=Structure(lattice=lat_hex))
>>> h = Miller(UVTW=[1, -1, 0, 0], phase=phase)
>>> h.symmetrise(unique=True)  # Not all unique
Miller (10,), point group 6/mmm, UVTW
[[ 1. -1.  0.  0.]
 [ 0.  1. -1.  0.]
 [-1.  0.  1.  0.]
 [-1.  1. -0.  0.]
 [ 0. -1.  1.  0.]
 [ 1. -0. -1.  0.]
 [ 1.  0. -1.  0.]
 [-1.  1.  0.  0.]
 [-1. -0.  1.  0.]
 [ 1. -1. -0.  0.]]
```

With this fix, the last call returns

```python
>>> h.symmetrise(unique=True)  # All unique
Miller (6,), point group 6/mmm, UVTW
[[ 1. -1.  0.  0.]
 [ 0.  1. -1.  0.]
 [-1. -0.  1.  0.]
 [-1.  1. -0.  0.]
 [ 0. -1.  1.  0.]
 [ 1.  0. -1.  0.]]
```


#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.