### PR TITLE
Clean up test suite output

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Added
 
 Changed
 -------
+- Bumped minimal version of ``diffpy.structure >= 3.0.2``.
 
 Deprecated
 ----------

--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -139,6 +139,7 @@ class CrystalMapPlot(Axes):
 
         Plot an arbitrary map property, also changing scalebar location
 
+        >>> _ = plt.figure()
         >>> ax = plt.subplot(projection="plot_map")
         >>> _ = ax.plot_map(xmap, xmap.dp, scalebar_properties={"location": 4})
 
@@ -366,6 +367,9 @@ class CrystalMapPlot(Axes):
         # Add colorbar
         divider = make_axes_locatable(self)
         cax = divider.append_axes(**kwargs)
+        # Suppress warning raised in colorbar(). See
+        # https://github.com/matplotlib/matplotlib/issues/21723.
+        cax.set_axisbelow(True)
         cbar = self.figure.colorbar(self.images[0], cax=cax)
 
         # Set label with padding

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -389,7 +389,7 @@ class Quaternion(Object3d):
         >>> from orix.quaternion import Quaternion
         >>> q = Quaternion.from_matrix([np.eye(3), 2 * np.eye(3), np.diag([1, -1, -1])])
         >>> q
-        Quaternion (2,)
+        Quaternion (3,)
         [[1. 0. 0. 0.]
          [1. 0. 0. 0.]
          [0. 1. 0. 0.]]

--- a/orix/tests/plot/test_crystal_map_plot.py
+++ b/orix/tests/plot/test_crystal_map_plot.py
@@ -31,7 +31,8 @@ from orix.plot import CrystalMapPlot
 PLOT_MAP = "plot_map"
 
 
-# TODO: Remove all pytest.mark.filterwarnings after (any) one release after 0.10.1
+# TODO: Remove all pytest.mark.filterwarnings after (any) one release after 0.10.1,
+#  after the warnings themselves are removed
 
 
 @pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in ")
@@ -181,12 +182,13 @@ class TestCrystalMapPlot:
 class TestCrystalMapPlotUtilities:
     def test_init_projection(self):
         # Option 1
-        fig = plt.figure()
-        ax1 = fig.add_subplot(projection=PLOT_MAP)
+        _ = plt.figure()
+        ax1 = plt.subplot(projection=PLOT_MAP)
         assert isinstance(ax1, CrystalMapPlot)
 
-        # Option 2 (`label` to suppress warning of non-unique figure objects)
-        ax2 = plt.subplot(projection=PLOT_MAP, label="unique")
+        # Option 2 (recommended)
+        fig = plt.figure()
+        ax2 = fig.add_subplot(projection=PLOT_MAP)
         assert isinstance(ax2, CrystalMapPlot)
 
         plt.close("all")
@@ -416,12 +418,10 @@ class TestStatusBar:
         x, y = ax.transData.transform(data_idx)
 
         # Mock a mouse event
-        plt.matplotlib.backends.backend_agg.FigureCanvasBase.motion_notify_event(
-            f.canvas, x, y
-        )
         cursor_event = plt.matplotlib.backend_bases.MouseEvent(
             "motion_notify_event", f.canvas, x, y
         )
+        f.canvas.callbacks.process(cursor_event.name, cursor_event)
 
         # Call our custom cursor data function
         cursor_data = im.get_cursor_data(cursor_event)

--- a/orix/tests/plot/test_inverse_pole_figure_plot.py
+++ b/orix/tests/plot/test_inverse_pole_figure_plot.py
@@ -128,7 +128,8 @@ class TestInversePoleFigurePlot:
     def test_inverse_pole_density_function(self):
         fig, axes = _setup_inverse_pole_figure_plot(symmetry=symmetry.C6h)
         v = Vector3d(np.random.randn(10_000, 3)).unit
-        axes[0].pole_density_function(v, colorbar=True, log=True)
+        with np.errstate(divide="ignore"):
+            axes[0].pole_density_function(v, colorbar=True, log=True)
         assert len(fig.axes) == 2
         assert any(isinstance(c, QuadMesh) for c in fig.axes[0].collections)
         assert fig.axes[1].get_label() == "<colorbar>"

--- a/orix/tests/quaternion/test_orientation_region.py
+++ b/orix/tests/quaternion/test_orientation_region.py
@@ -149,7 +149,7 @@ def test_get_proper_point_groups(Gl, Gr):
     return None
 
 
-@pytest.mark.xfail(raises=NotImplementedError, strict=True)
 def test_get_proper_point_group_not_implemented():
     """Double inversion case not yet implemented"""
-    get_proper_groups(Csz, Csz)
+    with pytest.raises(NotImplementedError):
+        _ = get_proper_groups(Csz, Csz)

--- a/orix/tests/quaternion/test_quaternion.py
+++ b/orix/tests/quaternion/test_quaternion.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
+import warnings
 
 import dask.array as da
 from diffpy.structure.spacegroups import sg225
@@ -324,9 +325,10 @@ class TestToFromEuler:
         """Quaternion.from_euler() warns only when "convention" argument
         is passed.
         """
-        with pytest.warns(None) as record:
+        # No warning is raised
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             _ = Quaternion.from_euler(eu)
-        assert len(record) == 0
 
         msg = (
             r"Argument `convention` is deprecated and will be removed in version 1.0. "
@@ -342,21 +344,22 @@ class TestToFromEuler:
         """Passing convention="mtex" to Quaternion.from_euler() works but
         warns.
         """
-        quat1 = Quaternion.from_euler(eu, direction="crystal2lab")
+        q1 = Quaternion.from_euler(eu, direction="crystal2lab")
         with pytest.warns(np.VisibleDeprecationWarning, match=r"Argument `convention`"):
-            quat2 = Quaternion.from_euler(eu, convention="mtex")
-        assert np.allclose(quat1.data, quat2.data)
+            q2 = Quaternion.from_euler(eu, convention="mtex")
+        assert np.allclose(q1.data, q2.data)
 
     # TODO: Remove in 1.0
     def test_to_euler_convention_warns(self, eu):
         """Quaternion.to_euler() warns only when "convention" argument is
         passed.
         """
-        quat1 = Quaternion.from_euler(eu)
+        q1 = Quaternion.from_euler(eu)
 
-        with pytest.warns(None) as record:
-            quat2 = quat1.to_euler()
-        assert len(record) == 0
+        # No warning is raised
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            q2 = q1.to_euler()
 
         msg = (
             r"Argument `convention` is deprecated and will be removed in version 1.0. "
@@ -364,8 +367,8 @@ class TestToFromEuler:
             r"See the documentation of `to_euler\(\)` for more details."
         )
         with pytest.warns(np.VisibleDeprecationWarning, match=msg):
-            quat3 = quat1.to_euler(convention="whatever")
-        assert np.allclose(quat2, quat3)
+            q3 = q1.to_euler(convention="whatever")
+        assert np.allclose(q2, q3)
 
 
 class TestFromToMatrix:

--- a/orix/tests/quaternion/test_symmetry.py
+++ b/orix/tests/quaternion/test_symmetry.py
@@ -204,6 +204,10 @@ def test_symmetry(symmetry, vector, expected):
     assert set(vector_calculated) == set(expected)
 
 
+def test_symmetry_repr():
+    assert repr(Oh).split("\n")[0] == "Symmetry (48,) m-3m"
+
+
 def test_same_symmetry_unique(all_symmetries):
     # test unique symmetry elements between two identical symmetries
     # are the symmetry itself
@@ -278,7 +282,6 @@ def test_is_proper(symmetry, expected):
     ],
 )
 def test_subgroups(symmetry, expected):
-    print(len(symmetry.subgroups))
     assert set(symmetry.subgroups) == set(expected)
 
 

--- a/orix/tests/sampling/test_s2_sampling.py
+++ b/orix/tests/sampling/test_s2_sampling.py
@@ -194,6 +194,6 @@ class TestS2Sampling:
         grid_2 = S2_sampling.sample_S2_hexagonal_mesh(resolution)
         assert np.allclose(grid.data, grid_2.data)
 
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_sample_s2_nonexistent(self):
-        S2_sampling.sample_S2(10, "batman")
+        with pytest.raises(NotImplementedError):
+            _ = S2_sampling.sample_S2(10, "batman")

--- a/orix/tests/test_neoeuler.py
+++ b/orix/tests/test_neoeuler.py
@@ -59,7 +59,7 @@ def test_homochoric_from_rotation(rotation):
 @pytest.mark.parametrize(
     "rotation", [Rotation([1, 0, 0, 0]), Rotation([0.9239, 0.2209, 0.2209, 0.2209])]
 )
-@pytest.mark.xfail(strict=True, reason=AttributeError)
 def test_homochoric_angle(rotation):
     h = Homochoric.from_rotation(rotation)
-    _ = h.angle
+    with pytest.raises(AttributeError):
+        _ = h.angle

--- a/orix/tests/test_object3d.py
+++ b/orix/tests/test_object3d.py
@@ -92,24 +92,35 @@ def object3d(request, test_object3d):
         (2, (3, 2)),
         (2, (4, 3, 2)),
         (2, (5, 4, 3, 2)),
-        pytest.param(2, (3,), marks=pytest.mark.xfail(raises=DimensionError)),
-        pytest.param(2, (2, 1), marks=pytest.mark.xfail(raises=DimensionError)),
-        pytest.param(2, (3, 3), marks=pytest.mark.xfail(raises=DimensionError)),
-        pytest.param(2, (3, 3, 3), marks=pytest.mark.xfail(raises=DimensionError)),
         (3, (3,)),
         (3, (4, 3)),
         (3, (5, 4, 3)),
         (3, (2, 5, 4, 3)),
-        pytest.param(3, (2,), marks=pytest.mark.xfail(raises=DimensionError)),
-        pytest.param(3, (3, 1), marks=pytest.mark.xfail(raises=DimensionError)),
-        pytest.param(3, (2, 2), marks=pytest.mark.xfail(raises=DimensionError)),
-        pytest.param(3, (2, 2, 4), marks=pytest.mark.xfail(raises=DimensionError)),
     ],
     indirect=["test_object3d", "data"],
 )
 def test_init(test_object3d, data):
     obj = test_object3d(data)
     assert np.allclose(obj.data, data)
+
+
+@pytest.mark.parametrize(
+    "test_object3d, data",
+    [
+        (2, (3,)),
+        (2, (2, 1)),
+        (2, (3, 3)),
+        (2, (3, 3, 3)),
+        (3, (2,)),
+        (3, (3, 1)),
+        (3, (2, 2)),
+        (3, (2, 2, 4)),
+    ],
+    indirect=["test_object3d", "data"],
+)
+def test_init_fails(test_object3d, data):
+    with pytest.raises(DimensionError):
+        _ = test_object3d(data)
 
 
 @pytest.mark.parametrize(
@@ -121,28 +132,29 @@ def test_init(test_object3d, data):
         (2, (5, 5, 2), 3),
         (2, (5, 5, 2), slice(0, 3)),
         (2, (5, 5, 2), (None, slice(1, 5))),
-        pytest.param(
-            2,
-            (5, 2),
-            (slice(1), slice(1), slice(1)),
-            marks=pytest.mark.xfail(raises=IndexError),
-        ),
-        pytest.param(2, (5, 2), slice(7, 8)),
-        pytest.param(
-            3,
-            (4, 4, 3),
-            (6, 6),
-            marks=pytest.mark.xfail(raises=IndexError, strict=True),
-        ),
+        (2, (5, 2), slice(7, 8)),
     ],
     indirect=["test_object3d", "data"],
 )
 def test_slice(test_object3d, data, key):
     obj = test_object3d(data)
     obj_subset = obj[key]
-    print(key)
     assert isinstance(obj_subset, test_object3d)
     assert np.allclose(obj_subset.data, data[key])
+
+
+@pytest.mark.parametrize(
+    "test_object3d, data, key, error_type",
+    [
+        (2, (5, 2), (slice(1), slice(1), slice(1)), IndexError),
+        (3, (4, 4, 3), (6, 6), IndexError),
+    ],
+    indirect=["test_object3d", "data"],
+)
+def test_slice_raises(test_object3d, data, key, error_type):
+    obj = test_object3d(data)
+    with pytest.raises(error_type):
+        _ = obj[key]
 
 
 def test_shape(object3d):

--- a/orix/tests/test_phase_list.py
+++ b/orix/tests/test_phase_list.py
@@ -16,13 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
-
 from diffpy.structure import Lattice, Structure
-from diffpy.structure import __version__ as ver_diffpy
 from diffpy.structure.spacegroups import GetSpaceGroup
 import numpy as np
-from packaging.version import Version
 import pytest
 
 from orix.crystal_map import Phase, PhaseList
@@ -337,11 +333,6 @@ class TestPhase:
         assert np.allclose(br.data, [0, 0.679, 0], atol=1e-3)
         assert np.allclose(cr.data, [0, 0, 0.714], atol=1e-3)
 
-    @pytest.mark.xfail(
-        sys.platform == "win32" and sys.version_info >= (3, 10),
-        reason="CifFile import fails on Windows with Python 3.10",
-        strict=True,
-    )
     def test_from_cif(self, cif_file):
         """CIF files parsed correctly with space group and all."""
         phase = Phase.from_cif(cif_file)

--- a/orix/tests/test_vector3d.py
+++ b/orix/tests/test_vector3d.py
@@ -83,7 +83,6 @@ def test_neg(vector):
         ([1, 2, 3], 0.5, [1.5, 2.5, 3.5]),
         ([1, 2, 3], [-1, 2], [[0, 1, 2], [3, 4, 5]]),
         ([1, 2, 3], np.array([-1, 1]), [[0, 1, 2], [2, 3, 4]]),
-        pytest.param([1, 2, 3], "dracula", None, marks=pytest.mark.xfail),
     ],
     indirect=["vector"],
 )
@@ -95,6 +94,16 @@ def test_add(vector, other, expected):
 
 
 @pytest.mark.parametrize(
+    "vector, other",
+    [([1, 2, 3], "dracula")],
+    indirect=["vector"],
+)
+def test_add_raises(vector, other):
+    with pytest.raises(TypeError):
+        _ = vector + other
+
+
+@pytest.mark.parametrize(
     "vector, other, expected",
     [
         ([1, 2, 3], Vector3d([[1, 2, 3], [-3, -2, -1]]), [[0, 0, 0], [4, 4, 4]]),
@@ -102,7 +111,6 @@ def test_add(vector, other, expected):
         ([1, 2, 3], 0.5, [0.5, 1.5, 2.5]),
         ([1, 2, 3], [-1, 2], [[2, 3, 4], [-1, 0, 1]]),
         ([1, 2, 3], np.array([-1, 1]), [[2, 3, 4], [0, 1, 2]]),
-        pytest.param([1, 2, 3], "dracula", None, marks=pytest.mark.xfail),
     ],
     indirect=["vector"],
 )
@@ -114,19 +122,24 @@ def test_sub(vector, other, expected):
 
 
 @pytest.mark.parametrize(
+    "vector, other",
+    [
+        ([1, 2, 3], "dracula"),
+    ],
+    indirect=["vector"],
+)
+def test_sub_raises(vector, other):
+    with pytest.raises(TypeError):
+        _ = vector - other
+
+
+@pytest.mark.parametrize(
     "vector, other, expected",
     [
-        pytest.param(
-            [1, 2, 3],
-            Vector3d([[1, 2, 3], [-3, -2, -1]]),
-            [[0, 0, 0], [4, 4, 4]],
-            marks=pytest.mark.xfail(raises=ValueError),
-        ),
         ([1, 2, 3], [4], [4, 8, 12]),
         ([1, 2, 3], 0.5, [0.5, 1.0, 1.5]),
         ([1, 2, 3], [-1, 2], [[-1, -2, -3], [2, 4, 6]]),
         ([1, 2, 3], np.array([-1, 1]), [[-1, -2, -3], [1, 2, 3]]),
-        pytest.param([1, 2, 3], "dracula", None, marks=pytest.mark.xfail),
     ],
     indirect=["vector"],
 )
@@ -138,14 +151,21 @@ def test_mul(vector, other, expected):
 
 
 @pytest.mark.parametrize(
+    "vector, other, error_type",
+    [
+        ([1, 2, 3], Vector3d([[1, 2, 3], [-3, -2, -1]]), ValueError),
+        ([1, 2, 3], "dracula", TypeError),
+    ],
+    indirect=["vector"],
+)
+def test_mul_raises(vector, other, error_type):
+    with pytest.raises(error_type):
+        _ = vector * other
+
+
+@pytest.mark.parametrize(
     "vector, other, expected",
     [
-        pytest.param(
-            [1, 2, 3],
-            Vector3d([[1, 2, 3], [-3, -2, -1]]),
-            [[0, 0, 0], [4, 4, 4]],
-            marks=pytest.mark.xfail(raises=ValueError),
-        ),
         ([4, 8, 12], [4], [1, 2, 3]),
         ([0.5, 1.0, 1.5], 0.5, [1, 2, 3]),
         (
@@ -158,7 +178,6 @@ def test_mul(vector, other, expected):
             np.array([-1, 1]),
             [[-1, -2, -3], [1, 2, 3]],
         ),
-        pytest.param([1, 2, 3], "dracula", None, marks=pytest.mark.xfail),
     ],
     indirect=["vector"],
 )
@@ -167,11 +186,22 @@ def test_div(vector, other, expected):
     assert np.allclose(s1.data, expected)
 
 
-@pytest.mark.xfail
-def test_rdiv():
-    v = Vector3d([1, 2, 3])
-    other = 1
-    _ = other / v
+@pytest.mark.parametrize(
+    "vector, other, error_type",
+    [
+        ([1, 2, 3], Vector3d([[1, 2, 3], [-3, -2, -1]]), ValueError),
+        ([1, 2, 3], "dracula", TypeError),
+    ],
+    indirect=["vector"],
+)
+def test_div_raises(vector, other, error_type):
+    with pytest.raises(error_type):
+        _ = vector / other
+
+
+def test_rdiv_raises():
+    with pytest.raises(ValueError):
+        _ = 1 / Vector3d.xvector()
 
 
 def test_dot(vector, something):
@@ -427,22 +457,23 @@ def test_transpose_3d_shape(shape, expected_shape, axes):
     assert v2.shape == tuple(expected_shape)
 
 
-@pytest.mark.xfail(strict=True, reason=ValueError)
 def test_zero_perpendicular():
-    t = Vector3d(np.asarray([0, 0, 0]))
-    _ = t.perpendicular()
+    with pytest.raises(ValueError):
+        _ = Vector3d.zero((1,)).perpendicular
 
 
-@pytest.mark.xfail(strict=True, reason=TypeError)
 class TestSpareNotImplemented:
     def test_radd_notimplemented(self, vector):
-        "cantadd" + vector
+        with pytest.raises(TypeError):
+            _ = "cantadd" + vector
 
     def test_rsub_notimplemented(self, vector):
-        "cantsub" - vector
+        with pytest.raises(TypeError):
+            _ = "cantsub" - vector
 
     def test_rmul_notimplemented(self, vector):
-        "cantmul" * vector
+        with pytest.raises(TypeError):
+            _ = "cantmul" * vector
 
 
 class TestVector3dInversePoleDensityFunction:

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     # fmt: off
     install_requires=[
         "dask[array]",
-        "diffpy.structure       >= 3",
+        "diffpy.structure       >= 3.0.2",
         "h5py",
         "matplotlib             >= 3.3",
         "matplotlib-scalebar",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ extra_feature_requirements = {
         "numpydoc",
         "pytest                         >= 5.4",
         "pytest-cov                     >= 2.8.1",
-        "pytest-xdist",
     ],
 }
 extra_feature_requirements["dev"] = [


### PR DESCRIPTION
#### Description of the change
This PR cleans up the test suite output by:
- Fixing causes for some *Matplotlib* warnings
- Silencing a `numpy.log()` warning
- Replace use of `pytest.mark.xfail()` with a `pytest.raises(<error_type>):` context. The replacement fullfills the same purpose as the former without cluttering the *pytest* output

I've also bumped the minimum version of *diffpy.structure* to 3.0.2 in *setup.py*. This ensures that `Phase.from_cif()` works on Windows with Python 3.10. I've added a changelog entry for this change.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.