### PR TITLE
Examples demonstrating (Mis)Orientation.from_align_vectors()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,8 +12,8 @@ Unreleased
 
 Added
 -----
-- Creation of ``Quaternion`` (s) (or instances of inheriting classes) from SciPy
-  ``Rotation`` (s).
+- Creation of one or more ``Quaternion`` (or instances of inheriting classes) from one
+  or more SciPy ``Rotation``.
 - Creation of one ``Quaternion`` or ``Rotation`` by aligning sets of vectors in two
   reference frames, one ``Orientation`` by aligning sets of sample vectors and crystal
   vectors, and one ``Misorientation`` by aligning two sets of crystal vectors in two
@@ -46,7 +46,7 @@ Security
 
 Fixed
 -----
-- ``Miller.symmetrise(unique=True)`` return the correct number of symmetrically
+- ``Miller.symmetrise(unique=True)`` returns the correct number of symmetrically
   equivalent but unique vectors, by rounding to 10 instead of 12 decimals prior to
   finding the unique vectors with NumPy.
 

--- a/examples/misorientations/README.txt
+++ b/examples/misorientations/README.txt
@@ -1,0 +1,2 @@
+Misorientations
+===============

--- a/examples/misorientations/misorientation_from_aligning_directions.py
+++ b/examples/misorientations/misorientation_from_aligning_directions.py
@@ -1,0 +1,73 @@
+"""
+=======================================
+Misorientation from aligning directions
+=======================================
+
+This example demonstrates how to use
+:meth:`~orix.quaternion.Misorientation.from_align_vectors` to estimate a misorientation
+from two sets of aligned crystal directions, one set in each crystal reference frame.
+"""
+
+from diffpy.structure import Lattice, Structure
+import numpy as np
+
+from orix.crystal_map import Phase
+from orix.quaternion import Misorientation, Orientation
+from orix.vector import Miller
+
+# Specify two crystal structures and symmetries
+phase1 = Phase(
+    point_group="m-3m", structure=Structure(lattice=Lattice(1, 1, 1, 90, 90, 90))
+)
+phase2 = Phase(
+    point_group="6/mmm", structure=Structure(lattice=Lattice(1, 1, 2, 90, 90, 120))
+)
+
+# Specify one orientation per crystal
+ori_ref1 = Orientation.from_axes_angles(
+    [1, 1, 1], np.pi / 3, symmetry=phase1.point_group
+)
+ori_ref2 = Orientation.from_axes_angles(
+    [1, 3, 2], np.pi / 2, symmetry=phase2.point_group
+)
+
+# Get the reference misorientation (goal). Transformations are composed
+# from the right, so: crystal 1 -> sample -> crystal 2
+mori_ref = Misorientation(
+    ori_ref2 * (~ori_ref1), symmetry=(ori_ref1.symmetry, ori_ref2.symmetry)
+)
+
+# Specify two directions in the first crystal
+vec_c1 = Miller(uvw=[[1, 1, 1], [0, 0, 1]], phase=phase1)
+
+# Express the same directions with respect to the second crystal
+vec_c2 = Miller(xyz=(mori_ref * vec_c1).data, phase=phase2)
+
+# Add some randomness to the second crystal directions (0 error
+# magnitude gives exact result)
+error_magnitude = 0.1
+vec_err = Miller(xyz=np.random.normal(0, error_magnitude, 3), phase=phase2)
+vec_c2_err = Miller(xyz=(vec_c2 + vec_err).data, phase=phase2)
+angle_err = np.rad2deg(vec_c2_err.angle_with(vec_c2)).mean()
+print("Vector angular deviation [deg]: ", angle_err)
+
+# Get the misorientation that aligns the directions in the first crystal
+# with those in the second crystal
+mori_new, err = Misorientation.from_align_vectors(vec_c2_err, vec_c1, return_rmsd=True)
+print("Error distance: ", err)
+
+# Plot the two directions in the (unrotated) first crystal's reference
+# frame as open circles
+fig = vec_c1.scatter(
+    ec=["r", "b"],
+    s=100,
+    fc="none",
+    grid=True,
+    axes_labels=["e1", "e2"],
+    return_figure=True,
+)
+fig.tight_layout()
+
+# Plot the two directions in the second crystal with respect to the
+# first crystal's axes
+(~mori_ref * vec_c2_err).scatter(c=["r", "b"], figure=fig)

--- a/examples/orientations/README.txt
+++ b/examples/orientations/README.txt
@@ -1,0 +1,2 @@
+Orientations
+============

--- a/examples/orientations/orientation_from_aligning_directions.py
+++ b/examples/orientations/orientation_from_aligning_directions.py
@@ -1,0 +1,61 @@
+"""
+====================================
+Orientation from aligning directions
+====================================
+
+This example demonstrates how to use
+:meth:`~orix.quaternion.Orientation.from_align_vectors` to estimate an orientation from
+two sets of aligned vectors, one set in the sample reference reference frame, the other
+in the crystal reference frame.
+"""
+
+from diffpy.structure import Lattice, Structure
+import numpy as np
+
+from orix.crystal_map import Phase
+from orix.quaternion import Orientation
+from orix.vector import Miller, Vector3d
+
+# Specify a crystal structure and symmetry
+phase = Phase(
+    point_group="6/mmm", structure=Structure(lattice=Lattice(1, 1, 2, 90, 90, 120))
+)
+
+# Define a reference orientation (goal)
+ori_ref = Orientation.from_axes_angles([1, 1, 1], np.pi / 4, phase.point_group)
+
+# Specify two crystal directions (any will do)
+vec_c = Miller(uvw=[[2, 1, 1], [1, 3, 1]], phase=phase)
+
+# Find out where these directions in the reference orientation (crystal)
+# point in the sample reference frame
+vec_r = Vector3d(~ori_ref * vec_c)
+
+# Plot the reference orientation sample directions as empty circles
+fig = vec_r.scatter(
+    ec=["r", "b"],
+    s=100,
+    fc="none",
+    grid=True,
+    axes_labels=["X", "Y"],
+    return_figure=True,
+)
+fig.tight_layout()
+
+# Add some randomness to the sample directions (0 error magnitude gives
+# exact result)
+err_magnitude = 0.1
+vec_err = Vector3d(np.random.normal(0, err_magnitude, 3))
+vec_r_err = vec_r + vec_err
+angle_err = np.rad2deg(vec_r_err.angle_with(vec_r)).mean()
+print("Vector angle deviation [deg]: ", angle_err)
+
+# Obtain the orientation which aligns the crystal directions with the
+# sample directions
+ori_new_r2c, err = Orientation.from_align_vectors(vec_c, vec_r_err, return_rmsd=True)
+ori_new_c2r = ~ori_new_r2c
+print("Error distance: ", err)
+
+# Plot the crystal directions in the new orientation
+vec_r2 = Vector3d(~ori_new_r2c * vec_c)
+vec_r2.scatter(c=["r", "b"], figure=fig)

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -646,9 +646,11 @@ class Orientation(Misorientation):
         Parameters
         ----------
         other
-            Directions of shape ``(n,)`` in the other crystal.
+            Crystal directions of shape ``(n,)`` in the crystal
+            reference frame.
         initial
-            Directions of shape ``(n,)`` in the initial crystal.
+            Sample directions of shape ``(n,)`` in the sample reference
+            frame.
         weights
             Relative importance of the different vectors.
         return_rmsd

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -854,7 +854,8 @@ class Quaternion(Object3d):
 
     @classmethod
     def from_scipy_rotation(cls, rotation: SciPyRotation) -> Quaternion:
-        """Return quaternion(s) from :class:`scipy.spatial.transform.Rotation`.
+        """Return quaternion(s) from
+        :class:`scipy.spatial.transform.Rotation`.
 
         Parameters
         ----------
@@ -868,25 +869,46 @@ class Quaternion(Object3d):
 
         Notes
         -----
-        The Scipy rotation is inverted to be consistent with the Orix framework of
-        passive rotations.
+        The SciPy rotation is inverted to be consistent with the orix
+        framework of passive rotations.
+
+        While orix represents quaternions with the scalar as the first
+        parameter, SciPy has the scalar as the last parameter.
 
         Examples
         --------
-        >>> from orix.quaternion import Quaternion, Rotation
+        >>> from orix.quaternion import Quaternion
+        >>> from orix.vector import Vector3d
         >>> from scipy.spatial.transform import Rotation as SciPyRotation
-        >>> euler = np.array([90, 0, 0]) * np.pi / 180
-        >>> scipy_rot = SciPyRotation.from_euler("ZXZ", euler)
-        >>> ori = Quaternion.from_scipy_rotation(scipy_rot)
-        >>> ori
+
+        SciPy and orix represent quaternions differently
+
+        >>> eu = np.deg2rad([90, 0, 0])
+        >>> r_scipy = SciPyRotation.from_euler("ZXZ", eu)
+        >>> r_scipy.as_quat()
+        array([0.        , 0.        , 0.70710678, 0.70710678])
+        >>> q1 = Quaternion.from_scipy_rotation(r_scipy)
+        >>> q1
         Quaternion (1,)
         [[ 0.7071  0.      0.     -0.7071]]
-        >>> Rotation.from_euler(euler, direction="crystal2lab")
-        Rotation (1,)
-        [[0.7071 0.     0.     0.7071]]
+        >>> ~q1
+        Quaternion (1,)
+        [[ 0.7071 -0.     -0.      0.7071]]
+
+        SciPy and orix rotate vectors differently since the SciPy
+        rotation is inverted when creating an orix quaternion
+
+        >>> v = [1, 1, 0]
+        >>> r_scipy.apply(v)
+        array([-1.,  1.,  0.])
+        >>> q1 * Vector3d(v)
+        Vector3d (1,)
+        [[ 1. -1.  0.]]
+        >>> ~q1 * Vector3d(v)
+        Vector3d (1,)
+        [[-1.  1.  0.]]
         """
         matrix = rotation.inv().as_matrix()
-
         return cls.from_matrix(matrix=matrix)
 
     @classmethod

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Optional, Tuple, Union
 import warnings
 
 import dask.array as da
@@ -418,6 +418,147 @@ class Quaternion(Object3d):
         q = cls(q).unit
 
         return q
+
+    @classmethod
+    def from_scipy_rotation(cls, rotation: SciPyRotation) -> Quaternion:
+        """Return quaternion(s) from
+        :class:`scipy.spatial.transform.Rotation`.
+
+        Parameters
+        ----------
+        rotation
+            SciPy rotation(s).
+
+        Returns
+        -------
+        quaternion
+            Quaternion(s).
+
+        Notes
+        -----
+        The SciPy rotation is inverted to be consistent with the orix
+        framework of passive rotations.
+
+        While orix represents quaternions with the scalar as the first
+        parameter, SciPy has the scalar as the last parameter.
+
+        Examples
+        --------
+        >>> from orix.quaternion import Quaternion
+        >>> from orix.vector import Vector3d
+        >>> from scipy.spatial.transform import Rotation as SciPyRotation
+
+        SciPy and orix represent quaternions differently
+
+        >>> r_scipy = SciPyRotation.from_euler("ZXZ", [90, 0, 0], degrees=True)
+        >>> r_scipy.as_quat()
+        array([0.        , 0.        , 0.70710678, 0.70710678])
+        >>> q = Quaternion.from_scipy_rotation(r_scipy)
+        >>> q
+        Quaternion (1,)
+        [[ 0.7071  0.      0.     -0.7071]]
+        >>> ~q
+        Quaternion (1,)
+        [[ 0.7071 -0.     -0.      0.7071]]
+
+        SciPy and orix rotate vectors differently
+
+        >>> v = [1, 1, 0]
+        >>> r_scipy.apply(v)
+        array([-1.,  1.,  0.])
+        >>> q * Vector3d(v)
+        Vector3d (1,)
+        [[ 1. -1.  0.]]
+        >>> ~q * Vector3d(v)
+        Vector3d (1,)
+        [[-1.  1.  0.]]
+        """
+        matrix = rotation.inv().as_matrix()
+        return cls.from_matrix(matrix=matrix)
+
+    @classmethod
+    def from_align_vectors(
+        cls,
+        other: Union[Vector3d, tuple, list],
+        initial: Union[Vector3d, tuple, list],
+        weights: Optional[np.ndarray] = None,
+        return_rmsd: bool = False,
+        return_sensitivity: bool = False,
+    ) -> Union[
+        Quaternion,
+        Tuple[Quaternion, float],
+        Tuple[Quaternion, np.ndarray],
+        Tuple[Quaternion, float, np.ndarray],
+    ]:
+        """Return an estimated quaternion to optimally align two sets of
+        vectors.
+
+        This method wraps
+        :meth:`~scipy.spatial.transform.Rotation.align_vectors`. See
+        that method for further explanations of parameters and returns.
+
+        Parameters
+        ----------
+        other
+            Vectors of shape ``(n,)`` in the other reference frame.
+        initial
+            Vectors of shape ``(n,)`` in the initial reference frame.
+        weights
+            Relative importance of the different vectors.
+        return_rmsd
+            Whether to return the (weighted) root mean square distance
+            between ``other`` and ``initial`` after alignment. Default
+            is ``False``.
+        return_sensitivity
+            Whether to return the sensitivity matrix. Default is
+            ``False``.
+
+        Returns
+        -------
+        estimated_quaternion
+            Best estimate of the quaternion that transforms ``initial``
+            to ``other``.
+        rmsd
+            Returned when ``return_rmsd=True``.
+        sensitivity
+            Returned when ``return_sensitivity=True``.
+
+        Examples
+        --------
+        >>> from orix.quaternion import Quaternion
+        >>> from orix.vector import Vector3d
+        >>> v1 = Vector3d([[1, 0, 0], [0, 1, 0]])
+        >>> v2 = Vector3d([[0, -1, 0], [0, 0, 1]])
+        >>> q12 = Quaternion.from_align_vectors(v2, v1)
+        >>> q12 * v1
+        Vector3d (2,)
+        [[ 0. -1.  0.]
+         [ 0.  0.  1.]]
+        >>> q21, dist = Quaternion.from_align_vectors(v1, v2, return_rmsd=True)
+        >>> dist
+        0.0
+        >>> q21 * v2
+        Vector3d (2,)
+        [[1. 0. 0.]
+         [0. 1. 0.]]
+        """
+        if not isinstance(other, Vector3d):
+            other = Vector3d(other)
+        if not isinstance(initial, Vector3d):
+            initial = Vector3d(initial)
+        vec1 = initial.unit.data
+        vec2 = other.unit.data
+
+        out = SciPyRotation.align_vectors(
+            vec1, vec2, weights=weights, return_sensitivity=return_sensitivity
+        )
+        out = list(out)
+        out[0] = cls.from_scipy_rotation(out[0])
+
+        if not return_rmsd:
+            del out[1]
+
+        return out[0] if len(out) == 1 else tuple(out)
 
     @classmethod
     def random(cls, shape: Union[int, tuple] = (1,)) -> Quaternion:
@@ -851,132 +992,3 @@ class Quaternion(Object3d):
         new_chunks = tuple(chunks1[:-1]) + tuple(chunks2[:-1]) + (-1,)
 
         return out.rechunk(new_chunks)
-
-    @classmethod
-    def from_scipy_rotation(cls, rotation: SciPyRotation) -> Quaternion:
-        """Return quaternion(s) from
-        :class:`scipy.spatial.transform.Rotation`.
-
-        Parameters
-        ----------
-        rotation
-            SciPy rotation(s).
-
-        Returns
-        -------
-        quaternion
-            Quaternion(s).
-
-        Notes
-        -----
-        The SciPy rotation is inverted to be consistent with the orix
-        framework of passive rotations.
-
-        While orix represents quaternions with the scalar as the first
-        parameter, SciPy has the scalar as the last parameter.
-
-        Examples
-        --------
-        >>> from orix.quaternion import Quaternion
-        >>> from orix.vector import Vector3d
-        >>> from scipy.spatial.transform import Rotation as SciPyRotation
-
-        SciPy and orix represent quaternions differently
-
-        >>> eu = np.deg2rad([90, 0, 0])
-        >>> r_scipy = SciPyRotation.from_euler("ZXZ", eu)
-        >>> r_scipy.as_quat()
-        array([0.        , 0.        , 0.70710678, 0.70710678])
-        >>> q1 = Quaternion.from_scipy_rotation(r_scipy)
-        >>> q1
-        Quaternion (1,)
-        [[ 0.7071  0.      0.     -0.7071]]
-        >>> ~q1
-        Quaternion (1,)
-        [[ 0.7071 -0.     -0.      0.7071]]
-
-        SciPy and orix rotate vectors differently since the SciPy
-        rotation is inverted when creating an orix quaternion
-
-        >>> v = [1, 1, 0]
-        >>> r_scipy.apply(v)
-        array([-1.,  1.,  0.])
-        >>> q1 * Vector3d(v)
-        Vector3d (1,)
-        [[ 1. -1.  0.]]
-        >>> ~q1 * Vector3d(v)
-        Vector3d (1,)
-        [[-1.  1.  0.]]
-        """
-        matrix = rotation.inv().as_matrix()
-        return cls.from_matrix(matrix=matrix)
-
-    @classmethod
-    def from_align_vectors(
-        cls,
-        other: Union[Vector3d, tuple, list],
-        initial: Union[Vector3d, tuple, list],
-        weights: Optional[np.ndarray] = None,
-        return_rmsd: bool = False,
-        return_sensitivity: bool = False,
-    ) -> Quaternion:
-        """Return an estimated quaternion to optimally align two sets of
-        vectors.
-
-        This method wraps :meth:`scipy.spatial.transform.Rotation.align_vectors`,
-        see that method for further explanations of parameters and
-        returns.
-
-        Parameters
-        ----------
-        other
-            Vectors of shape ``(N,)`` in the other reference frame.
-        initial
-            Vectors of shape ``(N,)`` in the initial reference frame.
-        weights
-            The relative importance of the different vectors.
-        return_rmsd
-            Whether to return the root mean square distance (weighted)
-            between ``other`` and ``initial`` after alignment.
-        return_sensitivity
-            Whether to return the sensitivity matrix.
-
-        Returns
-        -------
-        estimated quaternion
-            Best estimate of the quaternion
-            that transforms ``initial`` to ``other``.
-        rmsd
-            Returned when ``return_rmsd=True``.
-        sensitivity
-            Returned when ``return_sensitivity=True``.
-
-        Examples
-        --------
-        >>> from orix.quaternion import Quaternion
-        >>> from orix.vector import Vector3d
-        >>> vecs1 = Vector3d([[1, 0, 0], [0, 1, 0]])
-        >>> vecs2 = Vector3d([[0, -1, 0], [0,0, 1]])
-        >>> quat12 = Quaternion.from_align_vectors(vecs2, vecs1)
-        >>> quat12 * vecs1
-        Vector3d (2,)
-        [[ 0. -1.  0.]
-         [ 0.  0.  1.]]
-        """
-        if not isinstance(other, Vector3d):
-            other = Vector3d(other)
-        if not isinstance(initial, Vector3d):
-            initial = Vector3d(initial)
-        vec1 = initial.unit.data
-        vec2 = other.unit.data
-
-        out = SciPyRotation.align_vectors(
-            vec1, vec2, weights=weights, return_sensitivity=return_sensitivity
-        )
-        out = list(out)
-        out[0] = cls.from_scipy_rotation(out[0])
-
-        if not return_rmsd:
-            del out[1]
-
-        return out[0] if len(out) == 1 else out

--- a/orix/tests/quaternion/test_quaternion.py
+++ b/orix/tests/quaternion/test_quaternion.py
@@ -281,26 +281,33 @@ class TestQuaternion:
             q._outer_dask(other)
 
     def test_from_align_vectors(self):
-        a = Vector3d([[2, -1, 0], [0, 0, 1]])
-        b = Vector3d([[3, 1, 0], [-1, 3, 0]])
-        ori = Quaternion.from_align_vectors(a, b)
-        assert type(ori) == Quaternion
+        v1 = Vector3d([[2, -1, 0], [0, 0, 1]])
+        v2 = Vector3d([[3, 1, 0], [-1, 3, 0]])
+
+        q1 = Quaternion.from_align_vectors(v1, v2)
+        assert isinstance(q1, Quaternion)
         assert np.allclose(
-            ori.data, np.array([[0.65328148, 0.70532785, -0.05012611, -0.27059805]])
+            q1.data, np.array([[0.65328148, 0.70532785, -0.05012611, -0.27059805]])
         )
-        assert np.allclose(a.unit.data, (ori * b.unit).data)
-        _, e = Quaternion.from_align_vectors(a, b, return_rmsd=True)
-        assert e == 0
-        _, m = Quaternion.from_align_vectors(a, b, return_sensitivity=True)
-        assert np.allclose(m, np.array([[1, 0, 0], [0, 1, 0], [0, 0, 0.5]]))
+        assert np.allclose(v1.unit.data, (q1 * v2.unit).data)
+
+        out = Quaternion.from_align_vectors(v1, v2, return_rmsd=True)
+        assert isinstance(out, tuple)
+        error = out[1]
+        assert error == 0
+
+        _, sens_mat = Quaternion.from_align_vectors(v1, v2, return_sensitivity=True)
+        assert np.allclose(sens_mat, np.array([[1, 0, 0], [0, 1, 0], [0, 0, 0.5]]))
+
         out = Quaternion.from_align_vectors(
-            a, b, return_rmsd=True, return_sensitivity=True
+            v1, v2, return_rmsd=True, return_sensitivity=True
         )
         assert len(out) == 3
-        ori1 = Quaternion.from_align_vectors(
+
+        q2 = Quaternion.from_align_vectors(
             [[2, -1, 0], [0, 0, 1]], [[3, 1, 0], [-1, 3, 0]]
         )
-        assert np.allclose(ori1.data, ori.data)
+        assert np.allclose(q2.data, q1.data)
 
 
 class TestToFromEuler:

--- a/orix/tests/quaternion/test_rotation.py
+++ b/orix/tests/quaternion/test_rotation.py
@@ -551,7 +551,6 @@ class TestFromAxesAngles:
         r2 = Rotation.from_axes_angles(axangle.axis.data, axangle.angle)
         assert isinstance(r1, Rotation)
         assert isinstance(r2, Rotation)
-        #        assert np.allclose(r1.data, r2.data)
         assert r1 == r2
 
 
@@ -559,8 +558,18 @@ class TestFromScipyRotation:
     """These test address the Rotation.from_scipy_rotation()."""
 
     def test_from_scipy_rotation(self):
-        euler = np.array([15, 32, 41]) * np.pi / 180
+        euler = np.deg2rad([15, 32, 41])
         reference_rot = Rotation.from_euler(euler)
-        scipy_rot = SciPyRotation.from_euler("ZXZ", euler)  # bunge convention
+        scipy_rot = SciPyRotation.from_euler("ZXZ", euler)  # Bunge convention
         quat = Rotation.from_scipy_rotation(scipy_rot)
         assert np.allclose(reference_rot.angle_with(quat), 0)
+
+
+class TestFromAlignVectors:
+    def test_from_align_vectors(self):
+        v1 = Vector3d([[2, -1, 0], [0, 0, 1]])
+        v2 = Vector3d([[3, 1, 0], [-1, 3, 0]])
+        r12 = Rotation.from_align_vectors(v2, v1)
+        assert isinstance(r12, Rotation)
+        assert np.allclose((r12 * v1).unit.data, v2.unit.data)
+        assert np.allclose((~r12 * v2).unit.data, v1.unit.data)


### PR DESCRIPTION
#### Description of the change
Added two examples to the examples gallery (from PR comments https://github.com/pyxem/orix/pull/401#pullrequestreview-1138061052 and https://github.com/pyxem/orix/pull/401#pullrequestreview-1139428658):
* Get an orientation from two sets of vectors, one in the sample reference frame and the other in the crystal reference frame. Uses `Orientation.from_align_vectors()`.
* Get a misorientation from two sets of vectors, one in each of the two crystal reference frames. Uses `Misorientation.from_align_vectors()`.

I've also added the possibility to pass `symmetry` to `Orientation.from_scipy_rotation()` and `Misorientation.from_scipy_rotation()`. `Rotation.from_scipy_rotation()` is also updated, so that all these three methods have custom docstrings. I've also made sure these methods return a tuple instead of a list if either of `return_rmsd` or `return_sensitivity` are `True`.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.