### PR TITLE
Change release tag names from e.g. v0.11.0 to orix-0.11.0

### DIFF
--- a/.github/workflows/perhaps_make_a_tagged_release_draft.yml
+++ b/.github/workflows/perhaps_make_a_tagged_release_draft.yml
@@ -48,7 +48,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         draft: true
-        tag_name: v${{ env.BRANCH_VERSION }}
+        tag_name: orix-${{ env.BRANCH_VERSION }}
         release_name: orix ${{ env.BRANCH_VERSION }}
         commitish: main
         body_path: release_part_in_changelog.md

--- a/.github/workflows/perhaps_make_tagged_release_draft.py
+++ b/.github/workflows/perhaps_make_tagged_release_draft.py
@@ -73,7 +73,7 @@ if make_release:
     with open("release_part_in_changelog.rst", mode="w") as f:
         f.write(
             f"orix {branch_version_str} is a {release_type} release of orix, an open-source Python library for handling orientations, rotations and crystal symmetry.\n\n"
-            f"See below, the `changelog <https://orix.readthedocs.io/en/stable/changelog.html>`_ or the `GitHub changelog <https://github.com/pyxem/orix/compare/v{pypi_version_str}...v{branch_version_str}>`_ for all updates from the previous release.\n\n"
+            f"See below, the `changelog <https://orix.readthedocs.io/en/stable/changelog.html>`_ or the `GitHub changelog <https://github.com/pyxem/orix/compare/orix-{pypi_version_str}...orix-{branch_version_str}>`_ for all updates from the previous release.\n\n"
         )
         for line in content[changelog_start:changelog_end]:
             f.write(line)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,9 @@ Added
 Changed
 -------
 - Bumped minimal version of ``diffpy.structure >= 3.0.2``.
+- Release tags on GitHub are now named e.g. ``orix-0.10.3`` instead of ``v0.10.3``. This
+  also changes the name of GitHub release tarballs (and zip archives) to e.g.
+  ``orix-0.10.3.tar.gz``.
 
 Deprecated
 ----------


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
We have an action which automatically creates a release draft whenever the `__version__` changes in `orix/__init__.py` in a commit to `main`. With this PR, this release draft will now point to a tag with name e.g. "orix-0.11.0" instead of "v0.11.0". This was suggested by @MarDiehl in #418.

This means that tags after "v0.10.2" in [this list](https://github.com/pyxem/orix/tags) will be named "orix-0.11.0" and so on. I'm fine with this.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.