### PR TITLE
Mention GitHub source code archive links in installation guide

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -57,12 +57,20 @@ To install a specific version of orix (say version 0.8.1)::
 From source
 ===========
 
-To install orix from source, clone the repository from `GitHub
+The source code is hosted on `GitHub <https://github.com/pyxem/orix>`__. One way to
+install orix from source is to clone the repository from `GitHub
 <https://github.com/pyxem/orix>`__, and install with ``pip``::
 
     git clone https://github.com/pyxem/orix.git
     cd orix
     pip install --editable .
 
+The source can also be downloaded as tarballs or zip archives via links like
+`https://github.com/pyxem/orix/archive/v<major.minor.patch>/orix-<major.minor.patch>.tar.gz`_,
+where the version ``<major.minor.patch>`` can be e.g. ``0.10.2``, and ``tar.gz`` can be
+exchanged with ``zip``.
+
 See the :ref:`contributing guide <set-up-a-development-installation>` for how to set up
 a development installation and keep it up to date.
+
+.. _https://github.com/pyxem/orix/archive/v<major.minor.patch>/orix-<major.minor.patch>.tar.gz: https://github.com/pyxem/orix/archive/v<major.minor.patch>/orix-<major.minor.patch>.tar.gz


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

#### Description of the change
Mention GitHub source code archive links in installation guide. This information could have spared #418 and #419. 

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.