### PR TITLE
Allow setting padding and whether to show edges in StereographicPlot.restrict_to_sector()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,9 @@ Added
   ``from_euler()``, ``from_matrix()``, ``random()`` and ``identity()`` and methods
   ``to_euler()`` and ``to_matrix()`` are now available from the ``Quaternion`` class as
   well.
+- ``StereographicPlot.restrict_to_sector()`` allows two new parameters to control the
+  amount of padding (in degrees in stereographic projection) and whether to show the
+  sector edges. Keyword arguments can also be passed on to Matplotlib's ``PathPatch()``.
 
 Changed
 -------

--- a/examples/stereographic_projection/restrict_to_fundamental_sector.py
+++ b/examples/stereographic_projection/restrict_to_fundamental_sector.py
@@ -1,0 +1,56 @@
+r"""
+==============================
+Restrict to fundamental sector
+==============================
+
+This example shows how to restrict the stereographic plot to only the fundamental sector
+of a point group using :meth:`~orix.plot.StereographicPlot.restrict_to_sector`. The
+sector is typically obtained from :attr:`orix.quaternion.Symmetry.fundamental_sector`,
+and is often called the `fundamental triangle'.
+
+We demonstrate this functionality by drawing (near) great circles about some typically
+strongly reflecting low-index reciprocal lattice vectors :math:`\{hkl\}` in crystals of
+point group :math:`m\bar{3}m`. The deviations from the great circles are related to the
+kinematically calculated width of a Kikuchi band scattered from these vectors assuming a
+lattice parameter of 4.04 Å (Aluminium) and an accelerating voltage of 20 keV.
+"""
+
+import numpy as np
+
+from orix.crystal_map import Phase
+from orix.quaternion import symmetry
+from orix.vector import Miller
+
+# Symmetrically equivalent set of hkl
+hkl1 = Miller(
+    hkl=[[1, 1, 1], [2, 0, 0], [2, 2, 0], [3, 1, 1]],
+    phase=Phase(point_group=symmetry.Oh),
+)
+print(hkl1)
+hkl, idx = hkl1.symmetrise(unique=True, return_index=True)
+
+# Width of Kikuchi bands (deviation from great circles)
+theta = np.deg2rad([1.054, 1.218, 1.722, 2.019])
+theta = theta[idx]
+
+# Plot pair of near great circles
+fig = hkl.draw_circle(opening_angle=np.pi / 2 + theta, return_figure=True)
+hkl.draw_circle(opening_angle=np.pi / 2 - theta, figure=fig)
+
+# Restrict to fundamental sector of m-3m
+ax = fig.axes[0]
+ax.restrict_to_sector(hkl.phase.point_group.fundamental_sector, edgecolor="r", lw=2)
+
+# Get symmetrically equivalent set of zone axes <uvw> within fundamental
+# sector and round to lowest possible integer
+uvw = hkl.reshape(hkl.size, 1).cross(hkl.reshape(1, hkl.size)).flatten()
+uvw = uvw.in_fundamental_sector()
+uvw = uvw.unique(use_symmetry=True)
+uvw = uvw.round()
+
+# Plot zone axes
+for uvw_i in uvw:
+    uvw_idx = str(uvw_i.coordinates[0].astype(int)).replace(" ", "")
+    ax.text(uvw_i, s=uvw_idx, va="bottom", bbox=dict(facecolor="w", pad=1, alpha=0.75))
+
+_ = ax.set_title(r"Low-index $[uvw]$ in fundamental sector of $m\bar{3}m$", pad=10)

--- a/orix/plot/_symmetry_marker.py
+++ b/orix/plot/_symmetry_marker.py
@@ -23,6 +23,8 @@ Meant to be used indirectly in
 :func:`~orix.plot.StereographicPlot.symmetry_marker`.
 """
 
+from typing import Union
+
 import matplotlib.path as mpath
 import matplotlib.transforms as mtransforms
 import numpy as np
@@ -42,7 +44,7 @@ class SymmetryMarker:
     fold = None
     _marker = None
 
-    def __init__(self, v: Vector3d, size: int = 1):
+    def __init__(self, v: Union[Vector3d, np.ndarray, list, tuple], size: int = 1):
         self._vector = Vector3d(v)
         self._size = size
 

--- a/orix/tests/plot/test_stereographic_plot.py
+++ b/orix/tests/plot/test_stereographic_plot.py
@@ -515,3 +515,33 @@ class TestRestrictToFundamentalSector:
         assert len(ax5.lines) == 0
 
         plt.close("all")
+
+    def test_restrict_to_sector_pad(self):
+        v = Vector3d.zvector()
+
+        fig = v.scatter(return_figure=True)
+        ax = fig.axes[0]
+        assert np.allclose(ax.get_xlim(), [-1.05, 1.05])
+
+        # No change since the sector is the equator
+        ax.restrict_to_sector(C1.fundamental_sector)
+        assert np.allclose(ax.get_xlim(), [-1.05, 1.05])
+
+        # Default
+        fs_m3m = Oh.fundamental_sector
+        ax.restrict_to_sector(fs_m3m)
+        assert np.allclose(ax.get_xlim(), [-0.0103, 0.4245], atol=1e-4)
+
+        # Slightly wider
+        ax.restrict_to_sector(fs_m3m, pad=2)
+        assert np.allclose(ax.get_xlim(), [-0.0159, 0.4301], atol=1e-4)
+
+    def test_restrict_to_sector_edges(self):
+        v = Vector3d.zvector()
+
+        fig = v.scatter(return_figure=True)
+        ax = fig.axes[0]
+
+        ax.restrict_to_sector(Oh.fundamental_sector, show_edges=False)
+        assert len(ax.patches) == 1
+        assert ax.patches[0].get_label() == "sa_circle"

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -384,7 +384,7 @@ class Vector3d(Object3d):
         return dots
 
     def cross(self, other: Vector3d) -> Vector3d:
-        """The cross product of a vector with another vector.
+        """Return the cross product of a vector with another vector.
 
         Vectors must have compatible shape for broadcasting to work.
 
@@ -407,9 +407,12 @@ class Vector3d(Object3d):
 
     @classmethod
     def from_polar(
-        cls, azimuth: np.ndarray, polar: np.ndarray, radial: float = 1.0
+        cls,
+        azimuth: Union[np.ndarray, list, tuple],
+        polar: [np.ndarray, list, tuple],
+        radial: float = 1.0,
     ) -> Vector3d:
-        """Create a :class:`Vector3d` from spherical coordinates
+        """Return a :class:`Vector3d` from spherical coordinates
         according to the ISO 31-11 standard
         :cite:`weisstein2005spherical`.
 


### PR DESCRIPTION
#### Description of the change
This PR adds the option to control the padding/margins in angles in the stereographic projection when restricting a `StereographicPlot` with `restrict_to_sector()`. The possibility to not show the sector edges as well as passing keyword arguments controlling the appearance of the sector (edge color, line width etc.) is also added.

An example drawing the Kikuchi bands of low-index {hkl} of Aluminium in the stereographic projection and then restricting to the m-3m fundamental sector is added to the examples.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
This is the example added to the docs (can also be seen in the docs built from this PR):

```python
import numpy as np

from orix.crystal_map import Phase
from orix.quaternion import symmetry
from orix.vector import Miller

# Symmetrically equivalent set of hkl
hkl1 = Miller(
    hkl=[[1, 1, 1], [2, 0, 0], [2, 2, 0], [3, 1, 1]],
    phase=Phase(point_group=symmetry.Oh),
)
print(hkl1)
hkl, idx = hkl1.symmetrise(unique=True, return_index=True)

# Width of Kikuchi bands (deviation from great circles)
theta = np.deg2rad([1.054, 1.218, 1.722, 2.019])
theta = theta[idx]

# Plot pair of near great circles
fig = hkl.draw_circle(opening_angle=np.pi / 2 + theta, return_figure=True)
hkl.draw_circle(opening_angle=np.pi / 2 - theta, figure=fig)

# Restrict to fundamental sector of m-3m
ax = fig.axes[0]
ax.restrict_to_sector(hkl.phase.point_group.fundamental_sector, edgecolor="r", lw=2)

# Get symmetrically equivalent set of zone axes <uvw> within fundamental
# sector and round to lowest possible integer
uvw = hkl.reshape(hkl.size, 1).cross(hkl.reshape(1, hkl.size)).flatten()
uvw = uvw.in_fundamental_sector()
uvw = uvw.unique(use_symmetry=True)
uvw = uvw.round()

# Plot zone axes
for uvw_i in uvw:
    uvw_idx = str(uvw_i.coordinates[0].astype(int)).replace(" ", "")
    ax.text(uvw_i, s=uvw_idx, va="bottom", bbox=dict(facecolor="w", pad=1, alpha=0.75))

_ = ax.set_title(r"Low-index $[uvw]$ in fundamental sector of $m\bar{3}m$", pad=10)
```

![hkl_uvw](https://user-images.githubusercontent.com/12139781/216127654-273b9776-e143-4b31-a1ae-87613df23797.png)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.