### PR TITLE
Allow passing and getting degrees from methods using angles

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ Added
   ``from_euler()``, ``from_matrix()``, ``random()`` and ``identity()`` and methods
   ``to_euler()`` and ``to_matrix()`` are now available from the ``Quaternion`` class as
   well.
+- Possibility to pass degrees to ``from_axes_angles()`` method provided that
+  ``degrees=True`` is passed.
 
 Changed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,8 +24,8 @@ Added
   ``from_euler()``, ``from_matrix()``, ``random()`` and ``identity()`` and methods
   ``to_euler()`` and ``to_matrix()`` are now available from the ``Quaternion`` class as
   well.
-- Possibility to pass degrees to ``from_axes_angles()`` method provided that
-  ``degrees=True`` is passed.
+- Possibility to pass degrees to the methods ``from_axes_angles()``,  ``from_euler()``
+  and ``to_euler()`` provided that ``degrees=True`` is passed.
 
 Changed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,8 +26,8 @@ Added
   well.
 - Possibility to pass degrees to the ``Quaternion`` methods ``from_axes_angles()``,
   ``from_euler()`` and ``to_euler()`` provided that ``degrees=True`` is passed.
-- Possibility to pass degrees to the ``Rotation`` methods ``angle_with()`` and
-  ``angle_with_outer()`` provided that ``degrees=True`` is passed.
+- Can get degrees from all ``angle_with()`` and ``angle_with_outer()`` methods provided
+  that ``degrees=True`` is passed.
 - Possibility to pass degrees to the ``(Mis)Orientation`` method
   ``get_distance_matrix()`` provided that ``degrees=True`` is passed.
 - Possibility to pass degrees to the ``Vector3d`` methods ``from_polar()`` and

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,10 @@ Added
   well.
 - Possibility to pass degrees to the ``Quaternion`` methods ``from_axes_angles()``,
   ``from_euler()`` and ``to_euler()`` provided that ``degrees=True`` is passed.
+- Possibility to pass degrees to the ``Rotation`` methods ``angle_with()`` and
+  ``angle_with_outer()`` provided that ``degrees=True`` is passed.
+- Possibility to pass degrees to the ``(Mis)Orientation`` method
+  ``get_distance_matrix()`` provided that ``degrees=True`` is passed.
 - Possibility to pass degrees to the ``Vector3d`` methods ``from_polar()`` and
   ``to_polar()`` provided that ``degrees=True`` is passed.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,14 +24,18 @@ Added
   ``from_euler()``, ``from_matrix()``, ``random()`` and ``identity()`` and methods
   ``to_euler()`` and ``to_matrix()`` are now available from the ``Quaternion`` class as
   well.
-- Possibility to pass degrees to the ``Quaternion`` methods ``from_axes_angles()``,
-  ``from_euler()`` and ``to_euler()`` provided that ``degrees=True`` is passed.
-- Can get degrees from all ``angle_with()`` and ``angle_with_outer()`` methods provided
-  that ``degrees=True`` is passed.
-- Possibility to pass degrees to the ``(Mis)Orientation`` method
-  ``get_distance_matrix()`` provided that ``degrees=True`` is passed.
-- Possibility to pass degrees to the ``Vector3d`` methods ``from_polar()`` and
-  ``to_polar()`` provided that ``degrees=True`` is passed.
+- Option to pass degrees to the ``Quaternion`` methods ``from_axes_angles()``,
+  ``from_euler()`` and ``to_euler()`` by passing ``degrees=True``.
+- Option to get degrees from all ``angle_with()`` and ``angle_with_outer()`` methods
+  by passing ``degrees=True``.
+- Option to pass degrees to the ``(Mis)Orientation`` method ``get_distance_matrix()``
+  by passing ``degrees=True``.
+- Option to pass degrees to the ``Vector3d`` methods ``from_polar()`` and ``to_polar()``
+  by passing ``degrees=True``.
+- Option to get spherical coordinates from
+  ``InverseStereographicProjection.xy2spherical()`` in degrees or pass them as degrees
+  to ``StereographicProjection`` methods ``spherical2xy()`` and ``spherical2xy_split()``
+  by passing ``degrees=True``.
 
 Changed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,8 +24,10 @@ Added
   ``from_euler()``, ``from_matrix()``, ``random()`` and ``identity()`` and methods
   ``to_euler()`` and ``to_matrix()`` are now available from the ``Quaternion`` class as
   well.
-- Possibility to pass degrees to the methods ``from_axes_angles()``,  ``from_euler()``
-  and ``to_euler()`` provided that ``degrees=True`` is passed.
+- Possibility to pass degrees to the ``Quaternion`` methods ``from_axes_angles()``,
+  ``from_euler()`` and ``to_euler()`` provided that ``degrees=True`` is passed.
+- Possibility to pass degrees to the ``Vector3d`` methods ``from_polar()`` and
+  ``to_polar()`` provided that ``degrees=True`` is passed.
 
 Changed
 -------

--- a/doc/tutorials/clustering_misorientations.ipynb
+++ b/doc/tutorials/clustering_misorientations.ipynb
@@ -290,7 +290,7 @@
     "unique_cluster_labels = unique_labels[1:]  # Without the \"no-cluster\" label -1\n",
     "cluster_sizes = all_cluster_sizes[1:]\n",
     "\n",
-    "rc = Rotation.from_axes_angles((0, 0, 1), np.deg2rad(15))\n",
+    "rc = Rotation.from_axes_angles((0, 0, 1), 15, degrees=True)\n",
     "\n",
     "mori_mean = []\n",
     "for label in unique_cluster_labels:\n",
@@ -363,7 +363,8 @@
     "        (1, 0, 0),  # sigma13a\n",
     "        (2, 1, 0),  # sigma13b\n",
     "    ],\n",
-    "    angles=np.deg2rad([64.40, 34.96, 85.03, 76.89, 57.22]),\n",
+    "    angles=[64.40, 34.96, 85.03, 76.89, 57.22],\n",
+    "    degrees=True,\n",
     ")"
    ]
   },
@@ -568,7 +569,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/crystal_directions.ipynb
+++ b/doc/tutorials/crystal_directions.ipynb
@@ -36,7 +36,7 @@
     "import numpy as np\n",
     "from orix.crystal_map import Phase\n",
     "from orix.quaternion import Orientation, Rotation, symmetry\n",
-    "from orix.vector import AxAngle, Miller, Vector3d\n",
+    "from orix.vector import Miller, Vector3d\n",
     "\n",
     "\n",
     "plt.rcParams.update(\n",
@@ -129,7 +129,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.rad2deg(m1[0].angle_with(m1[1]))"
+    "m1[0].angle_with(m1[1], degrees=True)"
    ]
   },
   {
@@ -187,7 +187,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.rad2deg(m2[0].angle_with(m2[1]))"
+    "m2[0].angle_with(m2[1], degrees=True)"
    ]
   },
   {
@@ -629,7 +629,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.rad2deg(m11.angle_with(m12))"
+    "m11.angle_with(m12, degrees=True)"
    ]
   },
   {
@@ -639,7 +639,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.rad2deg(m11.angle_with(m12, use_symmetry=True))"
+    "m11.angle_with(m12, use_symmetry=True, degrees=True)"
    ]
   },
   {
@@ -667,7 +667,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "o = Orientation.from_axes_angles((0, 0, -1), np.deg2rad(45), symmetry=cubic.point_group)\n",
+    "o = Orientation.from_axes_angles(\n",
+    "    (0, 0, -1), 45, symmetry=cubic.point_group, degrees=True\n",
+    ")\n",
     "o"
    ]
   },
@@ -731,7 +733,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "o2 = Orientation.from_euler(np.deg2rad([10, 20, 30]), symmetry=trigonal.point_group)\n",
+    "o2 = Orientation.from_euler([10, 20, 30], symmetry=trigonal.point_group, degrees=True)\n",
     "o2"
    ]
   },
@@ -905,10 +907,8 @@
    "source": [
     "vz = Vector3d.zvector()\n",
     "v111 = Vector3d([1, 1, 1])\n",
-    "r1 = Rotation.from_neo_euler(\n",
-    "    AxAngle.from_axes_angles(v111.cross(vz), v111.angle_with(vz).data)\n",
-    ")\n",
-    "r2 = Rotation.from_neo_euler(AxAngle.from_axes_angles(vz, np.deg2rad(-15)))\n",
+    "r1 = Rotation.from_axes_angles(v111.cross(vz), v111.angle_with(vz).data)\n",
+    "r2 = Rotation.from_axes_angles(vz, -15, degrees=True)\n",
     "md5 = r2 * r1 * md4"
    ]
   },
@@ -981,7 +981,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/crystal_reference_frame.ipynb
+++ b/doc/tutorials/crystal_reference_frame.ipynb
@@ -237,8 +237,8 @@
    },
    "outputs": [],
    "source": [
-    "ori = Rotation.from_axes_angles((0, 1, 0), np.deg2rad(65))\n",
-    "phase.point_group.plot(figure=fig, orientation=ori, fc=\"none\", ec=\"C0\", s=150)\n",
+    "r = Rotation.from_axes_angles([0, 1, 0], 65, degrees=True)\n",
+    "phase.point_group.plot(figure=fig, orientation=r, fc=\"none\", ec=\"C0\", s=150)\n",
     "fig"
    ]
   },

--- a/doc/tutorials/point_groups.ipynb
+++ b/doc/tutorials/point_groups.ipynb
@@ -96,7 +96,7 @@
     "\n",
     "assert len(schoenflies) == 32\n",
     "\n",
-    "orientation = Rotation.from_axes_angles((-1, 8, 1), np.deg2rad(65))\n",
+    "orientation = Rotation.from_axes_angles((-1, 8, 1), 65, degrees=True)\n",
     "\n",
     "fig, ax = plt.subplots(\n",
     "    nrows=8, ncols=4, figsize=(10, 20), subplot_kw=dict(projection=\"stereographic\")\n",
@@ -151,7 +151,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/stereographic_projection.ipynb
+++ b/doc/tutorials/stereographic_projection.ipynb
@@ -466,9 +466,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "v6 = Vector3d.from_polar(\n",
-    "    azimuth=np.deg2rad([0, 60, 180]), polar=np.deg2rad([0, 60, 60])\n",
-    ")\n",
+    "v6 = Vector3d.from_polar(azimuth=[0, 60, 180], polar=[0, 60, 60], degrees=True)\n",
     "\n",
     "colors = [\"C0\", \"C1\", \"C2\"]\n",
     "fig6 = v6.scatter(\n",
@@ -601,7 +599,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/examples/misorientations/misorientation_from_aligning_directions.py
+++ b/examples/misorientations/misorientation_from_aligning_directions.py
@@ -24,41 +24,39 @@ phase2 = Phase(
 )
 
 # Specify one orientation per crystal
-ori_ref1 = Orientation.from_axes_angles(
-    [1, 1, 1], np.pi / 3, symmetry=phase1.point_group
+o1 = Orientation.from_axes_angles(
+    [1, 1, 1], 60, symmetry=phase1.point_group, degrees=True
 )
-ori_ref2 = Orientation.from_axes_angles(
-    [1, 3, 2], np.pi / 2, symmetry=phase2.point_group
+o2 = Orientation.from_axes_angles(
+    [1, 3, 2], 90, symmetry=phase2.point_group, degrees=True
 )
 
 # Get the reference misorientation (goal). Transformations are composed
 # from the right, so: crystal 1 -> sample -> crystal 2
-mori_ref = Misorientation(
-    ori_ref2 * (~ori_ref1), symmetry=(ori_ref1.symmetry, ori_ref2.symmetry)
-)
+m_ref = Misorientation(o2 * (~o1), symmetry=(o1.symmetry, o2.symmetry))
 
 # Specify two directions in the first crystal
-vec_c1 = Miller(uvw=[[1, 1, 1], [0, 0, 1]], phase=phase1)
+v_c1 = Miller(uvw=[[1, 1, 1], [0, 0, 1]], phase=phase1)
 
 # Express the same directions with respect to the second crystal
-vec_c2 = Miller(xyz=(mori_ref * vec_c1).data, phase=phase2)
+v_c2 = Miller(xyz=(m_ref * v_c1).data, phase=phase2)
 
 # Add some randomness to the second crystal directions (0 error
 # magnitude gives exact result)
 error_magnitude = 0.1
-vec_err = Miller(xyz=np.random.normal(0, error_magnitude, 3), phase=phase2)
-vec_c2_err = Miller(xyz=(vec_c2 + vec_err).data, phase=phase2)
-angle_err = np.rad2deg(vec_c2_err.angle_with(vec_c2)).mean()
+v_err = Miller(xyz=np.random.normal(0, error_magnitude, 3), phase=phase2)
+v_c2_err = Miller(xyz=(v_c2 + v_err).data, phase=phase2)
+angle_err = v_c2_err.angle_with(v_c2, degrees=True).mean()
 print("Vector angular deviation [deg]: ", angle_err)
 
 # Get the misorientation that aligns the directions in the first crystal
 # with those in the second crystal
-mori_new, err = Misorientation.from_align_vectors(vec_c2_err, vec_c1, return_rmsd=True)
+m_new, err = Misorientation.from_align_vectors(v_c2_err, v_c1, return_rmsd=True)
 print("Error distance: ", err)
 
 # Plot the two directions in the (unrotated) first crystal's reference
 # frame as open circles
-fig = vec_c1.scatter(
+fig = v_c1.scatter(
     ec=["r", "b"],
     s=100,
     fc="none",
@@ -70,4 +68,4 @@ fig.tight_layout()
 
 # Plot the two directions in the second crystal with respect to the
 # first crystal's axes
-(~mori_ref * vec_c2_err).scatter(c=["r", "b"], figure=fig)
+(~m_ref * v_c2_err).scatter(c=["r", "b"], figure=fig)

--- a/examples/orientations/orientation_from_aligning_directions.py
+++ b/examples/orientations/orientation_from_aligning_directions.py
@@ -22,17 +22,17 @@ phase = Phase(
 )
 
 # Define a reference orientation (goal)
-ori_ref = Orientation.from_axes_angles([1, 1, 1], np.pi / 4, phase.point_group)
+o_ref = Orientation.from_axes_angles([1, 1, 1], 45, phase.point_group, degrees=True)
 
 # Specify two crystal directions (any will do)
-vec_c = Miller(uvw=[[2, 1, 1], [1, 3, 1]], phase=phase)
+v_c = Miller(uvw=[[2, 1, 1], [1, 3, 1]], phase=phase)
 
 # Find out where these directions in the reference orientation (crystal)
 # point in the sample reference frame
-vec_r = Vector3d(~ori_ref * vec_c)
+v_r = Vector3d(~o_ref * v_c)
 
 # Plot the reference orientation sample directions as empty circles
-fig = vec_r.scatter(
+fig = v_r.scatter(
     ec=["r", "b"],
     s=100,
     fc="none",
@@ -45,17 +45,16 @@ fig.tight_layout()
 # Add some randomness to the sample directions (0 error magnitude gives
 # exact result)
 err_magnitude = 0.1
-vec_err = Vector3d(np.random.normal(0, err_magnitude, 3))
-vec_r_err = vec_r + vec_err
-angle_err = np.rad2deg(vec_r_err.angle_with(vec_r)).mean()
+v_err = Vector3d(np.random.normal(0, err_magnitude, 3))
+v_r_err = v_r + v_err
+angle_err = v_r_err.angle_with(v_r, degrees=True).mean()
 print("Vector angle deviation [deg]: ", angle_err)
 
 # Obtain the orientation which aligns the crystal directions with the
 # sample directions
-ori_new_r2c, err = Orientation.from_align_vectors(vec_c, vec_r_err, return_rmsd=True)
-ori_new_c2r = ~ori_new_r2c
+o_new_r2c, err = Orientation.from_align_vectors(v_c, v_r_err, return_rmsd=True)
 print("Error distance: ", err)
 
 # Plot the crystal directions in the new orientation
-vec_r2 = Vector3d(~ori_new_r2c * vec_c)
-vec_r2.scatter(c=["r", "b"], figure=fig)
+v_r2 = Vector3d(~o_new_r2c * v_c)
+v_r2.scatter(c=["r", "b"], figure=fig)

--- a/examples/plotting/subplots.py
+++ b/examples/plotting/subplots.py
@@ -21,21 +21,21 @@ xmap = data.sdss_ferrite_austenite(allow_download=True)
 print(xmap)
 
 pg_laue = xmap.phases[1].point_group.laue
-ori_au = xmap["austenite"].orientations
-ori_fe = xmap["ferrite"].orientations
+o_au = xmap["austenite"].orientations
+o_fe = xmap["ferrite"].orientations
 
 # Orientation colors
 ipf_key = plot.IPFColorKeyTSL(pg_laue)
-rgb_au = ipf_key.orientation2color(ori_au)
-rgb_fe = ipf_key.orientation2color(ori_fe)
+rgb_au = ipf_key.orientation2color(o_au)
+rgb_fe = ipf_key.orientation2color(o_fe)
 
 # Austenite <111> poles in the sample reference frame
 uvw_au = Miller(uvw=[1, 1, 1], phase=xmap.phases["austenite"]).symmetrise(unique=True)
-uvw_au_all = (~ori_au).outer(uvw_au)
+uvw_au_all = (~o_au).outer(uvw_au)
 
 # Ferrite <111> poles in the sample reference frame
 uvw_fe = Miller(uvw=[1, 1, 1], phase=xmap.phases["ferrite"]).symmetrise(unique=True)
-uvw_fe_all = (~ori_fe).outer(uvw_fe)
+uvw_fe_all = (~o_fe).outer(uvw_fe)
 
 # Create figure
 fig = plt.figure(figsize=(8, 8))

--- a/examples/stereographic_projection/zoom_inset_region.py
+++ b/examples/stereographic_projection/zoom_inset_region.py
@@ -11,7 +11,6 @@ Matplotlib example
 
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1.inset_locator import InsetPosition
-import numpy as np
 
 from orix import plot, projections, sampling
 from orix.vector import Vector3d
@@ -19,7 +18,7 @@ from orix.vector import Vector3d
 # Sample some orientations
 v = sampling.sample_S2(2)
 v_ref = Vector3d([1, 1, 1])
-v2 = v[v_ref.angle_with(v) < np.deg2rad(10)]
+v2 = v[v_ref.angle_with(v, degrees=True) < 10]
 
 # Plot them in the stereographic projection with a grid resolution of 10
 # degrees
@@ -32,7 +31,7 @@ ax.scatter(v_ref, c="r")
 
 # Define some vectors describing the x/y extent of the zoomed inset
 # region and get their stereographic coordinates (X, Y)
-v_inset = Vector3d.from_polar(azimuth=np.deg2rad([45, 45]), polar=np.deg2rad([36, 71]))
+v_inset = Vector3d.from_polar(azimuth=[45, 45], polar=[36, 71], degrees=True)
 stereo = projections.StereographicProjection()
 x_inset, y_inset = stereo.vector2xy(v_inset)
 

--- a/orix/projections/stereographic.py
+++ b/orix/projections/stereographic.py
@@ -83,7 +83,10 @@ class StereographicProjection:
         return _vector2xy(v, pole=self.pole)
 
     def spherical2xy(
-        self, azimuth: Union[float, np.ndarray], polar: Union[float, np.ndarray]
+        self,
+        azimuth: Union[np.ndarray, list, tuple, float],
+        polar: Union[np.ndarray, list, tuple, float],
+        degrees: bool = False,
     ) -> Tuple[np.ndarray, np.ndarray]:
         r"""Return stereographic coordinates (X, Y) from 3D unit vectors
         created from spherical coordinates, azimuth :math:`\phi` and
@@ -96,6 +99,9 @@ class StereographicProjection:
             Spherical azimuth coordinate.
         polar
             Spherical polar coordinate.
+        degrees
+            If ``True``, the coordinates are assumed to be in degrees.
+            Default is ``False``.
 
         Returns
         -------
@@ -114,7 +120,7 @@ class StereographicProjection:
         --------
         vector2xy
         """
-        v = Vector3d.from_polar(azimuth=azimuth, polar=polar)
+        v = Vector3d.from_polar(azimuth, polar, degrees=degrees)
         return self.vector2xy(v)
 
     @staticmethod
@@ -154,7 +160,10 @@ class StereographicProjection:
         return x_upper, y_upper, x_lower, y_lower
 
     def spherical2xy_split(
-        self, azimuth: Union[float, np.ndarray], polar: Union[float, np.ndarray]
+        self,
+        azimuth: Union[np.ndarray, list, tuple, float],
+        polar: Union[np.ndarray, list, tuple, float],
+        degrees: bool = False,
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         r"""Return two sets of stereographic coordinates (X, Y) from 3D
         unit vectors created from spherical coordinates, azimuth
@@ -168,6 +177,9 @@ class StereographicProjection:
             Spherical azimuth coordinate.
         polar
             Spherical polar coordinate.
+        degrees
+            If ``True``, the coordinates are assumed to be in degrees.
+            Default is ``False``.
 
         Returns
         -------
@@ -188,7 +200,7 @@ class StereographicProjection:
         --------
         vector2xy
         """
-        v = Vector3d.from_polar(azimuth=azimuth, polar=polar)
+        v = Vector3d.from_polar(azimuth, polar, degrees=degrees)
         return self.vector2xy_split(v)
 
     @property
@@ -296,7 +308,10 @@ class InverseStereographicProjection:
         return Vector3d(np.column_stack([vx, vy, vz]))
 
     def xy2spherical(
-        self, x: Union[float, np.ndarray], y: Union[float, np.ndarray]
+        self,
+        x: Union[float, np.ndarray],
+        y: Union[float, np.ndarray],
+        degrees: bool = False,
     ) -> Tuple[np.ndarray, np.ndarray]:
         r"""Return spherical coordinates, azimuth :math:`phi` and
         polar :math:`theta`, defined as in the ISO 31-11 standard
@@ -309,6 +324,9 @@ class InverseStereographicProjection:
             X coordinates.
         y
             Y coordinates.
+        degrees
+            If ``True``, the given angles are returned in degrees.
+            Default is ``False``.
 
         Returns
         -------
@@ -328,4 +346,5 @@ class InverseStereographicProjection:
         StereographicProjection.spherical2xy
         """
         v = self.xy2vector(x=x, y=y)
-        return v.azimuth, v.polar
+        azimuth, polar, _ = v.to_polar(degrees=degrees)
+        return azimuth, polar

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -596,14 +596,16 @@ class Orientation(Misorientation):
         euler: np.ndarray,
         symmetry: Optional[Symmetry] = None,
         direction: str = "lab2crystal",
+        degrees: bool = False,
         **kwargs,
     ) -> Orientation:
-        """Return orientation(s) from an array of Euler angles.
+        """Initialize from an array of Euler angles.
 
         Parameters
         ----------
         euler
-            Euler angles in the Bunge convention.
+            Euler angles in radians (``degrees=False``) or in degrees
+            (``degrees=True``) in the Bunge convention.
         symmetry
             Symmetry of orientation(s). If not given (default), no
             symmetry is set.
@@ -611,13 +613,16 @@ class Orientation(Misorientation):
             ``"lab2crystal"`` (default) or ``"crystal2lab"``.
             ``"lab2crystal"`` is the Bunge convention. If ``"MTEX"`` is
             provided then the direction is ``"crystal2lab"``.
+        degrees
+            If ``True``, the given angles are assumed to be in degrees.
+            Default is ``False``.
 
         Returns
         -------
         ori
             Orientations.
         """
-        ori = super().from_euler(euler=euler, direction=direction, **kwargs)
+        ori = super().from_euler(euler, direction=direction, degrees=degrees, **kwargs)
         if symmetry:
             ori.symmetry = symmetry
         return ori

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -58,7 +58,7 @@ class Misorientation(Rotation):
 
     def __init__(
         self,
-        data: Union[np.ndarray, list, tuple, Misorientation],
+        data: Union[np.ndarray, Misorientation, list, tuple],
         symmetry: Optional[Tuple[Symmetry, Symmetry]] = None,
     ):
         super().__init__(data)
@@ -340,7 +340,7 @@ class Misorientation(Rotation):
         Examples
         --------
         >>> from orix.quaternion import Misorientation, symmetry
-        >>> m = Misorientation.from_axes_angles([1, 0, 0], [0, np.pi / 2])
+        >>> m = Misorientation.from_axes_angles([1, 0, 0], [0, 90], degrees=True)
         >>> m.symmetry = (symmetry.D6, symmetry.D6)
         >>> m.get_distance_matrix(progressbar=False)
         array([[0.        , 1.57079633],
@@ -766,25 +766,30 @@ class Orientation(Misorientation):
     def from_axes_angles(
         cls,
         axes: Union[np.ndarray, Vector3d, tuple, list],
-        angles: Union[np.ndarray, tuple, list],
+        angles: Union[np.ndarray, tuple, list, float],
         symmetry: Optional[Symmetry] = None,
+        degrees: bool = False,
     ) -> Orientation:
-        """Return orientations from axis-angle pairs.
+        """Initialize from axis-angle pair(s).
 
         Parameters
         ----------
         axes
-            The axes of rotation.
+            Axes of rotation.
         angles
-            The angles of rotation, in radians.
+            Angles of rotation in radians (``degrees=False``) or degrees
+            (``degrees=True``).
         symmetry
             Symmetry of orientations. If not given (default), no
             symmetry is set.
+        degrees
+            If ``True``, the given angles are assumed to be in degrees.
+            Default is ``False``.
 
         Returns
         -------
         ori
-            Orientations.
+            Orientation(s).
 
         See Also
         --------
@@ -793,12 +798,12 @@ class Orientation(Misorientation):
         Examples
         --------
         >>> from orix.quaternion import Orientation, symmetry
-        >>> ori = Orientation.from_axes_angles((0, 0, -1), np.pi / 2, symmetry.Oh)
+        >>> ori = Orientation.from_axes_angles((0, 0, -1), 90, symmetry.Oh, degrees=True)
         >>> ori
         Orientation (1,) m-3m
         [[ 0.7071  0.      0.     -0.7071]]
         """
-        axangle = AxAngle.from_axes_angles(axes, angles)
+        axangle = AxAngle.from_axes_angles(axes, angles, degrees)
         return cls.from_neo_euler(axangle, symmetry)
 
     @classmethod
@@ -1025,9 +1030,9 @@ class Orientation(Misorientation):
         Examples
         --------
         >>> from orix.quaternion import Orientation, symmetry
-        >>> ori1 = Orientation.from_axes_angles([0, 0, 1], np.deg2rad([0, 45]), symmetry.Oh)
-        >>> ori2 = Orientation.from_axes_angles([0, 0, 1], np.deg2rad([45, 90]), symmetry.Oh)
-        >>> ori1.dot(ori2)
+        >>> o1 = Orientation.from_axes_angles([0, 0, 1], [0, 45], symmetry.Oh, degrees=True)
+        >>> o2 = Orientation.from_axes_angles([0, 0, 1], [45, 90], symmetry.Oh, degrees=True)
+        >>> o1.dot(o2)
         array([0.92387953, 0.92387953])
         """
         symmetry = _get_unique_symmetry_elements(self.symmetry, other.symmetry)
@@ -1057,9 +1062,9 @@ class Orientation(Misorientation):
         Examples
         --------
         >>> from orix.quaternion import Orientation, symmetry
-        >>> ori1 = Orientation.from_axes_angles([0, 0, 1], np.deg2rad([0, 45]), symmetry.Oh)
-        >>> ori2 = Orientation.from_axes_angles([0, 0, 1], np.deg2rad([45, 90]), symmetry.Oh)
-        >>> ori1.dot_outer(ori2)
+        >>> o1 = Orientation.from_axes_angles([0, 0, 1], [0, 45], symmetry.Oh, degrees=True)
+        >>> o2 = Orientation.from_axes_angles([0, 0, 1], [45, 90], symmetry.Oh, degrees=True)
+        >>> o1.dot_outer(o2)
         array([[0.92387953, 1.        ],
                [1.        , 0.92387953]])
         """

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -260,16 +260,21 @@ class Quaternion(Object3d):
     def from_axes_angles(
         cls,
         axes: Union[np.ndarray, Vector3d, tuple, list],
-        angles: Union[np.ndarray, tuple, list],
+        angles: Union[np.ndarray, tuple, list, float],
+        degrees: bool = False,
     ) -> Quaternion:
-        """Create unit quaternion(s) from axis-angle pair(s).
+        """Initialize from axis-angle pair(s).
 
         Parameters
         ----------
         axes
-            Rotation axes.
+            Axes of rotation.
         angles
-            Rotation angles in radians.
+            Angles of rotation in radians (``degrees=False``) or degrees
+            (``degrees=True``).
+        degrees
+            If ``True``, the given angles are assumed to be in degrees.
+            Default is ``False``.
 
         Returns
         -------
@@ -279,7 +284,7 @@ class Quaternion(Object3d):
         Examples
         --------
         >>> from orix.quaternion import Quaternion
-        >>> q = Quaternion.from_axes_angles((0, 0, -1), np.pi / 2)
+        >>> q = Quaternion.from_axes_angles((0, 0, -1), 90, degrees=True)
         >>> q
         Quaternion (1,)
         [[ 0.7071  0.      0.     -0.7071]]
@@ -288,7 +293,7 @@ class Quaternion(Object3d):
         --------
         from_neo_euler
         """
-        axangle = AxAngle.from_axes_angles(axes, angles)
+        axangle = AxAngle.from_axes_angles(axes, angles, degrees)
         q = cls.from_neo_euler(axangle).unit
         return q
 

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -72,7 +72,7 @@ class Rotation(Quaternion):
     neo-Euler representations. See :class:`NeoEuler`.
     """
 
-    def __init__(self, data: Union[np.ndarray, Rotation, Quaternion, list, tuple]):
+    def __init__(self, data: Union[np.ndarray, Rotation, list, tuple]):
         super().__init__(data)
         self._data = np.concatenate((self.data, np.zeros(self.shape + (1,))), axis=-1)
         if isinstance(data, Rotation):
@@ -189,16 +189,21 @@ class Rotation(Quaternion):
     def from_axes_angles(
         cls,
         axes: Union[np.ndarray, Vector3d, tuple, list],
-        angles: Union[np.ndarray, tuple, list],
+        angles: Union[np.ndarray, tuple, list, float],
+        degrees: bool = False,
     ) -> Rotation:
-        """Create rotation(s) from axis-angle pair(s).
+        """Initialize from axis-angle pair(s).
 
         Parameters
         ----------
         axes
-            Rotation axes.
+            Axes of rotation.
         angles
-            Rotation angles in radians.
+            Angles of rotation in radians (``degrees=False``) or degrees
+            (``degrees=True``).
+        degrees
+            If ``True``, the given angles are assumed to be in degrees.
+            Default is ``False``.
 
         Returns
         -------
@@ -208,7 +213,7 @@ class Rotation(Quaternion):
         Examples
         --------
         >>> from orix.quaternion import Rotation
-        >>> r = Rotation.from_axes_angles((0, 0, -1), np.pi / 2)
+        >>> r = Rotation.from_axes_angles((0, 0, -1), 90, degrees=True)
         >>> r
         Rotation (1,)
         [[ 0.7071  0.      0.     -0.7071]]
@@ -217,7 +222,7 @@ class Rotation(Quaternion):
         --------
         from_neo_euler
         """
-        return super().from_axes_angles(axes, angles)
+        return super().from_axes_angles(axes, angles, degrees)
 
     # TODO: Remove **kwargs in 1.0.
     # Deprication decorator is implemented in Quaternion

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -231,26 +231,32 @@ class Rotation(Quaternion):
         cls,
         euler: Union[np.ndarray, tuple, list],
         direction: str = "lab2crystal",
+        degrees: bool = False,
         **kwargs,
     ) -> Rotation:
-        """Create rotation(s) from Euler angle set(s) in radians
+        """Initialize from Euler angle set(s)
         :cite:`rowenhorst2015consistent`.
 
         Parameters
         ----------
         euler
-            Euler angles in radians in the Bunge convention.
+            Euler angles in radians (``degrees=False``) or in degrees
+            (``degrees=True``) in the Bunge convention.
         direction
             Direction of the transformation, either ``"lab2crystal"``
             (default) or the inverse, ``"crystal2lab"``. The former is
             the Bunge convention. Passing ``"MTEX"`` equals the latter.
+        degrees
+            If ``True``, the given angles are assumed to be in degrees.
+            Default is ``False``.
 
         Returns
         -------
         r
             Rotation(s).
         """
-        r = super().from_euler(euler=euler, direction=direction, **kwargs)
+        euler = np.asanyarray(euler)
+        r = super().from_euler(euler, direction=direction, degrees=degrees, **kwargs)
         r.improper = np.zeros(euler.shape[:-1])
         return r
 
@@ -701,18 +707,26 @@ class Rotation(Quaternion):
         return super().to_matrix()
 
     # TODO: Remove **kwargs in 1.0
-    def to_euler(self, **kwargs) -> np.ndarray:
+    def to_euler(self, degrees: bool = False, **kwargs) -> np.ndarray:
         r"""Return the rotations as Euler angles in the Bunge convention
         :cite:`rowenhorst2015consistent`.
+
+        Parameters
+        ----------
+        degrees
+            If ``True``, the given angles are returned in degrees.
+            Default is ``False``.
 
         Returns
         -------
         eu
-            Array of Euler angles in radians, in the ranges
+        eu
+            Array of Euler angles in radians (``degrees=False``) or
+            degrees (``degrees=True``), in the ranges
             :math:`\phi_1 \in [0, 2\pi]`, :math:`\Phi \in [0, \pi]`, and
             :math:`\phi_1 \in [0, 2\pi]`.
         """
-        return super().to_euler(**kwargs)
+        return super().to_euler(degrees, **kwargs)
 
     def _differentiators(self) -> np.ndarray:
         a = self.a

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -542,7 +542,7 @@ class Rotation(Quaternion):
         else:
             return dat
 
-    def angle_with(self, other: Rotation) -> np.ndarray:
+    def angle_with(self, other: Rotation, degrees: bool = False) -> np.ndarray:
         """Return the angles of rotation transforming the rotations to
         the other rotations.
 
@@ -550,11 +550,15 @@ class Rotation(Quaternion):
         ----------
         other
             Other rotations.
+        degrees
+            If ``True``, the angles are returned in degrees. Default is
+            ``False``.
 
         Returns
         -------
         angles
-            Angles of rotation.
+            Angles of rotation in radians (``degrees=False``) or degrees
+            (``degrees=True``).
 
         See Also
         --------
@@ -566,9 +570,11 @@ class Rotation(Quaternion):
         # Round because some dot products are slightly above 1
         dot_products = np.round(dot_products, np.finfo(dot_products.dtype).precision)
         angles = np.nan_to_num(np.arccos(2 * dot_products**2 - 1))
+        if degrees:
+            angles = np.rad2deg(angles)
         return angles
 
-    def angle_with_outer(self, other: Rotation):
+    def angle_with_outer(self, other: Rotation, degrees: bool = False) -> np.ndarray:
         """Return the angles of rotation transforming the rotations to
         all the other rotations.
 
@@ -576,11 +582,15 @@ class Rotation(Quaternion):
         ----------
         other
             Another rotation.
+        degrees
+            If ``True``, the angles are returned in degrees. Default is
+            ``False``.
 
         Returns
         -------
         angles
-            Angles of rotation.
+            Angles of rotation in radians (``degrees=False``) or degrees
+            (``degrees=True``).
 
         Examples
         --------
@@ -598,6 +608,8 @@ class Rotation(Quaternion):
         """
         dot_products = self.unit.dot_outer(other.unit)
         angles = np.nan_to_num(np.arccos(2 * dot_products**2 - 1))
+        if degrees:
+            angles = np.rad2deg(angles)
         return angles
 
     def outer(

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -732,7 +732,6 @@ class Rotation(Quaternion):
         Returns
         -------
         eu
-        eu
             Array of Euler angles in radians (``degrees=False``) or
             degrees (``degrees=True``), in the ranges
             :math:`\phi_1 \in [0, 2\pi]`, :math:`\Phi \in [0, \pi]`, and

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -507,12 +507,15 @@ class TestOrientationInitialization:
         axis = Vector3d.xvector() - Vector3d.yvector()
         angle = np.pi / 2
         axangle = AxAngle.from_axes_angles(axis, angle)
-        ori = Orientation.from_neo_euler(axangle, Oh)
-        ori2 = Orientation.from_axes_angles(axis, angle, Oh)
-        assert np.allclose(ori.to_euler(), (3 * np.pi / 4, np.pi / 2, 5 * np.pi / 4))
-        assert np.allclose(ori.data, ori2.data)
-        assert ori.symmetry.name == ori2.symmetry.name == "m-3m"
-        assert np.allclose(ori.symmetry.data, ori2.symmetry.data)
+        o1 = Orientation.from_neo_euler(axangle, Oh)
+        o2 = Orientation.from_axes_angles(axis, angle, Oh)
+        assert np.allclose(o1.to_euler(), (3 * np.pi / 4, np.pi / 2, 5 * np.pi / 4))
+        assert np.allclose(o1.data, o2.data)
+        assert o1.symmetry.name == o2.symmetry.name == "m-3m"
+        assert np.allclose(o1.symmetry.data, o2.symmetry.data)
+
+        o3 = Orientation.from_axes_angles(axis, np.rad2deg(angle), Oh, degrees=True)
+        assert np.allclose(o2.data, o3.data)
 
     def test_get_identity(self):
         """Get the identity orientation via two alternative routes."""

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -327,6 +327,9 @@ class TestMisorientation:
         )
         assert np.allclose(distance1, expected, atol=1e-4)
 
+        distance2 = m1.get_distance_matrix(degrees=True)
+        assert np.allclose(np.rad2deg(distance1), distance2)
+
     def test_get_distance_matrix_shape(self):
         shape = (3, 4)
         m2 = Misorientation.random(shape)
@@ -335,7 +338,7 @@ class TestMisorientation:
 
     def test_get_distance_matrix_progressbar_chunksize(self):
         m = Misorientation.random((5, 15, 4))
-        angle1 = m.get_distance_matrix(chunk_size=5, progressbar=True)
+        angle1 = m.get_distance_matrix(chunk_size=5)
         angle2 = m.get_distance_matrix(chunk_size=10, progressbar=False)
         assert np.allclose(angle1, angle2)
 
@@ -625,8 +628,11 @@ class TestOrientation:
         assert isinstance(angles_dask, np.ndarray)
         assert angles_dask.shape == (2, 2)
 
-        assert np.allclose(angles_numpy.data, angles_dask.data)
-        assert np.allclose(np.diag(angles_numpy.data), 0)
+        assert np.allclose(angles_numpy, angles_dask)
+        assert np.allclose(np.diag(angles_numpy), 0)
+
+        angles3 = o.get_distance_matrix(degrees=True)
+        assert np.allclose(np.rad2deg(angles_numpy), angles3)
 
     def test_get_distance_matrix_lazy_parameters(self):
         shape = (5, 15, 4)
@@ -634,7 +640,7 @@ class TestOrientation:
         abcd = rng.normal(size=np.prod(shape)).reshape(shape)
         o = Orientation(abcd)
 
-        angle1 = o.get_distance_matrix(lazy=True, chunk_size=5, progressbar=True)
+        angle1 = o.get_distance_matrix(lazy=True, chunk_size=5)
         angle2 = o.get_distance_matrix(lazy=True, chunk_size=10, progressbar=False)
 
         assert np.allclose(angle1.data, angle2.data)

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -704,6 +704,10 @@ class TestOrientation:
         else:
             assert not is_equal
 
+        ang_rad = (~o).angle_with(o)
+        ang_deg = (~o).angle_with(o, degrees=True)
+        assert np.allclose(np.rad2deg(ang_rad), ang_deg)
+
     def test_negate_orientation(self):
         o = Orientation.identity()
         o.symmetry = Oh

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -443,6 +443,9 @@ class TestOrientationInitialization:
         o3 = o3.map_into_symmetry_reduced_zone()
         assert np.allclose(o3.data, o2.data)
 
+        o4 = Orientation.from_euler(np.rad2deg(euler), degrees=True)
+        assert np.allclose(o4.data, o1.data)
+
     def test_from_matrix_symmetry(self):
         om = np.array(
             [np.eye(3), np.eye(3), np.diag([1, -1, -1]), np.diag([1, -1, -1])]
@@ -509,7 +512,7 @@ class TestOrientationInitialization:
         axangle = AxAngle.from_axes_angles(axis, angle)
         o1 = Orientation.from_neo_euler(axangle, Oh)
         o2 = Orientation.from_axes_angles(axis, angle, Oh)
-        assert np.allclose(o1.to_euler(), (3 * np.pi / 4, np.pi / 2, 5 * np.pi / 4))
+        assert np.allclose(o1.to_euler(degrees=True), [135, 90, 225])
         assert np.allclose(o1.data, o2.data)
         assert o1.symmetry.name == o2.symmetry.name == "m-3m"
         assert np.allclose(o1.symmetry.data, o2.symmetry.data)
@@ -748,7 +751,7 @@ class TestOrientation:
         vx = Vector3d.xvector()
         vz = Vector3d.zvector()
 
-        ori = Orientation.from_euler(np.radians((325, 48, 163)), symmetry=Oh)
+        ori = Orientation.from_euler((325, 48, 163), symmetry=Oh, degrees=True)
 
         # Returned figure has the expected default properties
         fig_size = (5, 5)

--- a/orix/tests/quaternion/test_quaternion.py
+++ b/orix/tests/quaternion/test_quaternion.py
@@ -30,18 +30,18 @@ from orix.vector import AxAngle, Vector3d
 @pytest.fixture(
     params=[
         # fmt: off
-    (0.707,  0.0,  0.0, 0.707),
-    (0.5  , -0.5, -0.5,   0.5),
-    (0.0  ,  0.0,  0.0,   1.0),
-    (1.0  ,  1.0,  1.0,   1.0),
-    ((0.5, -0.5, -0.5, 0.5), (0.0,  0.0,  0.0, 1.0)),
-    Quaternion(
-        [
-            [(0.0, 0.0, 0.0, 1.0), (0.707, 0.0, 0.0, 0.707)],
-            [(1.0, 1.0, 1.0, 1.0), (0.707, 0.0, 0.0, 0.707)],
-        ]
-    ),
-    np.array((4, 3, 2, 1)),
+        (0.707,  0.0,  0.0, 0.707),
+        (0.5  , -0.5, -0.5,   0.5),
+        (0.0  ,  0.0,  0.0,   1.0),
+        (1.0  ,  1.0,  1.0,   1.0),
+        ((0.5, -0.5, -0.5, 0.5), (0.0,  0.0,  0.0, 1.0)),
+        Quaternion(
+            [
+                [(0.0, 0.0, 0.0, 1.0), (0.707, 0.0, 0.0, 0.707)],
+                [(1.0, 1.0, 1.0, 1.0), (0.707, 0.0, 0.0, 0.707)],
+            ]
+        ),
+        np.array((4, 3, 2, 1)),
         # fmt: on
     ]
 )
@@ -316,7 +316,13 @@ class TestToFromEuler:
     def test_to_from_euler(self, eu):
         """Checks that going euler2quat2euler gives no change."""
         eu2 = Quaternion.from_euler(eu).to_euler()
-        assert np.allclose(eu, eu2.data)
+        assert np.allclose(eu, eu2)
+
+        eu3 = Quaternion.from_euler(np.rad2deg(eu), degrees=True).to_euler()
+        assert np.allclose(eu, eu3)
+
+        eu4 = Quaternion.from_euler(eu).to_euler(degrees=True)
+        assert np.allclose(np.rad2deg(eu), eu4)
 
     def test_mtex(self, eu):
         _ = Quaternion.from_euler(eu, direction="mtex")
@@ -324,14 +330,14 @@ class TestToFromEuler:
     def test_direction_values(self, eu):
         q_mtex = Quaternion.from_euler(eu, direction="mtex")
         q_c2l = Quaternion.from_euler(eu, direction="crystal2lab")
-        q_l2c = Quaternion.from_euler(eu, direction="lab2crystal")
+        q_l2c = Quaternion.from_euler(eu)
         q_default = Quaternion.from_euler(eu)
         assert np.allclose(q_default.data, q_l2c.data)
         assert np.allclose(q_mtex.data, q_c2l.data)
         assert np.allclose((q_l2c * q_c2l).data, [1, 0, 0, 0])
 
     def test_direction_kwarg(self, eu):
-        _ = Quaternion.from_euler(eu, direction="lab2crystal")
+        _ = Quaternion.from_euler(eu)
 
     def test_direction_kwarg_dumb(self, eu):
         with pytest.raises(ValueError, match="The chosen direction is not one of "):
@@ -345,7 +351,7 @@ class TestToFromEuler:
         _ = q.to_euler()
 
     def test_passing_degrees_warns(self):
-        with pytest.warns(UserWarning, match="Angles are assumed to be in radians, "):
+        with pytest.warns(UserWarning, match="Angles are quite high, did you forget "):
             q = Quaternion.from_euler([90, 0, 0])
             assert np.allclose(q.data, [0.5253, 0, 0, -0.8509], atol=1e-4)
 

--- a/orix/tests/quaternion/test_quaternion.py
+++ b/orix/tests/quaternion/test_quaternion.py
@@ -479,3 +479,8 @@ class TestFromAxesAngles:
         quat2 = Quaternion.from_neo_euler(axangle)
         quat3 = Quaternion.from_axes_angles(axangle.axis.data, axangle.angle)
         assert np.allclose(quat2.data, quat3.data)
+
+        quat4 = Quaternion.from_axes_angles(
+            axangle.axis.data, np.rad2deg(axangle.angle), degrees=True
+        )
+        assert np.allclose(quat4.data, quat3.data)

--- a/orix/tests/quaternion/test_rotation.py
+++ b/orix/tests/quaternion/test_rotation.py
@@ -581,3 +581,12 @@ class TestFromAlignVectors:
         assert isinstance(r12, Rotation)
         assert np.allclose((r12 * v1).unit.data, v2.unit.data)
         assert np.allclose((~r12 * v2).unit.data, v1.unit.data)
+
+
+class TestAngleWith:
+    def test_angle_with(self):
+        rot1 = Rotation.random((5,))
+        rot2 = Rotation.random((5,))
+        ang_rad = rot1.angle_with(rot2)
+        ang_deg = rot1.angle_with(rot2, degrees=True)
+        assert np.allclose(np.rad2deg(ang_rad), ang_deg)

--- a/orix/tests/quaternion/test_rotation.py
+++ b/orix/tests/quaternion/test_rotation.py
@@ -553,6 +553,11 @@ class TestFromAxesAngles:
         assert isinstance(r2, Rotation)
         assert r1 == r2
 
+        r3 = Rotation.from_axes_angles(
+            axangle.axis.data, np.rad2deg(axangle.angle), degrees=True
+        )
+        assert np.allclose(r3.data, r2.data)
+
 
 class TestFromScipyRotation:
     """These test address the Rotation.from_scipy_rotation()."""

--- a/orix/tests/quaternion/test_rotation.py
+++ b/orix/tests/quaternion/test_rotation.py
@@ -291,6 +291,9 @@ def test_angle_with_outer():
     assert dist2.shape == r2.shape + r.shape
     assert np.allclose(dist, dist2.T)
 
+    dist3 = r2.angle_with_outer(r, degrees=True)
+    assert np.allclose(dist3, np.rad2deg(dist2))
+
 
 @pytest.mark.parametrize(
     "rotation, improper, expected, improper_expected",

--- a/orix/tests/test_axangle.py
+++ b/orix/tests/test_axangle.py
@@ -72,9 +72,12 @@ def test_axis(axangle):
     ],
 )
 def test_from_axes_angles(axis, angle, expected_axis):
-    ax = AxAngle.from_axes_angles(axis, angle)
-    assert np.allclose(ax.axis.data, expected_axis)
-    assert np.allclose(ax.angle, abs(angle))
+    ax1 = AxAngle.from_axes_angles(axis, angle)
+    assert np.allclose(ax1.axis.data, expected_axis)
+    assert np.allclose(ax1.angle, abs(angle))
+
+    ax2 = AxAngle.from_axes_angles(axis, np.rad2deg(angle), degrees=True)
+    assert np.allclose(ax1.data, ax2.data)
 
 
 @pytest.mark.parametrize(

--- a/orix/tests/test_miller.py
+++ b/orix/tests/test_miller.py
@@ -504,8 +504,8 @@ class TestMillerBravais:
         m6 = Miller(hkil=[1, 1, -2, 0], phase=TRIGONAL_PHASE)
         m7 = Miller(hkil=[-1, -1, 2, 0], phase=TRIGONAL_PHASE)
 
-        assert np.allclose(np.rad2deg(m6.angle_with(m7)[0]), 180)
-        assert np.allclose(np.rad2deg(m6.angle_with(m7, use_symmetry=True)[0]), 60)
+        assert np.allclose(m6.angle_with(m7, degrees=True)[0], 180)
+        assert np.allclose(m6.angle_with(m7, use_symmetry=True, degrees=True)[0], 60)
 
     def test_convention_not_met(self):
         with pytest.raises(ValueError, match="The Miller-Bravais indices convention"):
@@ -536,7 +536,7 @@ class TestDeGraefExamples:
         m2 = Miller(uvw=[1, 2, 0], phase=TETRAGONAL_PHASE)
         m3 = Miller(uvw=[3, 1, 1], phase=TETRAGONAL_PHASE)
         assert np.allclose(m2.dot(m3), 5 / 4)  # nm^2
-        assert np.allclose(np.rad2deg(m2.angle_with(m3)[0]), 53.30, atol=0.01)
+        assert np.allclose(m2.angle_with(m3, degrees=True)[0], 53.30, atol=0.01)
 
         # Example 1.5: Reciprocal metric tensor
         lattice_recip = lattice.reciprocal()
@@ -545,7 +545,7 @@ class TestDeGraefExamples:
         # Example 1.6, 1.7: Angle between two plane normals
         m4 = Miller(hkl=[1, 2, 0], phase=TETRAGONAL_PHASE)
         m5 = Miller(hkl=[3, 1, 1], phase=TETRAGONAL_PHASE)
-        assert np.allclose(np.rad2deg(m4.angle_with(m5)[0]), 45.7, atol=0.1)
+        assert np.allclose(m4.angle_with(m5, degrees=True)[0], 45.7, atol=0.1)
 
         # Example 1.8: Reciprocal components of a lattice vector
         m6 = Miller(uvw=[1, 1, 4], phase=TETRAGONAL_PHASE)

--- a/orix/tests/test_stereographic_projection.py
+++ b/orix/tests/test_stereographic_projection.py
@@ -63,7 +63,7 @@ class TestStereographicProjection:
         x_desired = [1, 0, -1, 0, 0]
         y_desired = [0, 1, 0, -1, 0]
 
-        sp_up = StereographicProjection(pole=-1)
+        sp_up = StereographicProjection()
         x_up, y_up = sp_up.vector2xy(v)
         assert x_up.size == y_up.size == 5
         assert np.allclose(x_up, x_desired)
@@ -77,7 +77,7 @@ class TestStereographicProjection:
         assert np.allclose(y_down, y_desired[:-1])
 
     def test_vector2xy(self, vectors):
-        sp_up = StereographicProjection(pole=-1)
+        sp_up = StereographicProjection()
         x_up, y_up, x_down, y_down = sp_up.vector2xy_split(v=vectors)
         x1, y1 = sp_up.vector2xy(v=vectors)
         sp_down = StereographicProjection(pole=1)
@@ -89,27 +89,40 @@ class TestStereographicProjection:
         assert np.allclose(y2, y_down)
 
     def test_spherical2xy(self, vectors):
-        sp_up = StereographicProjection(pole=-1)
+        sp_up = StereographicProjection()
         azimuth = vectors.azimuth
         polar = vectors.polar
-        x_up, y_up, x_down, y_down = sp_up.spherical2xy_split(
-            azimuth=azimuth, polar=polar
-        )
-        x1, y1 = sp_up.spherical2xy(azimuth=azimuth, polar=polar)
+        x_up, y_up, x_down, y_down = sp_up.spherical2xy_split(azimuth, polar)
+        x1, y1 = sp_up.spherical2xy(azimuth, polar)
         sp_down = StereographicProjection(pole=1)
-        x2, y2 = sp_down.spherical2xy(azimuth=azimuth, polar=polar)
+        x2, y2 = sp_down.spherical2xy(azimuth, polar)
 
         assert np.allclose(x1, x_up)
         assert np.allclose(y1, y_up)
         assert np.allclose(x2, x_down)
         assert np.allclose(y2, y_down)
 
+        # Degrees
+        azimuth_deg = np.rad2deg(azimuth)
+        polar_deg = np.rad2deg(polar)
+        x_up3, y_up3, x_down3, y_down3 = sp_up.spherical2xy_split(
+            azimuth_deg, polar_deg, degrees=True
+        )
+        x3, y3 = sp_up.spherical2xy(azimuth_deg, polar_deg, degrees=True)
+        sp_down = StereographicProjection(pole=1)
+        x4, y4 = sp_down.spherical2xy(azimuth_deg, polar_deg, degrees=True)
+
+        assert np.allclose(x_up3, x3)
+        assert np.allclose(y_up3, y3)
+        assert np.allclose(x4, x_down3)
+        assert np.allclose(y4, y_down3)
+
     def test_project_loop_xy(self, vectors):
         is_up = vectors.z >= 0
         v_up_in = vectors[is_up]
         v_down_in = vectors[~is_up]
 
-        sp_up = StereographicProjection(pole=-1)
+        sp_up = StereographicProjection()
         sp_down = StereographicProjection(pole=1)
 
         x_up, y_up = sp_up.vector2xy(v_up_in)
@@ -129,19 +142,22 @@ class TestStereographicProjection:
         azimuth_down_in = v_down.azimuth
         polar_down_in = v_down.polar
 
-        sp_up = StereographicProjection(pole=-1)
+        sp_up = StereographicProjection()
         sp_down = StereographicProjection(pole=1)
 
-        x_up, y_up = sp_up.spherical2xy(azimuth=azimuth_up_in, polar=polar_up_in)
-        x_down, y_down = sp_down.spherical2xy(
-            azimuth=azimuth_down_in, polar=polar_down_in
-        )
-        azimuth_up_out, polar_up_out = sp_up.inverse.xy2spherical(x=x_up, y=y_up)
-        azimuth_down_out, polar_down_out = sp_down.inverse.xy2spherical(
-            x=x_down, y=y_down
-        )
+        x_up, y_up = sp_up.spherical2xy(azimuth_up_in, polar_up_in)
+        x_down, y_down = sp_down.spherical2xy(azimuth_down_in, polar_down_in)
+        azimuth_up_out, polar_up_out = sp_up.inverse.xy2spherical(x_up, y_up)
+        azimuth_down_out, polar_down_out = sp_down.inverse.xy2spherical(x_down, y_down)
 
         assert np.allclose(azimuth_up_in, azimuth_up_out)
         assert np.allclose(polar_up_in, polar_up_out)
         assert np.allclose(azimuth_down_in, azimuth_down_out)
         assert np.allclose(polar_down_in, polar_down_out)
+
+        # Degrees
+        azimuth_up_deg, polar_up_deg = sp_up.inverse.xy2spherical(
+            x_up, y_up, degrees=True
+        )
+        assert np.allclose(np.rad2deg(azimuth_up_out), azimuth_up_deg)
+        assert np.allclose(np.rad2deg(polar_up_out), polar_up_deg)

--- a/orix/tests/test_vector3d.py
+++ b/orix/tests/test_vector3d.py
@@ -253,11 +253,12 @@ def test_cross_error(vector, number):
     ],
 )
 def test_polar(azimuth, polar, radial, expected):
-    assert np.allclose(
-        Vector3d.from_polar(azimuth=azimuth, polar=polar, radial=radial).data,
-        expected.data,
-        atol=1e-5,
+    v1 = Vector3d.from_polar(azimuth, polar, radial)
+    v2 = Vector3d.from_polar(
+        np.rad2deg(azimuth), np.rad2deg(polar), radial, degrees=True
     )
+    assert np.allclose(v1.data, expected.data, atol=1e-5)
+    assert np.allclose(v2.data, v1.data, atol=1e-5)
 
 
 @pytest.mark.parametrize(
@@ -597,7 +598,7 @@ class TestVector3dPoleDensityFunction:
     def test_pdf_hemisphere_raises(self):
         v = Vector3d(np.random.randn(100, 3)).unit
         with pytest.raises(ValueError, match=r"Hemisphere must be either "):
-            fig1 = v.pole_density_function(return_figure=True, hemisphere="test")
+            _ = v.pole_density_function(return_figure=True, hemisphere="test")
 
 
 class TestSphericalCoordinates:
@@ -613,6 +614,11 @@ class TestSphericalCoordinates:
         assert np.allclose(polar.data, polar_desired)
         assert np.allclose(azimuth.data, azimuth_desired)
         assert np.allclose(radial.data, radial_desired)
+
+        azimuth2, polar2, radial2 = v.to_polar(degrees=True)
+        assert np.allclose(polar2.data, np.rad2deg(polar_desired))
+        assert np.allclose(azimuth2.data, np.rad2deg(azimuth_desired))
+        assert np.allclose(radial2.data, radial_desired)
 
     def test_polar_loop(self, vector):
         azimuth, polar, radial = vector.to_polar()
@@ -722,10 +728,10 @@ class TestPlotting:
             self.v.scatter(projection="equal_angle")
 
     def test_scatter_reproject(self):
-        o = Orientation.from_axes_angles((-1, 8, 1), np.deg2rad(65))
+        o = Orientation.from_axes_angles((-1, 8, 1), 65, degrees=True)
         v = (symmetry.Oh * o) * Vector3d.zvector()
         # normal scatter: half of the vectors are shown
-        fig1 = v.scatter(hemisphere="upper", reproject=False, return_figure=True)
+        fig1 = v.scatter(hemisphere="upper", return_figure=True)
         assert (
             sum(len(c.get_offsets()) for c in fig1.axes[0].collections) == v.size // 2
         )

--- a/orix/tests/test_vector3d.py
+++ b/orix/tests/test_vector3d.py
@@ -276,11 +276,15 @@ def test_zero(shape):
 
 
 def test_angle_with(vector, something):
-    a = vector.angle_with(vector)
-    assert np.allclose(a, 0)
-    a = vector.angle_with(something)
-    assert np.all(a >= 0)
-    assert np.all(a <= np.pi)
+    a1 = vector.angle_with(vector)
+    assert np.allclose(a1, 0)
+
+    a2 = vector.angle_with(something)
+    assert np.all(a2 >= 0)
+    assert np.all(a2 <= np.pi)
+
+    a3 = vector.angle_with(something, degrees=True)
+    assert np.allclose(np.rad2deg(a2), a3)
 
 
 def test_mul_array(vector):

--- a/orix/vector/miller.py
+++ b/orix/vector/miller.py
@@ -577,8 +577,13 @@ class Miller(Vector3d):
 
     # ------------- Overwritten Vector3d/Object3d methods ------------ #
 
-    def angle_with(self, other: Miller, use_symmetry: bool = False) -> np.ndarray:
-        """Calculate angles between these vectors and the other vectors
+    def angle_with(
+        self,
+        other: Miller,
+        use_symmetry: bool = False,
+        degrees: bool = False,
+    ) -> np.ndarray:
+        """Return the angles between these vectors and the other vectors
         possibly using symmetrically equivalent vectors to find the
         smallest angle under symmetry.
 
@@ -592,13 +597,18 @@ class Miller(Vector3d):
         use_symmetry
             Whether to consider equivalent vectors to find the smallest
             angle under symmetry. Default is ``False``.
+        degrees
+            If ``True``, the given angles are returned in degrees.
+            Default is ``False``.
 
         Returns
         -------
         angles
-            The angle between the vectors, in radians.
+            Angles in radians (``degrees=False``)  or degrees
+            (``degrees=True``).
         """
         self._compatible_with(other, raise_error=True)
+
         if use_symmetry:
             other2 = other.symmetrise(unique=True)
             cosines = self.dot_outer(other2) / (
@@ -606,9 +616,13 @@ class Miller(Vector3d):
             )
             cosines = np.round(cosines, 12)
             angles = np.min(np.arccos(cosines), axis=-1)
-            return angles
         else:
-            return super().angle_with(other)
+            angles = super().angle_with(other)
+
+        if degrees:
+            angles = np.rad2deg(angles)
+
+        return angles
 
     def cross(self, other: Miller):
         """Return the cross products of the vectors with the other

--- a/orix/vector/neo_euler.py
+++ b/orix/vector/neo_euler.py
@@ -165,17 +165,21 @@ class AxAngle(NeoEuler):
     def from_axes_angles(
         cls,
         axes: Union[Vector3d, np.ndarray, list, tuple],
-        angles: Union[np.ndarray, list, tuple],
+        angles: Union[np.ndarray, list, tuple, float],
+        degrees: bool = False,
     ) -> AxAngle:
-        """Create new AxAngle object explicitly from the given axes and
-        angles.
+        """Initialize from axes and angles.
 
         Parameters
         ----------
         axes
-            The axes of rotation.
+            Axes of rotation.
         angles
-            The angles of rotation, in radians.
+            Angles of rotation in radians (``degrees=False``) or degrees
+            (``degrees=True``).
+        degrees
+            If ``True``, the given angles are assumed to be in degrees.
+            Default is ``False``.
 
         Returns
         -------
@@ -183,6 +187,8 @@ class AxAngle(NeoEuler):
             Axis-angle instance of the axes and angles.
         """
         axes = Vector3d(axes).unit
+        if degrees:
+            angles = np.deg2rad(angles)
         angles = np.array(angles)
         axangle_data = angles[..., np.newaxis] * axes.data
         return cls(axangle_data)

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -476,8 +476,8 @@ class Vector3d(Object3d):
         """Return a unit vector in the z-direction."""
         return cls((0, 0, 1))
 
-    def angle_with(self, other: Vector3d) -> np.ndarray:
-        """Calculate the angles between these vectors in other vectors.
+    def angle_with(self, other: Vector3d, degrees: bool = False) -> np.ndarray:
+        """Return the angles between these vectors in other vectors.
 
         Vectors must have compatible shapes for broadcasting to work.
 
@@ -485,14 +485,21 @@ class Vector3d(Object3d):
         ----------
         other
             Another vector.
+        degrees
+            If ``True``, the given angles are returned in degrees.
+            Default is ``False``.
 
         Returns
         -------
         angles
-            The angle between the vectors, in radians.
+            Angles in radians (``degrees=False``)  or degrees
+            (``degrees=True``).
         """
         cosines = np.round(self.dot(other) / self.norm / other.norm, 10)
-        return np.arccos(cosines)
+        angles = np.arccos(cosines)
+        if degrees:
+            angles = np.rad2deg(angles)
+        return angles
 
     def rotate(
         self,

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -407,20 +407,28 @@ class Vector3d(Object3d):
 
     @classmethod
     def from_polar(
-        cls, azimuth: np.ndarray, polar: np.ndarray, radial: float = 1.0
+        cls,
+        azimuth: Union[np.ndarray, list, tuple, float],
+        polar: Union[np.ndarray, list, tuple, float],
+        radial: float = 1.0,
+        degrees: bool = False,
     ) -> Vector3d:
-        """Create a :class:`Vector3d` from spherical coordinates
-        according to the ISO 31-11 standard
-        :cite:`weisstein2005spherical`.
+        """Initialize from spherical coordinates according to the ISO
+        31-11 standard :cite:`weisstein2005spherical`.
 
         Parameters
         ----------
         azimuth
-            The azimuth angle, in radians.
+            Azimuth angle(s) in radians (``degrees=False``) or degrees
+            (``degrees=True``).
         polar
-            The polar angle, in radians.
+            Polar angle(s) in radians (``degrees=False``) or degrees
+            (``degrees=True``).
         radial
-            The radial distance. Defaults to 1 to produce unit vectors.
+            Radial distance. Defaults to 1 to produce unit vectors.
+        degrees
+            If ``True``, the angles are assumed to be in degrees.
+            Default is ``False``.
 
         Returns
         -------
@@ -428,6 +436,9 @@ class Vector3d(Object3d):
         """
         azimuth = np.atleast_1d(azimuth)
         polar = np.atleast_1d(polar)
+        if degrees:
+            azimuth = np.deg2rad(azimuth)
+            polar = np.deg2rad(polar)
         sin_polar = np.sin(polar)
         x = np.cos(azimuth) * sin_polar
         y = np.sin(azimuth) * sin_polar
@@ -589,22 +600,36 @@ class Vector3d(Object3d):
         axis = tuple(range(self.ndim))
         return self.__class__(self.data.mean(axis=axis))
 
-    def to_polar(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    def to_polar(
+        self, degrees: bool = False
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         r"""Return the azimuth :math:`\phi`, polar :math:`\theta`, and
-        radial :math:`r` spherical coordinates, the angles in radians.
-        The coordinates are defined as in the ISO 31-11 standard
-        :cite:`weisstein2005spherical`.
+        radial :math:`r` spherical coordinates defined as in the ISO
+        31-11 standard :cite:`weisstein2005spherical`.
+
+        Parameters
+        ----------
+        degrees
+            If ``True``, the given angles are returned in degrees.
+            Default is ``False``.
 
         Returns
         -------
         azimuth
-            Azimuth angles.
+            Azimuth angles in radians (``degrees=False``) or degrees
+            (``degrees=True``).
         polar
-            Polar angles.
+            Polar angles in radians (``degrees=False``) or degrees
+            (``degrees=True``).
         radial
             Radial values.
         """
-        return self.azimuth, self.polar, self.radial
+        azimuth = self.azimuth
+        polar = self.polar
+        if degrees:
+            azimuth = np.rad2deg(azimuth)
+            polar = np.rad2deg(polar)
+        return azimuth, polar, self.radial
 
     def in_fundamental_sector(self, symmetry: "Symmetry") -> Vector3d:
         """Project vectors to a symmetry's fundamental sector (inverse


### PR DESCRIPTION
#### Description of the change
No more `np.rad2deg(rot1.angle_with(rot2))` or `Rotation.from_euler(np.deg2rad([45, 90, 45]))`!

This PR adds the option to either pass or get angles as degrees in the following methods:
- InverseStereographicProjection
    - xy2spherical()
- StereographicProjection
    - spherical2xy()
    - spherical2xy_split()
- Quaternion
    - from_axes_angles()
    - from_euler()
    - to_euler()
- Rotation
    - angle_with()
    - angle_with_outer()
    - from_axes_angles()
    - from_euler()
    - to_euler()
- Misorientation
    - angle_with()
    - angle_with_outer()
    - from_axes_angles()
    - from_euler()
    - get_distance_matrix()
- Orientation
    - angle_with()
    - angle_with_outer()
    - from_euler()
    - get_distance_matrix()
- AxAngle
    - from_axes_angles()
- Miller
    - angle_with()
- Vector3d
    - angle_with()
    - from_polar()
    - to_polar()

Did I forget any? Please say so!

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)
- [x] Use new functionality in user guide (tutorials, examples)

#### Minimal example of the bug fix or new feature
```python
>>> from orix.quaternion import Rotation
>>> r1 = Rotation.from_euler([0, 90, 0], degrees=True)
>>> r2 = Rotation.from_axes_angles([1, 0, 0], 90, degrees=True)
>>> r1.angle_with(r2, degrees=True)
array([180.])
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.