### PR TITLE
Remove deprecated z coordinate in CrystalMap and related "3D functionality"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,14 @@ Deprecated
 
 Removed
 -------
+- Parameter ``z`` when creating a ``CrystalMap`` and the ``z`` and ``dz`` attributes of
+  the class were deprecated in 0.10.1 and are now removed.
+- Passing ``shape`` or ``step_sizes`` with three values to
+  ``create_coordinate_arrays()`` was depreacted in 0.10. and will now raise an error.
+- Parameter ``depth`` (and ``axes``) in ``CrystalMapPlot.plot_map()`` was depreacted in
+  0.10.1 and will now raise an error if passed.
+- The ``z`` and ``dz`` datasets are not present in new orix HDF5 files. They are not
+  read if present in older files.
 
 Fixed
 -----

--- a/orix/io/plugins/ang.py
+++ b/orix/io/plugins/ang.py
@@ -451,8 +451,6 @@ def file_writer(
         value per point and ``index`` is not given, only the first value
         is used.
     """
-    if xmap.ndim > 2:
-        raise ValueError("Writing a 3D dataset to an .ang file is not supported")
     header = _get_header_from_phases(xmap)
 
     # Number of decimals to round to

--- a/orix/io/plugins/orix_hdf5.py
+++ b/orix/io/plugins/orix_hdf5.py
@@ -22,7 +22,6 @@ format.
 
 import copy
 from typing import Optional
-import warnings
 from warnings import warn
 
 from diffpy.structure import Atom, Lattice, Structure

--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 from matplotlib.axes import Axes
 import matplotlib.colorbar as mbar
@@ -29,20 +29,16 @@ from matplotlib_scalebar.scalebar import ScaleBar
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 import numpy as np
 
-from orix._util import deprecated_argument
-
 
 class CrystalMapPlot(Axes):
     """Plotting of a :class:`~orix.crystal_map.crystal_map.CrystalMap`."""
 
     name = "plot_map"
     _data_axes = None
-    _data_slices = None
     _data_shape = None
     colorbar = None
     scalebar = None
 
-    @deprecated_argument(name="depth", since="0.10.1", removal="0.11.0")
     def plot_map(
         self,
         crystal_map: "orix.crystal_map.CrystalMap",
@@ -51,8 +47,6 @@ class CrystalMapPlot(Axes):
         scalebar_properties: Optional[dict] = None,
         legend: bool = True,
         legend_properties: Optional[dict] = None,
-        axes: Tuple[int] = None,
-        depth: Optional[int] = None,
         override_status_bar: bool = False,
         **kwargs,
     ) -> AxesImage:
@@ -81,24 +75,6 @@ class CrystalMapPlot(Axes):
         legend_properties
             Dictionary of keyword arguments passed to
             :meth:`matplotlib.axes.Axes.legend`.
-        axes
-            Which data axes to plot if data has more than two
-            dimensions. The index of data to plot in the final dimension
-            is determined by ``depth``. If ``None`` (default), data
-            along the two last axes is plotted.
-        depth
-            Which layer along the third axis to plot if data has more
-            than two dimensions. If ``None`` (default), data in the
-            first index (layer) is plotted.
-
-            .. deprecated:: 0.10.1
-
-                Will be removed in 0.11.0. Support for 3D crystal maps
-                is minimal and brittle, and it was therefore decided to
-                remove it altogether. If you rely on this functionality,
-                please report it in an issue at
-                https://github.com/pyxem/orix/issues.
-
         override_status_bar
             Whether to display Euler angles and any overlay values in
             the status bar when hovering over the map (default is
@@ -168,13 +144,12 @@ class CrystalMapPlot(Axes):
 
         >>> #plt.imsave("image2.png", im.get_array())
         """
-        self._set_plot_shape(crystal_map=crystal_map, axes=axes, depth=depth)
+        self._data_shape = crystal_map._original_shape
 
         patches = None
         if value is None:  # Phase map
             # Color each map pixel with corresponding phase color RGB tuple
             phase_id = crystal_map.get_map_data("phase_id")
-            phase_id = phase_id[self._data_slices]
             unique_phase_ids = np.unique(phase_id[~np.isnan(phase_id)])
             data = np.ones(phase_id.shape + (3,))
             for i, color in zip(
@@ -189,7 +164,6 @@ class CrystalMapPlot(Axes):
                 patches.append(mpatches.Patch(color=p.color_rgb, label=p.name))
         else:  # Create masked array of correct shape
             data = crystal_map.get_map_data(value)
-            data = data[self._data_slices]
 
         # Remove 1-dimensions
         data = np.squeeze(data)
@@ -406,55 +380,6 @@ class CrystalMapPlot(Axes):
             right = 1
         self.figure.subplots_adjust(top=1, bottom=0, right=right, left=0)
 
-    # TODO: Remove depth argument after (any) one release after 0.10.0
-    def _set_plot_shape(
-        self,
-        crystal_map: "orix.crystal_map.CrystalMap",
-        axes: Optional[List[int]] = None,
-        depth: Optional[int] = None,
-    ):
-        """Set `CrystalMapPlot` attributes describing which data axes to
-        plot.
-
-        Parameters
-        ----------
-        crystal_map
-            Map to determine plotting axes and slices from.
-        axes
-            Data axes to plot. If ``None``, the last two data axes are
-            plotted (default).
-        depth
-            Which data layer to plot along the final axis not in `axes`
-            if data is 3D. If ``None``, this is set to zero, i.e. the
-            first layer (default).
-        """
-        ndim = crystal_map.ndim
-
-        # Get data axes to plot
-        if axes is None:
-            axes = [ndim - 2, ndim - 1]
-        axes = list(axes)
-        axes.sort()
-        self._data_axes = axes[:2]  # Can only plot two axes!
-
-        if depth is None:  # Plot first layer
-            depth = 0
-
-        # Get data slices to plot
-        slices = []
-        data_shape = []
-        for data_axis, axis_size in zip(
-            crystal_map._coordinate_axes.keys(), crystal_map._original_shape
-        ):
-            data_slice = slice(depth, depth + 1, None)
-            for plot_axis in self._data_axes:
-                if data_axis == plot_axis:
-                    data_slice = slice(None, None, None)
-                    data_shape.append(axis_size)
-            slices.append(data_slice)
-        self._data_slices = tuple(slices)
-        self._data_shape = tuple(data_shape)
-
     def _add_legend(self, patches: List[mpatches.Patch], **kwargs):
         """Add a legend to the axes object.
 
@@ -506,7 +431,6 @@ class CrystalMapPlot(Axes):
         # TODO: Show orientations in Euler angles (computationally
         #  intensive...)
         r = crystal_map.get_map_data("rotations", decimals=3)
-        r = r[self._data_slices].squeeze()
 
         # Get image data, overwriting potentially masked regions set to 0.0
         image_data = image.get_array()  # numpy.masked.MaskedArray

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -19,7 +19,6 @@
 import gc
 import os
 from tempfile import TemporaryDirectory
-import warnings
 
 from diffpy.structure import Atom, Lattice, Structure
 from h5py import File
@@ -636,8 +635,8 @@ def phase_list(request):
         (
             # Tuple with default values for parameters: map_shape, step_sizes,
             # and n_rotations_per_point
-            (1, 4, 3),  # map_shape
-            (0, 1.5, 1.5),  # step_sizes
+            (4, 3),  # map_shape
+            (1.5, 1.5),  # step_sizes
             1,  # rotations_per_point
             [0],  # unique phase IDs
         )
@@ -645,11 +644,8 @@ def phase_list(request):
 )
 def crystal_map_input(request, rotations):
     # Unpack parameters
-    (nz, ny, nx), (dz, dy, dx), rotations_per_point, unique_phase_ids = request.param
-    # TODO: Remove after (any) one release after 0.10.1
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", "Returning coo", np.VisibleDeprecationWarning)
-        d, map_size = create_coordinate_arrays((nz, ny, nx), (dz, dy, dx))
+    (ny, nx), (dy, dx), rotations_per_point, unique_phase_ids = request.param
+    d, map_size = create_coordinate_arrays((ny, nx), (dy, dx))
     rot_idx = np.random.choice(
         np.arange(rotations.size), map_size * rotations_per_point
     )
@@ -666,10 +662,7 @@ def crystal_map_input(request, rotations):
 
 @pytest.fixture
 def crystal_map(crystal_map_input):
-    # TODO: Remove after (any) one release after 0.10.1
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", "Argument `z` ", np.VisibleDeprecationWarning)
-        return CrystalMap(**crystal_map_input)
+    return CrystalMap(**crystal_map_input)
 
 
 @pytest.fixture

--- a/orix/tests/io/test_ang.py
+++ b/orix/tests/io/test_ang.py
@@ -34,8 +34,6 @@ from orix.tests.conftest import (
     ANGFILE_TSL_HEADER,
 )
 
-# TODO: Remove all pytest.mark.filterwarnings after (any) one release after 0.10.1
-
 
 @pytest.mark.parametrize(
     "angfile_astar, expected_data",
@@ -83,7 +81,6 @@ def test_loadang(angfile_astar, expected_data):
     assert np.allclose(loaded_data.data, expected_data)
 
 
-@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in")
 class TestAngReader:
     @pytest.mark.parametrize(
         "angfile_tsl, map_shape, step_sizes, phase_id, n_unknown_cols, example_rot",
@@ -305,8 +302,8 @@ class TestAngReader:
             ),
             (
                 (
-                    (3, 6),  # map_shape
-                    (10, 10),  # step_sizes
+                    (3, 6),
+                    (10, 10),
                     np.concatenate(
                         (
                             np.ones(int(np.ceil((3 * 6) / 2))),
@@ -511,7 +508,6 @@ class TestAngReader:
         assert np.allclose(ids, expected_phase_id)
 
 
-@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in")
 class TestAngWriter:
     def test_write_read_loop(self, crystal_map, tmp_path):
         fname = tmp_path / "test_write_read_loop.ang"
@@ -527,9 +523,9 @@ class TestAngWriter:
     @pytest.mark.parametrize(
         "crystal_map_input, desired_shape, desired_step_sizes",
         [
-            (((1, 4, 3), (1, 2, 3), 1, [0]), (4, 3), (2, 3)),
-            (((1, 1, 3), (1, 1, 1), 1, [0]), (1, 3), (1, 1)),
-            (((1, 1, 6), (1, 1, 3.14), 1, [0]), (1, 6), (1, 3.14)),
+            (((4, 3), (2, 3), 1, [0]), (4, 3), (2, 3)),
+            (((1, 3), (1, 1), 1, [0]), (1, 3), (1, 1)),
+            (((1, 6), (1, 3.14), 1, [0]), (1, 6), (1, 3.14)),
         ],
         indirect=["crystal_map_input"],
     )
@@ -623,7 +619,7 @@ class TestAngWriter:
 
     @pytest.mark.parametrize(
         "crystal_map_input",
-        [((1, 1, 5), (1, 1, 2), 1, [0])],
+        [((1, 5), (1, 2), 1, [0])],
         indirect=["crystal_map_input"],
     )
     def test_1d_map(self, crystal_map_input, tmp_path):
@@ -638,22 +634,11 @@ class TestAngWriter:
         assert np.allclose(xmap.rotations.to_euler(), xmap_reload.rotations.to_euler())
 
     @pytest.mark.parametrize(
-        "crystal_map_input",
-        [((3, 3, 3), (1, 2, 3), 1, [0])],
-        indirect=["crystal_map_input"],
-    )
-    def test_3d_map_raises(self, crystal_map_input, tmp_path):
-        xmap = CrystalMap(**crystal_map_input)
-        fname = tmp_path / "test_3d_raises.ang"
-        with pytest.raises(ValueError, match="Writing a 3D dataset to an .ang file"):
-            save(fname, xmap)
-
-    @pytest.mark.parametrize(
         "crystal_map_input, index",
         [
-            (((1, 4, 3), (1, 2, 3), 5, [0]), 0),
-            (((1, 4, 3), (1, 2, 3), 5, [0]), 1),
-            (((1, 4, 3), (1, 2, 3), 5, [0]), 4),
+            (((4, 3), (2, 3), 5, [0]), 0),
+            (((4, 3), (2, 3), 5, [0]), 1),
+            (((4, 3), (2, 3), 5, [0]), 4),
         ],
         indirect=["crystal_map_input"],
     )
@@ -677,7 +662,7 @@ class TestAngWriter:
 
     @pytest.mark.parametrize(
         "crystal_map_input",
-        [((1, 4, 3), (1, 2, 2), 2, [0])],
+        [((4, 3), (2, 2), 2, [0])],
         indirect=["crystal_map_input"],
     )
     def test_write_data_index_none(self, crystal_map_input, tmp_path):

--- a/orix/tests/io/test_io.py
+++ b/orix/tests/io/test_io.py
@@ -31,9 +31,7 @@ import pytest
 from orix.crystal_map import Phase, PhaseList
 from orix.io import _overwrite_or_not, _plugin_from_manufacturer, load, loadctf, save
 from orix.io.plugins import bruker_h5ebsd, emsoft_h5ebsd, orix_hdf5
-from orix.quaternion.rotation import Rotation
-
-# TODO: Remove all pytest.mark.filterwarnings after (any) one release after 0.10.1
+from orix.quaternion import Rotation
 
 
 @contextmanager
@@ -69,7 +67,6 @@ def assert_dictionaries_are_equal(input_dict, output_dict):
                 assert input_value == output_value
 
 
-@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in")
 class TestGeneralIO:
     def test_load_no_filename_match(self):
         fname = "what_is_hip.ang"

--- a/orix/tests/io/test_orix_hdf5.py
+++ b/orix/tests/io/test_orix_hdf5.py
@@ -41,11 +41,7 @@ from orix.io.plugins.orix_hdf5 import (
 )
 from orix.tests.io.test_io import assert_dictionaries_are_equal
 
-# TODO: Remove all pytest.mark.filterwarnings after (any) one release after 0.10.1
 
-
-@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in")
-@pytest.mark.filterwarnings("ignore:Property `dz` is deprecated and will be removed in")
 class TestOrixHDF5Plugin:
     def test_file_writer(self, crystal_map, temp_file_path):
         save(filename=temp_file_path, object2write=crystal_map)
@@ -57,23 +53,23 @@ class TestOrixHDF5Plugin:
     @pytest.mark.parametrize(
         "crystal_map_input",
         [
-            ((4, 4, 3), (1, 1.5, 1.5), 1, [0, 1]),
-            ((2, 4, 3), (1, 1.5, 1.5), 2, [0, 1, 2]),
+            ((4, 3), (1.5, 1.5), 1, [0, 1]),
+            ((4, 3), (1.5, 1.5), 2, [0, 1, 2]),
         ],
         indirect=["crystal_map_input"],
     )
     def test_write_read_masked(self, crystal_map_input, temp_file_path):
-        cm = CrystalMap(**crystal_map_input)
-        save(filename=temp_file_path, object2write=cm[cm.x > 2])
-        cm2 = load(temp_file_path)
+        xmap = CrystalMap(**crystal_map_input)
+        save(filename=temp_file_path, object2write=xmap[xmap.x > 2])
+        xmap2 = load(temp_file_path)
 
-        assert cm2.size != cm.size
+        assert xmap2.size != xmap.size
         with pytest.raises(ValueError, match="operands could not be broadcast"):
-            _ = np.allclose(cm2.x, cm.x)
+            _ = np.allclose(xmap2.x, xmap.x)
 
-        cm2.is_in_data = cm.is_in_data
-        assert cm2.size == cm.size
-        assert np.allclose(cm2.x, cm.x)
+        xmap2.is_in_data = xmap.is_in_data
+        assert xmap2.size == xmap.size
+        assert np.allclose(xmap2.x, xmap.x)
 
     def test_file_writer_raises(self, temp_file_path, crystal_map):
         with pytest.raises(OSError, match="Cannot write to the already open file "):
@@ -89,17 +85,17 @@ class TestOrixHDF5Plugin:
                 )
 
     def test_crystalmap2dict(self, crystal_map_input):
-        cm = CrystalMap(**crystal_map_input)
-        cm_dict = crystalmap2dict(cm)
+        xmap = CrystalMap(**crystal_map_input)
+        xmap_dict = crystalmap2dict(xmap)
 
         this_dict = {"hello": "there"}
-        cm_dict2 = crystalmap2dict(cm, dictionary=this_dict)
+        cm_dict2 = crystalmap2dict(xmap, dictionary=this_dict)
 
         cm_dict2.pop("hello")
-        assert_dictionaries_are_equal(cm_dict, cm_dict2)
+        assert_dictionaries_are_equal(xmap_dict, cm_dict2)
 
-        assert np.allclose(cm_dict["data"]["x"], crystal_map_input["x"])
-        assert cm_dict["header"]["z_step"] == cm.dz
+        assert np.allclose(xmap_dict["data"]["x"], crystal_map_input["x"])
+        assert xmap_dict["header"]["y_step"] == xmap.dy
 
     def test_phaselist2dict(self, phase_list):
         pl_dict = phaselist2dict(phase_list)
@@ -148,12 +144,12 @@ class TestOrixHDF5Plugin:
 
     def test_file_reader(self, crystal_map, temp_file_path):
         save(filename=temp_file_path, object2write=crystal_map)
-        cm2 = load(filename=temp_file_path)
-        assert_dictionaries_are_equal(crystal_map.__dict__, cm2.__dict__)
+        xmap2 = load(filename=temp_file_path)
+        assert_dictionaries_are_equal(crystal_map.__dict__, xmap2.__dict__)
 
     def test_dict2crystalmap(self, crystal_map):
-        cm2 = dict2crystalmap(crystalmap2dict(crystal_map))
-        assert_dictionaries_are_equal(crystal_map.__dict__, cm2.__dict__)
+        xmap2 = dict2crystalmap(crystalmap2dict(crystal_map))
+        assert_dictionaries_are_equal(crystal_map.__dict__, xmap2.__dict__)
 
     def test_dict2phaselist(self, phase_list):
         phase_list2 = dict2phaselist(phaselist2dict(phase_list))
@@ -162,10 +158,12 @@ class TestOrixHDF5Plugin:
         assert phase_list.ids == phase_list2.ids
         assert phase_list.names == phase_list2.names
         assert phase_list.colors == phase_list2.colors
-        assert [
-            s1.name == s2.name
-            for s1, s2 in zip(phase_list.point_groups, phase_list2.point_groups)
-        ]
+        assert all(
+            [
+                s1.name == s2.name
+                for s1, s2 in zip(phase_list.point_groups, phase_list2.point_groups)
+            ]
+        )
 
     def test_dict2phase(self, phase_list):
         phase1 = phase_list[0]
@@ -183,10 +181,6 @@ class TestOrixHDF5Plugin:
         phase_dict = phase2dict(phase1)
         phase2 = dict2phase(phase_dict)
         assert phase1.space_group.number == phase2.space_group.number
-
-        phase_dict.pop("space_group")
-        phase3 = dict2phase(phase_dict)
-        assert phase3.space_group is None
 
     def test_dict2structure(self, phase_list):
         structure1 = phase_list[0].structure
@@ -214,25 +208,6 @@ class TestOrixHDF5Plugin:
         assert str(atom.element) == str(atom2.element)
         assert np.allclose(atom.xyz, atom2.xyz)
 
-    def test_read_point_group_from_v0_3_x(self, temp_file_path, crystal_map):
-        crystal_map.phases[0].point_group = "1"
-        save(filename=temp_file_path, object2write=crystal_map)
-
-        # First, ensure point group data set name is named "symmetry", as in v0.3.0
-        with File(temp_file_path, mode="r+") as f:
-            for phase in f["crystal_map/header/phases"].values():
-                phase["symmetry"] = phase["point_group"]
-                del phase["point_group"]
-
-        # Then, make sure it can still be read
-        cm2 = load(filename=temp_file_path)
-        # And that the symmetry operations are the same, for good measure
-        print(crystal_map)
-        print(cm2)
-        assert np.allclose(
-            crystal_map.phases[0].point_group.data, cm2.phases[0].point_group.data
-        )
-
     def test_write_read_nd_crystalmap_properties(self, temp_file_path, crystal_map):
         """Crystal map properties with more than one value in each point
         (e.g. top matching scores from dictionary indexing) can be written
@@ -258,11 +233,3 @@ class TestOrixHDF5Plugin:
         assert np.allclose(xmap2.prop[prop3d_name], xmap.prop[prop3d_name])
         assert np.allclose(xmap2.prop[prop2d_name].reshape(prop2d_shape), prop2d)
         assert np.allclose(xmap2.prop[prop3d_name].reshape(prop3d_shape), prop3d)
-
-    def test_write_read_2d(self, temp_file_path, crystal_map_input):
-        crystal_map_input["z"] = None
-        xmap = CrystalMap(**crystal_map_input)
-        assert xmap._coordinates["z"] is None
-        save(filename=temp_file_path, object2write=xmap)
-        xmap2 = load(temp_file_path)
-        assert xmap2._coordinates["z"] is None

--- a/orix/tests/plot/test_crystal_map_plot.py
+++ b/orix/tests/plot/test_crystal_map_plot.py
@@ -31,41 +31,35 @@ from orix.plot import CrystalMapPlot
 PLOT_MAP = "plot_map"
 
 
-# TODO: Remove all pytest.mark.filterwarnings after (any) one release after 0.10.1,
-#  after the warnings themselves are removed
-
-
-@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in ")
-@pytest.mark.filterwarnings("ignore:Argument `depth` is deprecated and will be removed")
 class TestCrystalMapPlot:
     @pytest.mark.parametrize(
         "crystal_map_input, expected_data_shape",
         [
-            (((1, 10, 20), (0, 1.5, 1.5), 1, [0]), (10, 20, 3)),
-            (((1, 4, 3), (0, 0.1, 0.1), 1, [0]), (4, 3, 3)),
+            (((10, 20), (1.5, 1.5), 1, [0]), (10, 20, 3)),
+            (((4, 3), (0.1, 0.1), 1, [0]), (4, 3, 3)),
         ],
         indirect=["crystal_map_input"],
     )
     def test_plot_phase(self, crystal_map_input, phase_list, expected_data_shape):
-        cm = CrystalMap(**crystal_map_input)
+        xmap = CrystalMap(**crystal_map_input)
 
-        assert np.unique(cm.phase_id) == np.array([0])  # Test code assumption
+        assert np.unique(xmap.phase_id) == np.array([0])  # Test code assumption
         assert phase_list.ids == [0, 1, 2]
-        cm.phases = phase_list
-        cm[0, 0].phase_id = 0
-        cm[1, 1].phase_id = 2
+        xmap.phases = phase_list
+        xmap[0, 0].phase_id = 0
+        xmap[1, 1].phase_id = 2
 
         fig = plt.figure()
         ax = fig.add_subplot(projection=PLOT_MAP)
-        im = ax.plot_map(cm)
+        im = ax.plot_map(xmap)
 
         # Expected image data
-        phase_id = cm.get_map_data("phase_id")
+        phase_id = xmap.get_map_data("phase_id")
         unique_phase_ids = np.unique(phase_id[~np.isnan(phase_id)])
         expected_data = np.ones(phase_id.shape + (3,))
-        for i, color in zip(unique_phase_ids, cm.phases_in_data.colors_rgb):
+        for i, color in zip(unique_phase_ids, xmap.phases_in_data.colors_rgb):
             mask = phase_id == int(i)
-            expected_data[mask] = expected_data[mask] * color
+            expected_data[mask] *= color
 
         image_data = im.get_array()
         assert np.allclose(image_data.shape, expected_data_shape)
@@ -74,94 +68,87 @@ class TestCrystalMapPlot:
         plt.close("all")
 
     def test_plot_property(self, crystal_map):
-        cm = crystal_map
+        xmap = crystal_map
 
         prop_name = "iq"
-        prop_data = np.arange(cm.size)
-        cm.prop[prop_name] = prop_data
+        prop_data = np.arange(xmap.size)
+        xmap.prop[prop_name] = prop_data
 
         fig = plt.figure()
         ax = fig.add_subplot(projection=PLOT_MAP)
-        im = ax.plot_map(cm, cm.iq)
+        im = ax.plot_map(xmap, xmap.iq)
 
-        assert np.allclose(im.get_array(), prop_data.reshape(cm.shape))
+        assert np.allclose(im.get_array(), prop_data.reshape(xmap.shape))
 
         plt.close("all")
 
     def test_plot_scalar(self, crystal_map):
-        cm = crystal_map
+        xmap = crystal_map
 
-        angles = cm.rotations.angle
+        angles = xmap.rotations.angle
 
         fig1 = plt.figure()
         ax1 = fig1.add_subplot(projection=PLOT_MAP)
         # Test use of `vmax` as well
-        im1 = ax1.plot_map(cm, angles, vmax=angles.max() - 10)
+        im1 = ax1.plot_map(xmap, angles, vmax=angles.max() - 10)
 
-        assert np.allclose(im1.get_array(), angles.reshape(cm.shape), atol=1e-3)
+        assert np.allclose(im1.get_array(), angles.reshape(xmap.shape), atol=1e-3)
 
         fig2 = plt.figure()
         ax2 = fig2.add_subplot(projection=PLOT_MAP)
-        im2 = ax2.plot_map(cm, cm.rotations.angle)
+        im2 = ax2.plot_map(xmap, xmap.rotations.angle)
 
-        assert np.allclose(im2.get_array(), angles.reshape(cm.shape), atol=1e-3)
+        assert np.allclose(im2.get_array(), angles.reshape(xmap.shape), atol=1e-3)
 
         plt.close("all")
 
     @pytest.mark.parametrize(
         "crystal_map_input",
-        [((2, 9, 3), (1, 1.5, 1.5), 1, [0]), ((2, 10, 5), (1, 0.1, 0.1), 1, [0])],
+        [((9, 3), (1.5, 1.5), 1, [0]), ((10, 5), (0.1, 0.1), 1, [0])],
         indirect=["crystal_map_input"],
     )
     def test_plot_masked_phase(self, crystal_map_input, phase_list):
-        cm = CrystalMap(**crystal_map_input)
+        xmap = CrystalMap(**crystal_map_input)
 
         # Test code assumptions
-        assert np.unique(cm.phase_id) == np.array([0])
+        assert np.unique(xmap.phase_id) == np.array([0])
         assert phase_list.ids == [0, 1, 2]
-        assert cm.ndim == 3
+        assert xmap.ndim == 2
 
-        cm.phases = phase_list
+        xmap.phases = phase_list
 
-        cm[0, :2, :1].phase_id = 1
-        cm[1, 2:4, :1].phase_id = 2
-        assert np.allclose(np.unique(cm.phase_id), np.array([0, 1, 2]))
+        xmap[:2, :1].phase_id = 1
+        xmap[2:4, :1].phase_id = 2
+        assert np.allclose(np.unique(xmap.phase_id), np.array([0, 1, 2]))
 
         # One phase plot per masked map
         for i, phase in phase_list:
             fig = plt.figure()
             ax = fig.add_subplot(projection=PLOT_MAP)
-            _ = ax.plot_map(cm[cm.phase_id == i])
+            _ = ax.plot_map(xmap[xmap.phase_id == i])
 
         plt.close("all")
 
     @pytest.mark.parametrize(
         "crystal_map_input",
-        [((2, 9, 6), (1, 1.5, 1.5), 2, [0]), ((2, 10, 5), (1, 0.1, 0.1), 1, [0])],
+        [((9, 6), (1.5, 1.5), 2, [0]), ((10, 5), (0.1, 0.1), 1, [0])],
         indirect=["crystal_map_input"],
     )
     def test_plot_masked_scalar(self, crystal_map_input):
-        cm = CrystalMap(**crystal_map_input)
+        xmap = CrystalMap(**crystal_map_input)
 
-        cm.prop["test"] = np.zeros(cm.size)
-        cm[1, 5, 4].test = 1
+        xmap.prop["test"] = np.zeros(xmap.size)
+        xmap[5, 4].test = 1
 
-        fig1 = plt.figure()
-        ax1 = fig1.add_subplot(projection=PLOT_MAP)
-        im1 = ax1.plot_map(cm, cm.test)
+        fig = plt.figure()
+        ax = fig.add_subplot(projection=PLOT_MAP)
+        im = ax.plot_map(xmap, xmap.test)
 
-        fig2 = plt.figure()
-        ax2 = fig2.add_subplot(projection=PLOT_MAP)
-        im2 = ax2.plot_map(cm, cm.test, depth=1)
+        expected_data_im = np.zeros(ax._data_shape)
+        expected_data_im[5, 4] = 1
 
-        expected_data_im1 = np.zeros(ax1._data_shape)
-        expected_data_im2 = np.zeros(ax2._data_shape)
-        expected_data_im2[5, 4] = 1
-
-        im1_data = im1.get_array()
-        im2_data = im2.get_array()
-        assert np.allclose(im1_data, expected_data_im1)
-        assert np.allclose(im2_data, expected_data_im2)
+        im_data = im.get_array()
+        assert np.allclose(im_data, expected_data_im)
 
         plt.close("all")
 
@@ -177,8 +164,6 @@ class TestCrystalMapPlot:
         plt.close("all")
 
 
-@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in ")
-@pytest.mark.filterwarnings("ignore:Argument `depth` is deprecated and will be removed")
 class TestCrystalMapPlotUtilities:
     def test_init_projection(self):
         # Option 1
@@ -194,25 +179,25 @@ class TestCrystalMapPlotUtilities:
         plt.close("all")
 
     @pytest.mark.parametrize(
-        "crystal_map_input, idx_to_change, axes, depth, expected_plot_shape",
+        "crystal_map_input, idx_to_change, expected_plot_shape",
         [
-            (((2, 10, 20), (1, 1.5, 1.5), 1, [0]), (1, 5, 4), (1, 2), 1, (10, 20)),
-            (((4, 4, 3), (0.1, 0.1, 0.1), 1, [0]), (0, 0, 2), (0, 1), 2, (4, 4)),
-            (((10, 10, 10), (1, 1, 1), 2, [0]), (-1, 8, -1), (0, 2), 8, (10, 10)),
+            (((10, 20), (1.5, 1.5), 1, [0]), (5, 4), (10, 20)),
+            (((4, 3), (0.1, 0.1), 1, [0]), (0, 2), (4, 3)),
+            (((10, 10), (1, 1), 2, [0]), (8, -1), (10, 10)),
         ],
         indirect=["crystal_map_input"],
     )
     def test_get_plot_shape(
-        self, crystal_map_input, idx_to_change, axes, depth, expected_plot_shape
+        self, crystal_map_input, idx_to_change, expected_plot_shape
     ):
-        cm = CrystalMap(**crystal_map_input)
+        xmap = CrystalMap(**crystal_map_input)
 
-        cm.prop["test"] = np.zeros(cm.size)
-        cm[idx_to_change].test = 1
+        xmap.prop["test"] = np.zeros(xmap.size)
+        xmap[idx_to_change].test = 1
 
         fig = plt.figure()
         ax = fig.add_subplot(projection=PLOT_MAP)
-        im = ax.plot_map(cm, cm.test, axes=axes, depth=depth)
+        im = ax.plot_map(xmap, xmap.test)
 
         assert ax._data_shape == expected_plot_shape
         assert np.allclose(np.unique(im.get_array()), np.array([0, 1]))
@@ -221,28 +206,28 @@ class TestCrystalMapPlotUtilities:
 
     @pytest.mark.parametrize("to_plot", ["scalar", "rgb"])
     def test_add_overlay(self, crystal_map, to_plot):
-        cm = crystal_map
+        xmap = crystal_map
 
-        assert np.allclose(cm.phase_id, np.zeros(cm.size))  # Assumption
+        assert np.allclose(xmap.phase_id, np.zeros(xmap.size))  # Assumption
 
         fig = plt.figure()
         ax = fig.add_subplot(projection=PLOT_MAP)
         if to_plot == "scalar":
-            im = ax.plot_map(cm, cm.y)
+            im = ax.plot_map(xmap, xmap.y)
             im_data = im.get_array()
             assert im_data.ndim == 2
             im_data = im.to_rgba(im_data)[:, :, :3]
         else:  # rgb
-            im = ax.plot_map(cm)
+            im = ax.plot_map(xmap)
             im_data = copy.deepcopy(im.get_array())
 
-        to_overlay = cm.id
-        ax.add_overlay(cm, to_overlay)
+        to_overlay = xmap.id
+        ax.add_overlay(xmap, to_overlay)
         im_data2 = ax.images[0].get_array()
 
         assert np.allclose(im_data, im_data2) is False
 
-        overlay = cm.get_map_data(to_overlay)
+        overlay = xmap.get_map_data(to_overlay)
         overlay_min = np.nanmin(overlay)
         rescaled_overlay = (overlay - overlay_min) / (np.nanmax(overlay) - overlay_min)
 
@@ -272,9 +257,9 @@ class TestCrystalMapPlotUtilities:
     def test_phase_legend(
         self, crystal_map, phase_names, phase_colors, legend_properties
     ):
-        cm = crystal_map
-        cm[0, 0].phase_id = 1
-        cm.phases = PhaseList(
+        xmap = crystal_map
+        xmap[0, 0].phase_id = 1
+        xmap.phases = PhaseList(
             names=phase_names, point_groups=[3, 3], colors=phase_colors
         )
 
@@ -283,7 +268,7 @@ class TestCrystalMapPlotUtilities:
 
         fig = plt.figure()
         ax = fig.add_subplot(projection=PLOT_MAP)
-        _ = ax.plot_map(cm, legend_properties=legend_properties)
+        _ = ax.plot_map(xmap, legend_properties=legend_properties)
 
         legend = ax.legend_
 
@@ -451,14 +436,13 @@ class TestStatusBar:
         plt.close("all")
 
 
-@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in ")
 class TestScalebar:
     @pytest.mark.parametrize(
         "crystal_map_input, scalebar_properties",
         [
-            (((1, 10, 30), (0, 1, 1), 1, [0]), {}),  # Default
+            (((10, 30), (1, 1), 1, [0]), {}),  # Default
             (
-                ((1, 10, 30), (0, 1, 1), 1, [0]),
+                ((10, 30), (1, 1), 1, [0]),
                 {"location": 4, "sep": 6, "box_alpha": 0.8},
             ),
         ],

--- a/orix/tests/quaternion/test_orientation_region.py
+++ b/orix/tests/quaternion/test_orientation_region.py
@@ -18,14 +18,12 @@
 
 import pytest
 
-from orix.quaternion.orientation import Orientation
+from orix.quaternion import Orientation, OrientationRegion
 from orix.quaternion.orientation_region import (
-    OrientationRegion,
     _get_large_cell_normals,
     get_proper_groups,
 )
 from orix.quaternion.symmetry import *
-from orix.quaternion.symmetry import get_distinguished_points
 
 
 @pytest.mark.parametrize(

--- a/orix/tests/sampling/test_cubochoric_sampling.py
+++ b/orix/tests/sampling/test_cubochoric_sampling.py
@@ -21,7 +21,7 @@ import pytest
 
 # fmt: off
 # isort: off
-from orix.quaternion.rotation import Rotation
+from orix.quaternion import Rotation
 from orix.quaternion.symmetry import C1, C2, D2, C4, D4, C3, D3, C6, D6, T, O
 from orix.sampling import get_sample_fundamental, get_sample_local
 from orix.sampling._cubochoric_sampling import (

--- a/orix/tests/sampling/test_sampling.py
+++ b/orix/tests/sampling/test_sampling.py
@@ -19,10 +19,10 @@
 import numpy as np
 import pytest
 
-from orix.quaternion.rotation import Rotation
+from orix.quaternion import Rotation
 from orix.quaternion.symmetry import C2, C6, D6, get_point_group
-from orix.sampling import get_sample_fundamental, get_sample_local
-from orix.sampling.SO3_sampling import _resolution_to_num_steps, uniform_SO3_sample
+from orix.sampling import get_sample_fundamental, get_sample_local, uniform_SO3_sample
+from orix.sampling.SO3_sampling import _resolution_to_num_steps
 from orix.sampling._polyhedral_sampling import (
     _get_angles_between_nn_gridpoints,
     _get_first_nearest_neighbors,

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -21,7 +21,7 @@ from matplotlib_scalebar.scalebar import ScaleBar
 import numpy as np
 import pytest
 
-from orix.crystal_map import CrystalMap, Phase, PhaseList
+from orix.crystal_map import CrystalMap, Phase, PhaseList, create_coordinate_arrays
 from orix.plot import CrystalMapPlot
 from orix.quaternion import Orientation, Rotation
 from orix.quaternion.symmetry import C2, C3, C4, O
@@ -30,11 +30,6 @@ from orix.quaternion.symmetry import C2, C3, C4, O
 # testing IO and the Phase() and PhaseList() classes
 
 
-# TODO: Remove all pytest.mark.filterwarnings after (any) one release after 0.10.1
-
-
-@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed")
-@pytest.mark.filterwarnings("ignore:Returning coordinates for a 3D map is deprecated")
 class TestCrystalMap:
     def test_minimal_init(self, rotations):
         map_size = 2
@@ -62,28 +57,28 @@ class TestCrystalMap:
         ),
         [
             (
-                ((1, 5, 5), (0, 1.5, 1.5), 3, [0]),
+                ((5, 5), (1.5, 1.5), 3, [0]),
                 (5, 5),
                 25,
-                {"z": 0, "y": 1.5, "x": 1.5},
+                {"y": 1.5, "x": 1.5},
                 3,
-                (True, False, False),
+                (False, False),
             ),
             (
-                ((1, 1, 10), (0, 0.1, 0.1), 1, [0]),
+                ((1, 10), (0.1, 0.1), 1, [0]),
                 (10,),
                 10,
-                {"z": 0, "y": 0, "x": 0.1},
+                {"y": 0, "x": 0.1},
                 1,
-                (True, True, False),
+                (True, False),
             ),
             (
-                ((1, 10, 1), (0, 1e-3, 0), 2, [0]),
+                ((10, 1), (1e-3, 0), 2, [0]),
                 (10,),
                 10,
-                {"z": 0, "y": 1e-3, "x": 0},
+                {"y": 1e-3, "x": 0},
                 2,
-                (True, False, True),
+                (False, True),
             ),
         ],
         indirect=["crystal_map_input"],
@@ -98,11 +93,7 @@ class TestCrystalMap:
         expected_coords_nan,
     ):
         xmap = CrystalMap(**crystal_map_input)
-        coordinate_arrays = [
-            crystal_map_input["z"],
-            crystal_map_input["y"],
-            crystal_map_input["x"],
-        ]
+        coordinate_arrays = [crystal_map_input["y"], crystal_map_input["x"]]
 
         assert xmap.shape == expected_shape
         assert xmap.size == expected_size
@@ -129,8 +120,8 @@ class TestCrystalMap:
     @pytest.mark.parametrize(
         "crystal_map_input",
         [
-            ((1, 4, 3), (0, 1.5, 1.5), 1, [0, 1]),
-            ((1, 4, 3), (0, 1.5, 1.5), 1, [1, -1]),
+            ((4, 3), (1.5, 1.5), 1, [0, 1]),
+            ((4, 3), (1.5, 1.5), 1, [1, -1]),
         ],
         indirect=["crystal_map_input"],
     )
@@ -148,15 +139,15 @@ class TestCrystalMap:
             assert -1 not in xmap.phases.ids
 
     @pytest.mark.parametrize(
-        "crystal_map_input",
+        "crystal_map_input, expected_presence",
         [
-            ((1, 4, 3), (0, 1.5, 1.5), 1, [0, 1, 2]),
-            ((1, 4, 3), (0, 1.5, 1.5), 1, [0, 1, 2, 3]),
-            ((1, 4, 3), (0, 1.5, 1.5), 1, [2, 42]),
+            (((4, 3), (1.5, 1.5), 1, [0, 1, 2]), [True, True, True]),
+            (((4, 3), (1.5, 1.5), 1, [0, 1, 2, 3]), [True, True, True, True]),
+            (((4, 3), (1.5, 1.5), 1, [2, 42]), [True, False]),
         ],
         indirect=["crystal_map_input"],
     )
-    def test_init_with_phase_list(self, crystal_map_input):
+    def test_init_with_phase_list(self, crystal_map_input, expected_presence):
         point_groups = [C2, C3, C4]
         phase_list = PhaseList(point_groups=point_groups)
         xmap = CrystalMap(phase_list=phase_list, **crystal_map_input)
@@ -166,9 +157,11 @@ class TestCrystalMap:
         n_different = n_point_groups - n_phase_ids
         if n_different < 0:
             point_groups += [None] * abs(n_different)
-        assert [
-            xmap.phases.point_groups[i] == point_groups[i] for i in range(n_phase_ids)
-        ]
+
+        for p1, p2, expected in zip(
+            xmap.phases.point_groups, point_groups, expected_presence
+        ):
+            assert (p1 == p2) == expected
 
         unique_phase_ids = list(np.unique(crystal_map_input["phase_id"]).astype(int))
         assert xmap.phases.ids == unique_phase_ids
@@ -182,10 +175,10 @@ class TestCrystalMap:
     @pytest.mark.parametrize(
         "crystal_map_input, phase_names, phase_ids, desired_phase_names",
         [
-            (((1, 7, 4), (0, 1, 1), 1, [0]), ["a", "b", "c"], [0, 1, 2], ["a"]),
-            (((1, 7, 4), (0, 1, 1), 1, [0, 1]), ["a", "b", "c"], [0, 2, 1], ["a", "c"]),
-            (((1, 7, 4), (0, 1, 1), 1, [0, 2]), ["a", "b", "c"], [0, 2, 1], ["a", "b"]),
-            (((1, 7, 4), (0, 1, 1), 1, [3]), ["a", "b", "c"], [0, 2, 1], ["a"]),
+            (((7, 4), (1, 1), 1, [0]), ["a", "b", "c"], [0, 1, 2], ["a"]),
+            (((7, 4), (1, 1), 1, [0, 1]), ["a", "b", "c"], [0, 2, 1], ["a", "c"]),
+            (((7, 4), (1, 1), 1, [0, 2]), ["a", "b", "c"], [0, 2, 1], ["a", "b"]),
+            (((7, 4), (1, 1), 1, [3]), ["a", "b", "c"], [0, 2, 1], ["a"]),
         ],
         indirect=["crystal_map_input"],
     )
@@ -205,31 +198,34 @@ class TestCrystalMap:
                 (5, 5),
                 None,
                 dict(
-                    z=None,
-                    y=np.tile(np.sort(np.tile(np.arange(5) * 1, 5)), 1).flatten(),
-                    x=np.tile(np.arange(5) * 1, 5 * 1).flatten(),
+                    y=np.sort(np.tile(np.arange(5) * 1, 5)).flatten(),
+                    x=np.tile(np.arange(5), 5).flatten(),
                 ),
-                dict(z=0, y=1, x=1),
+                dict(y=1, x=1),
             ),
             (
-                (2, 2, 3),
-                (2, 3, 4),
+                (2, 3),
+                (3, 4),
                 dict(
-                    z=np.array([np.ones(2 * 3) * i * 2 for i in range(2)]).flatten(),
-                    y=np.tile(np.sort(np.tile(np.arange(2) * 3, 3)), 2).flatten(),
-                    x=np.tile(np.arange(3) * 4, 2 * 2).flatten(),
+                    y=np.sort(np.tile(np.arange(2) * 3, 3)).flatten(),
+                    x=np.tile(np.arange(3) * 4, 2).flatten(),
                 ),
-                dict(z=2, y=3, x=4),
+                dict(y=3, x=4),
             ),
             (
                 None,  # Default (5, 10)
                 None,  # Default (1, 1)
                 dict(
-                    z=None,
-                    y=np.tile(np.sort(np.tile(np.arange(5) * 1, 10)), 1).flatten(),
-                    x=np.tile(np.arange(10) * 1, 5 * 1).flatten(),
+                    y=np.sort(np.tile(np.arange(5), 10)).flatten(),
+                    x=np.tile(np.arange(10), 5).flatten(),
                 ),
-                dict(z=0, y=1, x=1),
+                dict(y=1, x=1),
+            ),
+            (
+                (5,),
+                (1,),
+                dict(y=None, x=np.tile(np.arange(5), 1).flatten()),
+                dict(y=0, x=1),
             ),
         ],
     )
@@ -246,7 +242,7 @@ class TestCrystalMap:
             np.array([1, 0, 0, 0] * desired_size).reshape((desired_size, 4)),
         )
         assert xmap.shape == shape
-        for i in ["z", "y", "x"]:
+        for i in ["y", "x"]:
             assert xmap._step_sizes[i] == desired_step_sizes[i]
             coords = xmap._coordinates[i]
             desired_coords = desired_coordinates[i]
@@ -311,32 +307,30 @@ class TestCrystalMap:
             xmap.phases = phase_list
 
 
-@pytest.mark.filterwarnings("ignore:Returning coordinates for a 3D map is deprecated ")
-@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in ")
 class TestCrystalMapGetItem:
     @pytest.mark.parametrize(
         "crystal_map_input, slice_tuple, expected_shape",
         [
-            (((5, 5, 5), (1, 1, 1), 1, [0]), slice(None, None, None), (5, 5, 5)),
+            (((5, 5), (1, 1), 1, [0]), slice(None, None, None), (5, 5)),
             (
-                ((5, 5, 5), (1, 1, 1), 1, [0]),
+                ((5, 5), (1, 1), 1, [0]),
                 (slice(1, 2, None), slice(None, None, None)),
-                (1, 5, 5),
+                (1, 5),
             ),
             (
-                ((2, 5, 5), (1, 1, 1), 1, [0]),
-                (slice(0, 2, None), slice(None, None, None), slice(1, 4, None)),
-                (2, 5, 3),
+                ((5, 5), (1, 1), 1, [0]),
+                (slice(None, None, None), slice(1, 4, None)),
+                (5, 3),
             ),
             (
-                ((3, 10, 10), (1, 0.5, 0.1), 2, [0]),
-                (1, slice(5, 10, None), slice(None, None, None)),
-                (1, 5, 10),
+                ((10, 10), (0.5, 0.1), 2, [0]),
+                (slice(5, 10, None), slice(None, None, None)),
+                (5, 10),
             ),
             (
-                ((3, 10, 10), (1, 0.5, 0.1), 2, [0]),
-                (slice(None, 10, None), slice(2, 4, None), slice(None, 3, None)),
-                (3, 2, 3),
+                ((10, 10), (0.5, 0.1), 2, [0]),
+                (slice(2, 4, None), slice(None, 3, None)),
+                (2, 3),
             ),
         ],
         indirect=["crystal_map_input"],
@@ -387,7 +381,7 @@ class TestCrystalMapGetItem:
 
     @pytest.mark.parametrize(
         "crystal_map_input",
-        [((1, 4, 3), (1, 1, 1), 1, [0])],
+        [((4, 3), (1, 1), 1, [0])],
         indirect=["crystal_map_input"],
     )
     def test_get_by_condition(self, crystal_map_input):
@@ -422,11 +416,11 @@ class TestCrystalMapGetItem:
     @pytest.mark.parametrize(
         "crystal_map_input, integer_slices, expected_id, raises",
         [
-            (((3, 4, 4), (1, 1, 1), 1, [0]), (0, 0, 2), 2, False),
-            (((3, 4, 4), (1, 1, 1), 3, [0]), (0, 2, 0), 8, False),
-            (((3, 4, 4), (1, 1, 1), 3, [0]), (2, 0, 0), 32, False),
-            (((1, 4, 1), (0, 1, 0), 2, [0]), 1, 1, False),
-            (((3, 4, 4), (1, 1, 1), 3, [0]), (1000, 0, 0), None, True),
+            (((4, 4), (1, 1), 1, [0]), (0, 2), 2, False),
+            (((4, 4), (1, 1), 3, [0]), (2, 0), 8, False),
+            (((4, 4), (1, 1), 3, [0]), (2, 3), 11, False),
+            (((4, 1), (1, 0), 2, [0]), 1, 1, False),
+            (((4, 4), (1, 1), 3, [0]), (1000, 0, 0), None, True),
         ],
         indirect=["crystal_map_input"],
     )
@@ -436,7 +430,7 @@ class TestCrystalMapGetItem:
         # This also tests `phase_id`
         xmap = CrystalMap(**crystal_map_input)
         if raises:
-            with pytest.raises(IndexError, match=".* is out of bounds for"):
+            with pytest.raises(IndexError):
                 _ = xmap[integer_slices]
         else:
             point = xmap[integer_slices]
@@ -470,25 +464,20 @@ class TestCrystalMapGetItem:
 
     def test_row_col(self):
         """Map points are assigned correct row and column coordinates."""
-        # Not implemented for when xmap.z is not None
-        xmap = CrystalMap.empty((3, 4, 5))
-        assert xmap.row is None
-        assert xmap.col is None
+        xmap1 = CrystalMap.empty()
+        xmap1.phases[0].name = "a"
+        xmap1.phases.add(Phase("b"))
+        xmap1[1:4, 5:9].phase_id = 1
+        xmap1[1, 1].phase_id = 1
 
-        xmap2 = CrystalMap.empty()
-        xmap2.phases[0].name = "a"
-        xmap2.phases.add(Phase("b"))
-        xmap2[1:4, 5:9].phase_id = 1
-        xmap2[1, 1].phase_id = 1
-
-        rows, cols = np.indices(xmap2.shape)
-        assert np.allclose(xmap2.row, rows.flatten())
-        assert np.allclose(xmap2.col, cols.flatten())
+        rows, cols = np.indices(xmap1.shape)
+        assert np.allclose(xmap1.row, rows.flatten())
+        assert np.allclose(xmap1.col, cols.flatten())
 
         # Sliced (weird formatting to increase readability of 2D map)
         # fmt: off
         assert np.allclose(
-            xmap2["a"].row,
+            xmap1["a"].row,
             np.array([
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 1,    1, 1, 1,             1,
@@ -498,7 +487,7 @@ class TestCrystalMapGetItem:
             ])
         )
         assert np.allclose(
-            xmap2["b"].row,
+            xmap1["b"].row,
             np.array([
 
                    0,          0, 0, 0, 0,
@@ -508,7 +497,7 @@ class TestCrystalMapGetItem:
             ])
         )
         assert np.allclose(
-            xmap2["a"].col,
+            xmap1["a"].col,
             np.array([
                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
                 0,    2, 3, 4,             9,
@@ -518,7 +507,7 @@ class TestCrystalMapGetItem:
             ])
         )
         assert np.allclose(
-            xmap2["b"].col,
+            xmap1["b"].col,
             np.array([
 
                    0,          4, 5, 6, 7,
@@ -530,17 +519,17 @@ class TestCrystalMapGetItem:
         # fmt: on
 
         # 1D without 1-dimension
-        xmap3 = CrystalMap.empty((5,))
-        assert np.allclose(xmap3.row, np.zeros(xmap3.size))
-        assert np.allclose(xmap3.col, np.arange(xmap3.size))
+        xmap2 = CrystalMap.empty((5,))
+        assert np.allclose(xmap2.row, np.zeros(xmap2.size))
+        assert np.allclose(xmap2.col, np.arange(xmap2.size))
 
         # 1D with 1-dimension
-        xmap4 = CrystalMap.empty((1, 5))
-        assert np.allclose(xmap4.row, np.zeros(xmap4.size))
-        assert np.allclose(xmap4.col, np.arange(xmap4.size))
-        xmap5 = CrystalMap.empty((5, 1))
-        assert np.allclose(xmap5.row, np.arange(xmap5.size))
-        assert np.allclose(xmap5.col, np.zeros(xmap5.size))
+        xmap3 = CrystalMap.empty((1, 5))
+        assert np.allclose(xmap3.row, np.zeros(xmap3.size))
+        assert np.allclose(xmap3.col, np.arange(xmap3.size))
+        xmap4 = CrystalMap.empty((5, 1))
+        assert np.allclose(xmap4.row, np.arange(xmap4.size))
+        assert np.allclose(xmap4.col, np.zeros(xmap4.size))
 
 
 class TestCrystalMapSetAttributes:
@@ -611,7 +600,6 @@ class TestCrystalMapSetAttributes:
         assert xmap.phases_in_data.names == xmap.phases.names
 
 
-@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in ")
 class TestCrystalMapOrientations:
     def test_orientations(self, crystal_map_input, phase_list):
         x = crystal_map_input["x"]
@@ -678,7 +666,7 @@ class TestCrystalMapOrientations:
 
     @pytest.mark.parametrize(
         "crystal_map_input, rotations_per_point",
-        [(((1, 5, 5), (0, 1.5, 1.5), 3, [0]), 3)],
+        [(((5, 5), (1.5, 1.5), 3, [0]), 3)],
         indirect=["crystal_map_input"],
     )
     def test_multiple_orientations_per_point(
@@ -719,7 +707,6 @@ class TestCrystalMapProp:
         assert np.allclose(xmap.prop[prop_name], np.ones(xmap.size) * new_prop_value)
 
 
-@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in ")
 class TestCrystalMapMasking:
     def test_getitem_with_masking(self, crystal_map_input):
         x = crystal_map_input["x"]
@@ -732,26 +719,19 @@ class TestCrystalMapMasking:
         assert np.allclose(xmap2.prop.is_in_data, xmap2.is_in_data)
 
 
-@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in")
-@pytest.mark.filterwarnings("ignore:Property `z` is deprecated and will be removed in")
 class TestCrystalMapGetMapData:
     @pytest.mark.parametrize(
         "crystal_map_input, to_get, expected_array",
         [
             (
-                ((1, 4, 4), (0, 0.5, 1), 2, [0]),
+                ((4, 4), (0.5, 1), 2, [0]),
                 "x",
                 np.array([0, 1, 2, 3] * 4).reshape((4, 4)),
             ),
             (
-                ((1, 4, 4), (0, 0.5, 1), 2, [0]),
+                ((4, 4), (0.5, 1), 2, [0]),
                 "y",
                 np.array([[i * 0.5] * 4 for i in range(4)]),  # [0, 0, 0, 0, 0.5, ...]
-            ),
-            (
-                ((2, 4, 4), (0.28, 0.5, 1), 2, [0]),
-                "z",
-                np.stack((np.zeros((4, 4)), np.ones((4, 4)) * 0.28)),
             ),
         ],
         indirect=["crystal_map_input"],
@@ -766,10 +746,8 @@ class TestCrystalMapGetMapData:
         # Get via numpy array
         if to_get == "x":
             data_via_array = xmap.get_map_data(xmap.x)
-        elif to_get == "y":
+        else:
             data_via_array = xmap.get_map_data(xmap.y)
-        else:  # to_get == "z"
-            data_via_array = xmap.get_map_data(xmap.z)
         assert np.allclose(data_via_array, expected_array)
 
         # Make sure they are the same
@@ -788,7 +766,7 @@ class TestCrystalMapGetMapData:
 
     @pytest.mark.parametrize(
         "crystal_map_input",
-        [((1, 3, 2), (0, 1, 1), 3, [0]), ((3, 1, 2), (1, 1, 1), 1, [0])],
+        [((3, 2), (1, 1), 3, [0]), ((3, 2), (1, 1), 1, [0])],
         indirect=["crystal_map_input"],
     )
     def test_get_orientations_array(self, crystal_map_input, phase_list):
@@ -842,7 +820,7 @@ class TestCrystalMapGetMapData:
 
     @pytest.mark.parametrize(
         "crystal_map_input",
-        [((1, 2, 2), (0, 1, 1), 2, [0]), ((3, 2, 2), (1, 1, 1), 1, [0])],
+        [((2, 2), (1, 1), 2, [0]), ((2, 2), (1, 1), 1, [0])],
         indirect=["crystal_map_input"],
     )
     def test_get_rotations_array(self, crystal_map_input):
@@ -865,7 +843,7 @@ class TestCrystalMapGetMapData:
 
     @pytest.mark.parametrize(
         "crystal_map_input",
-        [((3, 9, 3), (1, 1.5, 1.5), 2, [0]), ((2, 10, 5), (1, 0.1, 0.1), 3, [0])],
+        [((9, 3), (1.5, 1.5), 2, [0]), ((10, 5), (0.1, 0.1), 3, [0])],
         indirect=["crystal_map_input"],
     )
     def test_get_phase_id_array_from_3d_data(self, crystal_map_input):
@@ -875,9 +853,8 @@ class TestCrystalMapGetMapData:
     @pytest.mark.parametrize(
         "crystal_map_input, to_get",
         [
-            (((1, 4, 3), (1, 1, 1), 1, [0]), "z"),
-            (((4, 1, 3), (1, 1, 1), 1, [0]), "y"),
-            (((4, 3, 1), (1, 1, 1), 1, [0]), "x"),
+            (((1, 3), (1, 1), 1, [0]), "y"),
+            (((3, 1), (1, 1), 1, [0]), "x"),
         ],
         indirect=["crystal_map_input"],
     )
@@ -983,26 +960,25 @@ class TestCrystalMapCopying:
         assert np.may_share_memory(xmap2._phase_id, crystal_map._phase_id) is False
 
 
-@pytest.mark.filterwarnings("ignore:Argument `z` is deprecated and will be removed in ")
 class TestCrystalMapShape:
     @pytest.mark.parametrize(
         "crystal_map_input, expected_slices",
         [
             (
-                ((1, 10, 30), (0, 0.1, 0.1), 2, [0]),
+                ((10, 30), (0.1, 0.1), 2, [0]),
                 (slice(0, 10, None), slice(0, 30, None)),
             ),
             (
-                ((2, 13, 27), (0.3, 0.7, 0.9), 3, [0]),
-                (slice(0, 2, None), slice(0, 13, None), slice(0, 27, None)),
+                ((13, 27), (0.7, 0.9), 3, [0]),
+                (slice(0, 13, None), slice(0, 27, None)),
             ),
             (
-                ((1, 4, 3), (0, 1.5, 1.5), 1, [0]),
+                ((4, 3), (1.5, 1.5), 1, [0]),
                 (slice(0, 4, None), slice(0, 3, None)),
             ),
             # Testing rounding 15 / 2 = 7.5 and 45 / 2 = 22.5
             (
-                ((1, 15, 45), (0, 2, 2), 1, [0]),
+                ((15, 45), (2, 2), 1, [0]),
                 (slice(0, 15, None), slice(0, 45, None)),
             ),
         ],
@@ -1015,38 +991,21 @@ class TestCrystalMapShape:
     @pytest.mark.parametrize(
         "crystal_map_input, slices, expected_size, expected_shape, expected_slices",
         [
-            # Slice 3D data with an index in all axes
+            # Slice 2D data with an index in all axes
             (
-                ((2, 3, 4), (1, 1, 1), 1, [0]),
-                (1, 2, 3),
+                ((3, 4), (1, 1), 1, [0]),
+                (2, 3),
                 1,
-                (1, 1, 1),
-                (slice(1, 2, None), slice(2, 3, None), slice(3, 4, None)),
+                (1, 1),
+                (slice(2, 3, None), slice(3, 4, None)),
             ),
-            # Slice 3D data with indices in only two axes
+            # Slice 2D data with an index in only one axis
             (
-                ((2, 3, 4), (0.1, 0.1, 0.1), 1, [0]),
-                (1, 2),
-                4,
-                (1, 1, 4),
-                (slice(1, 2, None), slice(2, 3, None), slice(0, 4, None)),
-            ),
-            # Slice 3D data with indices in only two axes (same as above, to make sure
-            # slice determination is unaffected by step size)
-            (
-                ((2, 3, 4), (1, 1, 1), 1, [0]),
-                (1, 2),
-                4,
-                (1, 1, 4),
-                (slice(1, 2, None), slice(2, 3, None), slice(0, 4, None)),
-            ),
-            # Slice 3D data with an index in only one axis
-            (
-                ((2, 3, 4), (0.1, 0.1, 0.1), 1, [0]),
+                ((3, 4), (0.1, 0.1), 1, [0]),
                 (1,),
-                12,
-                (1, 3, 4),
-                (slice(1, 2, None), slice(0, 3, None), slice(0, 4, None)),
+                4,
+                (1, 4),
+                (slice(1, 2, None), slice(0, 4, None)),
             ),
         ],
         indirect=["crystal_map_input"],
@@ -1066,10 +1025,10 @@ class TestCrystalMapShape:
     @pytest.mark.parametrize(
         "crystal_map_input, expected_shape",
         [
-            (((1, 10, 30), (0, 0.1, 0.1), 2, [0]), (10, 30)),
-            (((2, 13, 27), (0.3, 0.7, 0.9), 3, [0]), (2, 13, 27)),
-            (((1, 4, 3), (0, 1.5, 1.5), 1, [0]), (4, 3)),
-            (((1, 15, 45), (0, 2, 2), 2, [0]), (15, 45)),
+            (((10, 30), (0.1, 0.1), 2, [0]), (10, 30)),
+            (((13, 27), (0.7, 0.9), 3, [0]), (13, 27)),
+            (((4, 3), (1.5, 1.5), 1, [0]), (4, 3)),
+            (((15, 45), (2, 2), 2, [0]), (15, 45)),
         ],
         indirect=["crystal_map_input"],
     )
@@ -1080,10 +1039,10 @@ class TestCrystalMapShape:
     @pytest.mark.parametrize(
         "crystal_map_input, expected_shape",
         [
-            (((1, 10, 30), (0, 0.1, 0.1), 2, [0]), (10, 30, 2)),
-            (((2, 13, 27), (0.3, 0.7, 0.9), 3, [0]), (2, 13, 27, 3)),
-            (((1, 4, 3), (0, 1.5, 1.5), 5, [0]), (4, 3, 5)),
-            (((1, 15, 45), (0, 2, 2), 2, [0]), (15, 45, 2)),
+            (((10, 30), (0.1, 0.1), 2, [0]), (10, 30, 2)),
+            (((13, 27), (0.7, 0.9), 3, [0]), (13, 27, 3)),
+            (((4, 3), (1.5, 1.5), 5, [0]), (4, 3, 5)),
+            (((15, 45), (2, 2), 2, [0]), (15, 45, 2)),
         ],
         indirect=["crystal_map_input"],
     )
@@ -1094,11 +1053,11 @@ class TestCrystalMapShape:
     @pytest.mark.parametrize(
         "crystal_map_input, expected_coordinate_axes",
         [
-            (((1, 10, 30), (0, 0.1, 0.1), 1, [0]), {0: "y", 1: "x"}),
-            (((2, 13, 27), (0.3, 0.7, 0.9), 1, [0]), {0: "z", 1: "y", 2: "x"}),
-            (((1, 13, 27), (0, 1.5, 1.5), 1, [0]), {0: "y", 1: "x"}),
-            (((2, 13, 1), (1, 2, 1), 2, [0]), {0: "z", 1: "y"}),
-            (((2, 1, 13), (1, 0, 2), 1, [0]), {0: "z", 1: "x"}),
+            (((10, 30), (0.1, 0.1), 1, [0]), {0: "y", 1: "x"}),
+            (((13, 27), (0.7, 0.9), 1, [0]), {0: "y", 1: "x"}),
+            (((13, 27), (1.5, 1.5), 1, [0]), {0: "y", 1: "x"}),
+            (((13, 1), (2, 1), 2, [0]), {0: "y"}),
+            (((1, 13), (0, 2), 1, [0]), {0: "x"}),
         ],
         indirect=["crystal_map_input"],
     )
@@ -1136,3 +1095,9 @@ class TestCrystalMapPlotMethod:
         assert sbar2.location == 1  # "upper right"
 
         plt.close("all")
+
+
+class TestCreateCoordinateArrays:
+    def test_create_coordinate_arrays_raises(self):
+        with pytest.raises(ValueError, match="Can only create coordinate arrays for "):
+            _ = create_coordinate_arrays((1, 2, 3))


### PR DESCRIPTION
#### Description of the change
The appearance of "3D functionality" in the `CrystalMap` (implemented by me, but never tested on a real 3D dataset for its usefulness) was deprecated in 0.10.1 and will be removed in 0.11.0. This PR makes the necessary changes to the class, the plotting and IO plugins (orix HDF5 and ang).

The only issue I can see is that people have stored 3D datasets in orix' HDF5 format, which they now cannot read back with the changed orix HDF5 reader. I hope no-one has done this, but if they have, let's hope they shout out in an issue so we can fix this.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.