### PR TITLE
Fix phase list when initializing CrystalMap with a sparse phase list

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ All user facing changes to this project are documented in this file. The format 
 on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`__, and this project tries
 its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`__.
 
+2023-03-14 - version 0.11.1
+===========================
+
+Fixed
+-----
+- Initialization of a crystal map with a phase list with fewer phases than in the phase
+  ID array given returns a map with a new phase list with correct phase IDs.
+
 2023-02-09 - version 0.11.0
 ===========================
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -86,7 +86,6 @@ html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "github_url": "https://github.com/pyxem/orix",
     "header_links_before_dropdown": 6,
-    "icon_links": [],  # Workaround for pydata/pydata-sphinx-theme#1220
     "logo": {"alt_text": project, "text": project},
     "navigation_with_keys": False,
     "show_toc_level": 2,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -86,6 +86,7 @@ html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "github_url": "https://github.com/pyxem/orix",
     "header_links_before_dropdown": 6,
+    "icon_links": [],  # Workaround for pydata/pydata-sphinx-theme#1220
     "logo": {"alt_text": project, "text": project},
     "navigation_with_keys": False,
     "show_toc_level": 2,

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -1,5 +1,5 @@
 __name__ = "orix"
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 __author__ = "orix developers"
 __author_email__ = "pyxem.team@gmail.com"
 __description__ = "orix is an open-source Python library for handling crystal orientation mapping data."

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -23,7 +23,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from orix.crystal_map.crystal_map_properties import CrystalMapProperties
-from orix.crystal_map.phase_list import Phase, PhaseList
+from orix.crystal_map.phase_list import ALL_COLORS, Phase, PhaseList
 from orix.quaternion import Orientation, Rotation
 
 
@@ -251,7 +251,7 @@ class CrystalMap:
         if phase_list is None:
             self._phases = PhaseList(ids=unique_phase_ids)
         else:
-            phase_list = copy.deepcopy(phase_list)
+            phase_list = phase_list.deepcopy()
             phase_ids = phase_list.ids
             n_different = len(phase_ids) - len(unique_phase_ids)
             if n_different > 0:
@@ -265,15 +265,20 @@ class CrystalMap:
                         break
             elif n_different < 0:
                 # Create new phase list adding the missing phases with
-                # default initial values
-                phase_list = PhaseList(
-                    names=phase_list.names,
-                    space_groups=phase_list.space_groups,
-                    point_groups=phase_list.point_groups,
-                    colors=phase_list.colors,
-                    structures=phase_list.structures,
-                    ids=unique_phase_ids,
+                # default initial values (but unique colors)
+                phase_dict = {}
+                all_colors = list(ALL_COLORS.keys())
+                all_unique_colors = np.delete(
+                    all_colors, np.isin(all_colors, phase_list.colors)
                 )
+                ci = 0
+                for i in unique_phase_ids:
+                    if i in phase_ids:
+                        phase_dict[i] = phase_list[i]
+                    else:
+                        phase_dict[i] = Phase(color=all_unique_colors[ci])
+                        ci += 1
+                phase_list = PhaseList(phase_dict)
             # Ensure phase list IDs correspond to IDs in phase_id array
             new_ids = list(unique_phase_ids.astype(int))
             phase_list._dict = dict(zip(new_ids, phase_list._dict.values()))

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -166,6 +166,31 @@ class TestCrystalMap:
         unique_phase_ids = list(np.unique(crystal_map_input["phase_id"]).astype(int))
         assert xmap.phases.ids == unique_phase_ids
 
+    def test_init_with_sparse_phase_list(self):
+        """Initialize a map with a sparse phase list only containing one
+        of the phase IDs passed in the phase list.
+        """
+        pl = PhaseList(ids=[1], names=["b"], space_groups=[225])
+        phase_id = np.array([0, 0, 1, 1, 1, 3])
+        xmap = CrystalMap(
+            rotations=Rotation.identity(phase_id.size),
+            is_in_data=phase_id == 1,
+            phase_list=pl,
+            phase_id=phase_id,
+        )
+        for i, name, color, sg_name in zip(
+            [0, 1, 3],
+            ["", "b", ""],
+            ["tab:orange", "tab:blue", "tab:green"],
+            [None, "Fm-3m", None],
+        ):
+            assert xmap.phases[i].name == name
+            assert xmap.phases[i].color == color
+            if sg_name is None:
+                assert xmap.phases[i].space_group is None
+            else:
+                assert xmap.phases[i].space_group.short_name == sg_name
+
     def test_init_with_single_point_group(self, crystal_map_input):
         point_group = O
         phase_list = PhaseList(point_groups=point_group)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ extra_feature_requirements = {
         "sphinx-design",
         "sphinx-gallery                 < 0.11",
         "sphinx-last-updated-by-git",
-        "pydata-sphinx-theme",
+        "pydata-sphinx-theme            >= 0.13.1",
         "sphinxcontrib-bibtex           >= 1.0",
         "scikit-image",
         "scikit-learn",


### PR DESCRIPTION
#### Description of the change
This is a fix for a bug spotted by @Erlendos12 in https://github.com/pyxem/kikuchipy/discussions/620. When a `CrystalMap` is initialized with a phase ID array with more IDs than there are phases in the given phase list, the returned map does not link the phase ID array with the correct phase in the phase list. It does with this fix. See below for an example.

I'd like to release a 0.11.1 patch with this fix as soon as this PR is merged onto `main`, if that is OK with people.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)
- [x] Fix docs (https://readthedocs.org/projects/orix/builds/19674675/), see https://github.com/pydata/pydata-sphinx-theme/issues/1220

#### Minimal example of the bug fix or new feature
```python
>>> import numpy as np
>>> from orix.crystal_map import CrystalMap, PhaseList
>>> from orix.quaternion import Rotation
>>> pl = PhaseList(ids=[1], names=["b"], space_groups=[225])
>>> pl
Id  Name  Space group  Point group  Proper point group     Color
 1     b        Fm-3m         m-3m                 432  tab:blue
>>> phase_id = np.array([0, 0, 1, 1, 1, 3])
>>> xmap = CrystalMap(
...     rotations=Rotation.identity(phase_id.size),
...     is_in_data=phase_id == 1,
...     phase_list=pl,
...     phase_id=phase_id,
... )

# Output with 0.11.0

>>> xmap
Phase  Orientations  Name  Space group  Point group  Proper point group       Color
    1    3 (100.0%)  None         None         None                None  tab:orange
Properties: 
Scan unit: px
>>> xmap.phases
Id  Name  Space group  Point group  Proper point group       Color
 0     b        Fm-3m         m-3m                 432    tab:blue
 1  None         None         None                None  tab:orange
 3  None         None         None                None   tab:green


# Output after fix (with upcoming 0.11.1)

>>> xmap
Phase  Orientations  Name  Space group  Point group  Proper point group     Color
    1    3 (100.0%)     b        Fm-3m         m-3m                 432  tab:blue
Properties: 
Scan unit: px
>>> xmap.phases
Id  Name  Space group  Point group  Proper point group       Color
 0  None         None         None                None  tab:orange
 1     b        Fm-3m         m-3m                 432    tab:blue
 3  None         None         None                None   tab:green
```

This example is also an added test.

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.