### PR TITLE
Option to use euler fundamental region for mean orientation

### DIFF
--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -31,6 +31,7 @@ import numpy as np
 from tqdm import tqdm
 
 from orix.quaternion.orientation_region import OrientationRegion
+from orix.quaternion import Quaternion
 from orix.quaternion.rotation import Rotation
 from orix.quaternion.symmetry import C1, Symmetry, _get_unique_symmetry_elements
 from orix.vector import AxAngle, NeoEuler, Vector3d
@@ -791,6 +792,39 @@ class Orientation(Misorientation):
             range(self.ndim)
         )
         return highest_dot_products.transpose(*order)
+
+    def mean(self, mean_in_euler_fundamental_region=False) -> Orientation:
+        """Return the mean orientation with unitary weights.
+
+        Returns
+        -------
+        ori_mean
+            Mean orientation.
+
+        mean_in_euler_fundamental_region
+            Calculate mean orientation in euler fundamental region.
+
+        Notes
+        -----
+        The method used here corresponds to Equation (13) in
+        https://arc.aiaa.org/doi/pdf/10.2514/1.28949.
+
+        Examples
+        --------
+        >>> from orix.quaternion import Orientation, symmetry
+        >>> oris = Orientation.from_axes_angles([1, 0, 0], np.deg2rad([0, 45]), symmetry.Oh)
+        >>> oris.mean(mean_in_euler_fundamental_region=True)
+        Orientation (1,) m-3m
+        [[0.2469 0.     0.3708 0.8953]]
+        """
+        if mean_in_euler_fundamental_region:
+            quat = Quaternion.from_euler(self.in_euler_fundamental_region())
+        else:
+            quat = Quaternion(self)
+
+        mean = quat.mean()
+
+        return Orientation(mean, symmetry=self.symmetry)
 
     def plot_unit_cell(
         self,

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -30,8 +30,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 from tqdm import tqdm
 
-from orix.quaternion.orientation_region import OrientationRegion
 from orix.quaternion import Quaternion
+from orix.quaternion.orientation_region import OrientationRegion
 from orix.quaternion.rotation import Rotation
 from orix.quaternion.symmetry import C1, Symmetry, _get_unique_symmetry_elements
 from orix.vector import AxAngle, NeoEuler, Vector3d

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -698,3 +698,38 @@ class TestOrientation:
             ori.symmetry = pg
             region = np.radians(pg.euler_fundamental_region)
             assert np.all(np.max(ori.in_euler_fundamental_region(), axis=0) <= region)
+
+    def test_mean(self):
+        oris = Orientation(
+            [
+                [0.215, 0.9696, -0.1001, -0.0602],
+                [0.2132, 0.97, -0.0977, -0.0643],
+                [0.2154, 0.9693, -0.098, -0.067],
+                [0.2157, 0.9692, -0.0989, -0.0659],
+                [0.2141, 0.9693, -0.1012, -0.0668],
+                [0.2132, 0.9696, -0.1001, -0.0659],
+                [0.2083, 0.9715, -0.0952, -0.0605],
+                [0.1558, 0.7913, -0.569, -0.1608],
+                [0.1495, 0.79, -0.5704, -0.1681],
+                [0.1537, 0.7908, -0.5686, -0.1663],
+                [0.1552, 0.7918, -0.5677, -0.1634],
+                [0.1518, 0.792, -0.5679, -0.165],
+                [0.0484, 0.3993, -0.8886, -0.2203],
+                [0.0459, 0.4007, -0.888, -0.2209],
+            ],
+            symmetry=D6,
+        )
+        mean_not_fund_region = oris.mean()
+        mean_fund_region = oris.mean(mean_in_euler_fundamental_region=True)
+
+        assert np.allclose(
+            mean_not_fund_region.data,
+            Orientation([0.1835, 0.8938, -0.3888, -0.1277], symmetry=D6).data,
+            atol=0.0001,
+        )
+
+        assert np.allclose(
+            mean_fund_region.data,
+            Orientation([0.8887, -0.2184, 0.0502, -0.4], symmetry=D6).data,
+            atol=0.0001,
+        )


### PR DESCRIPTION
#### Description of the change

Added override to the `mean()` function in the `Orientation` class with the option to calculate the mean in the euler fundamental region. Also keeps the symmetry of the `Orientation` for the returned mean. This way, when plotting in an IPF, I think the mean `Orientation` makes more sense. 

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
import orix.plot
from orix.quaternion import Orientation
from orix.quaternion.symmetry import D6h
from orix.vector import Vector3d
import matplotlib.pyplot as plt
from matplotlib.gridspec import GridSpec

oris = Orientation(
[[ 0.215 ,  0.9696, -0.1001, -0.0602],
 [ 0.2132 , 0.97  , -0.0977, -0.0643],
 [ 0.2154 , 0.9693 ,-0.098 , -0.067 ],
 [ 0.2157 , 0.9692, -0.0989, -0.0659],
 [ 0.2141 , 0.9693 ,-0.1012, -0.0668],
 [ 0.2132 , 0.9696, -0.1001, -0.0659],
 [ 0.2083 , 0.9715 ,-0.0952, -0.0605],
 [ 0.1558 , 0.7913 ,-0.569 , -0.1608],
 [ 0.1495 , 0.79   ,-0.5704, -0.1681],
 [ 0.1537 , 0.7908, -0.5686, -0.1663],
 [ 0.1552 , 0.7918 ,-0.5677, -0.1634],
 [ 0.1518 , 0.792 , -0.5679, -0.165 ],
 [ 0.0484 , 0.3993, -0.8886, -0.2203],
 [ 0.0459 , 0.4007, -0.888,  -0.2209]], symmetry = D6h)

fig = plt.figure(figsize=(9,5))

gs = GridSpec(2,3)

ax_x_not_fundamental = fig.add_subplot(gs[0,0], projection = "ipf", direction = Vector3d.xvector(), symmetry = D6h)
ax_y_not_fundamental = fig.add_subplot(gs[0,1], projection = "ipf", direction = Vector3d.yvector(), symmetry = D6h)
ax_z_not_fundamental = fig.add_subplot(gs[0,2], projection = "ipf", direction = Vector3d.zvector(), symmetry = D6h)

ax_x_fundamental = fig.add_subplot(gs[1,0], projection = "ipf", direction = Vector3d.xvector(), symmetry = D6h)
ax_y_fundamental = fig.add_subplot(gs[1,1], projection = "ipf", direction = Vector3d.yvector(), symmetry = D6h)
ax_z_fundamental = fig.add_subplot(gs[1,2], projection = "ipf", direction = Vector3d.zvector(), symmetry = D6h)

ax_x_not_fundamental.set_title("X")
ax_y_not_fundamental.set_title("Not in fundamental region\nY")
ax_z_not_fundamental.set_title("Z")

ax_x_fundamental.set_title("X")
ax_y_fundamental.set_title("In fundamental region\nY")
ax_z_fundamental.set_title("Z")

mean_ori_not_in_fundamental = oris.mean()
mean_ori_in_fundamental = oris.mean(mean_in_euler_fundamental_region=True)

ax_x_not_fundamental.scatter(oris, label ="Data")
ax_y_not_fundamental.scatter(oris)
ax_z_not_fundamental.scatter(oris)
ax_x_not_fundamental.scatter(mean_ori_not_in_fundamental, c = "r", label = "Mean")
ax_y_not_fundamental.scatter(mean_ori_not_in_fundamental, c = "r")
ax_z_not_fundamental.scatter(mean_ori_not_in_fundamental, c = "r")

ax_x_fundamental.scatter(oris)
ax_y_fundamental.scatter(oris)
ax_z_fundamental.scatter(oris)
ax_x_fundamental.scatter(mean_ori_in_fundamental, c = "r")
ax_y_fundamental.scatter(mean_ori_in_fundamental, c = "r")
ax_z_fundamental.scatter(mean_ori_in_fundamental, c = "r")


fig.tight_layout()
handles, labels = ax_x_not_fundamental.get_legend_handles_labels()
handle_list, label_list = [], []
for handle, label in zip(handles, labels):
    if label in ["sa_circle", "sa_sector"]:
        continue
    if label not in label_list:
        handle_list.append(handle)
        label_list.append(label)
fig.legend(handle_list, label_list, loc = "upper left", fontsize = 12)
```


![Orientation](https://user-images.githubusercontent.com/99223999/224976138-e3338406-c981-44aa-9618-d3ecdd9a002f.png)


#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.