### PR TITLE
Fixed failing example in from_matrix docs of quaternion

### DIFF
--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -389,7 +389,7 @@ class Quaternion(Object3d):
         >>> from orix.quaternion import Quaternion
         >>> q = Quaternion.from_matrix([np.eye(3), 2 * np.eye(3), np.diag([1, -1, -1])])
         >>> q
-        Quaternion (2,)
+        Quaternion (3,)
         [[1. 0. 0. 0.]
          [1. 0. 0. 0.]
          [0. 1. 0. 0.]]


### PR DESCRIPTION
#### Description of the change

Fixed failing example in docstring of `from_matrix()` in `Quaternion` class.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
N/A

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.