### PR TITLE
List explicit support for Python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.11'
 
       - uses: isort/isort-action@master
         with:
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.9, "3.10"]
+        python-version: ["3.10", "3.11"]
         include:
           - os: ubuntu-latest
             python-version: 3.7

--- a/.github/workflows/perhaps_make_a_tagged_release_draft.yml
+++ b/.github/workflows/perhaps_make_a_tagged_release_draft.yml
@@ -15,12 +15,12 @@ jobs:
   make-tagged-release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: r-lib/actions/setup-pandoc@v1
+    - uses: r-lib/actions/setup-pandoc@v2
 
     - name: Set up Python ${{ runner.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,8 +20,11 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -37,15 +40,10 @@ jobs:
       run: |
         python -m build
 
-    - name: Publish package to TestPyPI
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+    - name: Publish package distribution to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
 
-    - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Publish package distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test_documentation_notebooks.yml
+++ b/.github/workflows/test_documentation_notebooks.yml
@@ -18,21 +18,24 @@ jobs:
     env:
       MPLBACKEND: agg
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
-
-      - name: Display versions
-        run: python -V; pip -V
+          python-version: '3.11'
 
       - name: Install dependencies and package
         shell: bash
         run: |
           pip install -U -e .'[tests, doc]'
           pip install nbval
+
+      - name: Display versions
+        run: |
+          python -V
+          pip -V
+          pip list
 
       - name: Test documentation notebooks
         run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Added
   use when plotting vectors.
 - Two offsets in the stereographic coordinates (X, Y) can be given to
   ``StereographicPlot.text()`` to offset text coordinates.
+- Explicit support for Python 3.11.
 
 Changed
 -------

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -11,9 +11,9 @@ sphinx:
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.11"
 
 # Build doc in all formats (HTML, PDF and ePub)
 formats:

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",


### PR DESCRIPTION
#### Description of the change
This PR adds explicit support for Python 3.11. No changes to code was necessary to support this, meaning that people are most likely already using orix on 3.11. No changes to the minimal versions of packages (diffpy.structure > 3.0.2 and matplotlib >= 3.3) are necessary.

I've also replaced our use of API tokens for publishing to PyPI and TestPyPI with the [Trusted publisher](https://docs.pypi.org/trusted-publishers/using-a-publisher/) approach, which uses short-lived tokens provided by GitHub instead.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.