### PR TITLE
add to_dict method to crystal_map to allow for easy extraction of tho…

### DIFF
--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -749,6 +749,43 @@ class CrystalMap:
 
         return representation
 
+    def to_dict(self) -> dict[dict[str,str]]:
+        """Return dictionary of the data."""
+        result = {}
+        if self.size == 0:
+            return result
+
+        phases = self.phases_in_data
+        phase_ids = self.phase_id
+
+        # Ensure attributes set to None are treated OK
+        names = ["None" if not name else name for name in phases.names]
+        sg_names = ["None" if not i else i.short_name for i in phases.space_groups]
+        pg_names = ["None" if not i else i.name for i in phases.point_groups]
+        ppg_names = [
+            "None" if not i else i.proper_subgroup.name for i in phases.point_groups
+        ]
+
+        # Determine dictionary of phases
+        unique_phases = np.unique(phase_ids)
+        for i, phase_id in enumerate(unique_phases.astype(int)):
+            p_size = np.where(phase_ids == phase_id)[0].size
+            p_percentage = 100 * p_size / self.size
+            result[phase_id] = {
+                "number pixel"      : p_size,
+                "percentage"        : p_percentage,
+                "name"              : names[i],
+                "space group"       : sg_names[i],
+                "point group"       : pg_names[i],
+                "proper point group": ppg_names[i],
+                "color"             : phases.colors[i]
+            }
+
+        # Properties and spatial coordinates and scan unit
+        result["properties"] = list(self.prop.keys())
+        result["scan unit"]  = self.scan_unit
+        return result
+
     def deepcopy(self) -> "CrystalMap":
         """Return a deep copy using :func:`copy.deepcopy` function."""
         return copy.deepcopy(self)


### PR DESCRIPTION
add to_dict method to crystal_map to allow for easy extraction of those results that would be printed with __repr__

#### Description of the change


#### Progress of the PR
- [X] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Unit tests with pytest for all lines
       -> most tests were successful; some failed because of some 'url.requests' issue.
- [ ] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)
      -> copied existing code: hence style should be ok (I don't have black installed and have no experience of using it)

#### Minimal example of the bug fix or new feature
```python
>>> from orix.io import load
>>> datadir = 'data/04/'
>>> fname = 'sdss_ferrite_austenite.ang' #.ang file produced by EMsoft
>>> cm = load(datadir + fname)
>>> metadata = cm.to_dict()
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.