### PR TITLE
Add Sampling

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -35,6 +35,11 @@
       "affiliation": "Norwegian University of Science and Technology"
     },
     {
+      "name": "Carter Francis",
+      "orcid": "0000-0003-2564-1851",
+      "affiliation": "University of Wisconsin Madison"
+    },
+    {
       "name": "Simon Høgås"
     },
     {

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,9 @@ Added
 - The ``random()`` methods of ``Orientation`` and ``Misorientation`` now accept
   ``symmetry``. A ``random()`` method is also added to ``Vector3d`` and ``Miller``, the
   latter accepting a ``phase``.
+- ``Added orix.sampling.get_sample_zone_axis`` for getting zone axes for some point group.
+- ``Added orix.sampling.get_sample_reduced_fundamental`` for getting reduced
+  fundamental zone for some point group.
 
 Changed
 -------

--- a/examples/rotations/sampling_rotations.py
+++ b/examples/rotations/sampling_rotations.py
@@ -8,11 +8,9 @@ get both the zone axis and the reduced fundamental zone rotations for
 the phase of interest.
 """
 from diffpy.structure import Atom, Lattice, Structure
+
 from orix.crystal_map import Phase
-from orix.sampling import (
-    get_sample_reduced_fundamental,
-    get_sample_zone_axis,
-)
+from orix.sampling import get_sample_reduced_fundamental, get_sample_zone_axis
 from orix.vector import Vector3d
 
 a = 5.431

--- a/examples/rotations/sampling_rotations.py
+++ b/examples/rotations/sampling_rotations.py
@@ -7,6 +7,7 @@ This example shows how to sample some phase object in Orix. We will
 get both the zone axis and the reduced fundamental zone rotations for
 the phase of interest.
 """
+
 from diffpy.structure import Atom, Lattice, Structure
 
 from orix.crystal_map import Phase

--- a/examples/rotations/sampling_rotations.py
+++ b/examples/rotations/sampling_rotations.py
@@ -9,7 +9,10 @@ the phase of interest.
 """
 from diffpy.structure import Atom, Lattice, Structure
 from orix.crystal_map import Phase
-from orix.sampling import (get_sample_reduced_fundamental, get_sample_zone_axis,)
+from orix.sampling import (
+    get_sample_reduced_fundamental,
+    get_sample_zone_axis,
+)
 from orix.vector import Vector3d
 
 a = 5.431
@@ -25,13 +28,21 @@ struct = Structure(atoms=atom_list, lattice=latt)
 p = Phase(structure=struct, space_group=227)
 reduced_fun = get_sample_reduced_fundamental(resolution=4, point_group=p.point_group)
 
-vect_rot = reduced_fun*Vector3d.zvector()  # get the vector representation of the rotations
+vect_rot = (
+    reduced_fun * Vector3d.zvector()
+)  # get the vector representation of the rotations
 vect_rot.scatter(grid=True)  # plot the stereographic projection of the rotations
 
 # %%
 
-zone_axis_rot, directions = get_sample_zone_axis(phase=p, density="7", return_directions=True)  # get the zone axis rotations
-zone_vect_rot = zone_axis_rot*Vector3d.zvector()  # get the vector representation of the rotations
-zone_vect_rot.scatter(grid=True, vector_labels=directions, text_kwargs={"size":8, "rotation":0})  # plot the stereographic projection of the rotations
+zone_axis_rot, directions = get_sample_zone_axis(
+    phase=p, density="7", return_directions=True
+)  # get the zone axis rotations
+zone_vect_rot = (
+    zone_axis_rot * Vector3d.zvector()
+)  # get the vector representation of the rotations
+zone_vect_rot.scatter(
+    grid=True, vector_labels=directions, text_kwargs={"size": 8, "rotation": 0}
+)  # plot the stereographic projection of the rotations
 
 # %%

--- a/examples/rotations/sampling_rotations.py
+++ b/examples/rotations/sampling_rotations.py
@@ -1,0 +1,37 @@
+"""
+==================
+Sampling rotations
+==================
+
+This example shows how to sample some phase object in Orix. We will
+get both the zone axis and the reduced fundamental zone rotations for
+the phase of interest.
+"""
+from diffpy.structure import Atom, Lattice, Structure
+from orix.crystal_map import Phase
+from orix.sampling import (get_sample_reduced_fundamental, get_sample_zone_axis,)
+from orix.vector import Vector3d
+
+a = 5.431
+latt = Lattice(a, a, a, 90, 90, 90)
+atom_list = []
+for coords in [[0, 0, 0], [0.5, 0, 0.5], [0, 0.5, 0.5], [0.5, 0.5, 0]]:
+    x, y, z = coords[0], coords[1], coords[2]
+    atom_list.append(Atom(atype="Si", xyz=[x, y, z], lattice=latt))  # Motif part A
+    atom_list.append(
+        Atom(atype="Si", xyz=[x + 0.25, y + 0.25, z + 0.25], lattice=latt)
+    )  # Motif part B
+struct = Structure(atoms=atom_list, lattice=latt)
+p = Phase(structure=struct, space_group=227)
+reduced_fun = get_sample_reduced_fundamental(resolution=4, point_group=p.point_group)
+
+vect_rot = reduced_fun*Vector3d.zvector()  # get the vector representation of the rotations
+vect_rot.scatter(grid=True)  # plot the stereographic projection of the rotations
+
+# %%
+
+zone_axis_rot, directions = get_sample_zone_axis(phase=p, density="7", return_directions=True)  # get the zone axis rotations
+zone_vect_rot = zone_axis_rot*Vector3d.zvector()  # get the vector representation of the rotations
+zone_vect_rot.scatter(grid=True, vector_labels=directions, text_kwargs={"size":8, "rotation":0})  # plot the stereographic projection of the rotations
+
+# %%

--- a/orix/sampling/__init__.py
+++ b/orix/sampling/__init__.py
@@ -29,10 +29,11 @@ from orix.sampling.S2_sampling import (
 )
 from orix.sampling.S2_sampling import sampling_methods as sample_S2_methods
 from orix.sampling.SO3_sampling import uniform_SO3_sample
-from orix.sampling.sample_generators import get_sample_fundamental, get_sample_local
+from orix.sampling.sample_generators import get_sample_fundamental, get_sample_local, get_sample_reduced_fundamental
 
 __all__ = [
     "get_sample_fundamental",
+    "get_sample_reduced_fundamental",
     "get_sample_local",
     "sample_S2",
     "sample_S2_methods",

--- a/orix/sampling/__init__.py
+++ b/orix/sampling/__init__.py
@@ -29,12 +29,16 @@ from orix.sampling.S2_sampling import (
 )
 from orix.sampling.S2_sampling import sampling_methods as sample_S2_methods
 from orix.sampling.SO3_sampling import uniform_SO3_sample
-from orix.sampling.sample_generators import get_sample_fundamental, get_sample_local, get_sample_reduced_fundamental
+from orix.sampling.sample_generators import (get_sample_fundamental,
+                                             get_sample_local,
+                                             get_sample_reduced_fundamental,
+                                             get_sample_zone_axis)
 
 __all__ = [
     "get_sample_fundamental",
     "get_sample_reduced_fundamental",
     "get_sample_local",
+    "get_sample_zone_axis",
     "sample_S2",
     "sample_S2_methods",
     "uniform_SO3_sample",

--- a/orix/sampling/__init__.py
+++ b/orix/sampling/__init__.py
@@ -29,10 +29,12 @@ from orix.sampling.S2_sampling import (
 )
 from orix.sampling.S2_sampling import sampling_methods as sample_S2_methods
 from orix.sampling.SO3_sampling import uniform_SO3_sample
-from orix.sampling.sample_generators import (get_sample_fundamental,
-                                             get_sample_local,
-                                             get_sample_reduced_fundamental,
-                                             get_sample_zone_axis)
+from orix.sampling.sample_generators import (
+    get_sample_fundamental,
+    get_sample_local,
+    get_sample_reduced_fundamental,
+    get_sample_zone_axis,
+)
 
 __all__ = [
     "get_sample_fundamental",

--- a/orix/sampling/sample_generators.py
+++ b/orix/sampling/sample_generators.py
@@ -24,6 +24,11 @@ from orix.quaternion import OrientationRegion, Rotation, Symmetry
 from orix.quaternion.symmetry import get_point_group
 from orix.sampling.SO3_sampling import _three_uniform_samples_method, uniform_SO3_sample
 from orix.sampling._cubochoric_sampling import cubochoric_sampling
+from orix.quaternion import symmetry
+from orix.sampling import sample_S2
+from orix.vector import Vector3d
+
+from diffsims.rotations import ConstrainedRotation
 
 
 def get_sample_fundamental(
@@ -165,3 +170,56 @@ def _remove_larger_than_angle(rot: Rotation, max_angle: Union[int, float]) -> Ro
     mask = half_angles < half_angle
     rot_out = rot[mask]
     return rot_out
+
+
+def get_sample_reduced_fundamental(
+    resolution: float,
+    mesh: str = None,
+    point_group: Symmetry = None,
+) -> Rotation:
+    """Produces orientations to align various crystallographic directions with
+    the z-axis, with the constraint that the first Euler angle phi_1=0.
+    The crystallographic directions sample the fundamental zone, representing
+    the smallest region of symmetrically unique directions of the relevant
+    crystal system or point group.
+    Parameters
+    ----------
+    resolution
+        An angle in degrees representing the maximum angular distance to a
+        first nearest neighbor grid point.
+    mesh
+        Type of meshing of the sphere that defines how the grid is created. See
+        orix.sampling.sample_S2 for all the options. A suitable default is
+        chosen depending on the crystal system.
+        point_group
+        Symmetry operations that determines the unique directions. Defaults to
+        no symmetry, which means sampling all 3D unit vectors.
+    Returns
+    -------
+    ConstrainedRotation
+        (N, 3) array representing Euler angles for the different orientations
+    """
+    if point_group is None:
+        point_group = symmetry.C1
+
+    if mesh is None:
+        s2_auto_sampling_map = {
+            "triclinic": "icosahedral",
+            "monoclinic": "icosahedral",
+            "orthorhombic": "spherified_cube_edge",
+            "tetragonal": "spherified_cube_edge",
+            "cubic": "spherified_cube_edge",
+            "trigonal": "hexagonal",
+            "hexagonal": "hexagonal",
+        }
+        mesh = s2_auto_sampling_map[point_group.system]
+
+    s2_sample = sample_S2(resolution, method=mesh)
+    fundamental = s2_sample[s2_sample <= point_group.fundamental_sector]
+
+    phi = fundamental.polar
+    phi2 = (np.pi / 2 - fundamental.azimuth) % (2 * np.pi)
+    phi1 = np.zeros(phi2.shape[0])
+    euler_angles = np.vstack([phi1, phi, phi2]).T
+
+    return Rotation.from_euler(euler_angles, degrees=False)

--- a/orix/sampling/sample_generators.py
+++ b/orix/sampling/sample_generators.py
@@ -19,9 +19,9 @@
 from typing import Optional, Union
 
 import numpy as np
-from transforms3d.euler import axangle2euler
 
 from orix.quaternion import OrientationRegion, Rotation, Symmetry
+from orix.vector import Vector3d
 from orix.quaternion.symmetry import get_point_group
 from orix.sampling.SO3_sampling import _three_uniform_samples_method, uniform_SO3_sample
 from orix.sampling._cubochoric_sampling import cubochoric_sampling
@@ -307,10 +307,15 @@ def get_sample_zone_axis(
     else:
         raise ValueError("Density must be either 3 or 7")
 
-    euler_angles = np.array([
-        _get_rotation_from_z_to_direction(phase.structure, d) for d in direction_list
-    ])
+    # rotate the directions to the z axis
+    rots = np.stack(
+        [
+            Rotation.from_align_vectors(v, Vector3d.zvector()).data
+            for v in direction_list
+        ]
+    )
+    rotations = Rotation(rots)
     if return_directions:
-        return Rotation.from_euler(euler_angles), direction_list
+        return rotations, direction_list
     else:
-        return Rotation.from_euler(euler_angles)
+        return rotations

--- a/orix/sampling/sample_generators.py
+++ b/orix/sampling/sample_generators.py
@@ -190,7 +190,7 @@ def get_sample_reduced_fundamental(
         Type of meshing of the sphere that defines how the grid is created. See
         orix.sampling.sample_S2 for all the options. A suitable default is
         chosen depending on the crystal system.
-        point_group
+    point_group
         Symmetry operations that determines the unique directions. Defaults to
         no symmetry, which means sampling all 3D unit vectors.
     Returns
@@ -224,43 +224,6 @@ def get_sample_reduced_fundamental(
     return Rotation.from_euler(euler_angles, degrees=False)
 
 
-def _get_rotation_from_z_to_direction(structure, direction):
-    """
-    Finds the rotation that takes [001] to a given zone axis.
-    Parameters
-    ----------
-    structure : diffpy.structure.structure.Structure
-        The structure for which a rotation needs to be found.
-    direction : array like
-        [UVW] direction that the 'z' axis should end up point down.
-    Returns
-    -------
-    euler_angles : tuple
-        'rzxz' in degrees.
-    See Also
-    --------
-    generate_zap_map
-    :meth:`~diffsims.generators.rotation_list_generators.get_grid_around_beam_direction`
-    Notes
-    -----
-    This implementation works with an axis arrangement that has +x as
-    left to right, +y as bottom to top and +z as out of the plane of a
-    page. Rotations are counter clockwise as you look from the tip of the
-    axis towards the origin
-    """
-    # Case where we don't need a rotation, As axis is [0,0,z] or [0,0,0]
-    if np.dot(direction, [0, 0, 1]) == np.linalg.norm(direction):
-        return (0, 0, 0)
-    # Normalize our directions
-    cartesian_direction = structure.lattice.cartesian(direction)
-    cartesian_direction = cartesian_direction / np.linalg.norm(cartesian_direction)
-    # Find the rotation using cartesian vector geometry
-    rotation_axis = np.cross([0, 0, 1], cartesian_direction)
-    rotation_angle = np.arccos(np.dot([0, 0, 1], cartesian_direction))
-    euler = axangle2euler(rotation_axis, rotation_angle, axes="rzxz")
-    return euler
-
-
 def _corners_to_centroid_and_edge_centers(corners):
     """
     Produces the midpoints and center of a trio of corners
@@ -290,6 +253,15 @@ def get_sample_zone_axis(
 ) -> Rotation:
     """Produces rotations to align various crystallographic directions with
     the sample zone axes.
+
+    Parameters
+    ----------
+    density
+        Either '3' or '7' for the number of directions to return.
+    phase
+        The phase for which the zone axis rotations are required.
+    return_directions
+        If True, returns the directions as well as the rotations.
     """
     system = phase.point_group.system
     corners_dict = {

--- a/orix/sampling/sample_generators.py
+++ b/orix/sampling/sample_generators.py
@@ -20,14 +20,13 @@ from typing import Optional, Union
 
 import numpy as np
 
-from orix.quaternion import OrientationRegion, Rotation, Symmetry
-from orix.vector import Vector3d
+from orix.crystal_map import Phase
+from orix.quaternion import OrientationRegion, Rotation, Symmetry, symmetry
 from orix.quaternion.symmetry import get_point_group
+from orix.sampling import sample_S2
 from orix.sampling.SO3_sampling import _three_uniform_samples_method, uniform_SO3_sample
 from orix.sampling._cubochoric_sampling import cubochoric_sampling
-from orix.quaternion import symmetry
-from orix.sampling import sample_S2
-from orix.crystal_map import Phase
+from orix.vector import Vector3d
 
 
 def get_sample_fundamental(

--- a/orix/tests/sampling/test_sampling.py
+++ b/orix/tests/sampling/test_sampling.py
@@ -209,15 +209,18 @@ class TestSampleFundamental:
         atom_list = []
         for coords in [[0, 0, 0], [0.5, 0, 0.5], [0, 0.5, 0.5], [0.5, 0.5, 0]]:
             x, y, z = coords[0], coords[1], coords[2]
-            atom_list.append(Atom(atype="Si", xyz=[x, y, z], lattice=latt))  # Motif part A
+            atom_list.append(
+                Atom(atype="Si", xyz=[x, y, z], lattice=latt)
+            )  # Motif part A
             atom_list.append(
                 Atom(atype="Si", xyz=[x + 0.25, y + 0.25, z + 0.25], lattice=latt)
             )  # Motif part B
         struct = Structure(atoms=atom_list, lattice=latt)
         p = Phase(structure=struct, space_group=227)
         if get_directions:
-            rot, _ = get_sample_zone_axis(phase=p, density=density, return_directions=True)
+            rot, _ = get_sample_zone_axis(
+                phase=p, density=density, return_directions=True
+            )
         else:
             rot = get_sample_zone_axis(phase=p, density=density)
         assert isinstance(rot, Rotation)
-

--- a/orix/tests/sampling/test_sampling.py
+++ b/orix/tests/sampling/test_sampling.py
@@ -185,7 +185,7 @@ class TestSampleFundamental:
         assert np.isclose(ratio, 3, atol=0.2)
 
     def test_get_sample_reduced_fundamental(self):
-        rotations = get_sample_reduced_fundamental(resolution=4, point_group=C1)
+        rotations = get_sample_reduced_fundamental(resolution=4)
         rotations2 = get_sample_reduced_fundamental(resolution=4, point_group=C2)
         rotations4 = get_sample_reduced_fundamental(resolution=4, point_group=C4)
         rotations6 = get_sample_reduced_fundamental(resolution=4, point_group=C4)

--- a/orix/tests/sampling/test_sampling.py
+++ b/orix/tests/sampling/test_sampling.py
@@ -20,8 +20,13 @@ import numpy as np
 import pytest
 
 from orix.quaternion import Rotation
-from orix.quaternion.symmetry import C2, C6, D6, get_point_group
-from orix.sampling import get_sample_fundamental, get_sample_local, uniform_SO3_sample
+from orix.quaternion.symmetry import C1, C2, C4, C6, D6, get_point_group
+from orix.sampling import (
+    get_sample_fundamental,
+    get_sample_local,
+    uniform_SO3_sample,
+    get_sample_reduced_fundamental,
+)
 from orix.sampling.SO3_sampling import _resolution_to_num_steps
 from orix.sampling._polyhedral_sampling import (
     _get_angles_between_nn_gridpoints,
@@ -175,3 +180,19 @@ class TestSampleFundamental:
         C2_sample = get_sample_fundamental(4, space_group=3, method="haar_euler")
         ratio = C2_sample.size / C6_sample.size
         assert np.isclose(ratio, 3, atol=0.2)
+
+    def test_get_sample_reduced_fundamental(self):
+        rotations = get_sample_reduced_fundamental(resolution=4, point_group=C1)
+        rotations2 = get_sample_reduced_fundamental(resolution=4, point_group=C2)
+        rotations4 = get_sample_reduced_fundamental(resolution=4, point_group=C4)
+        rotations6 = get_sample_reduced_fundamental(resolution=4, point_group=C4)
+
+        assert (
+            np.abs(rotations.size / rotations2.size) - 2 < 0.1
+        )  # about 2 times more rotations
+        assert (
+            np.abs(rotations2.size / rotations4.size) - 2 < 0.1
+        )  # about 2 times more rotations
+        assert (
+            np.abs(rotations.size / rotations6.size) - 6 < 0.1
+        )  # about 6 times more rotations

--- a/orix/tests/sampling/test_sampling.py
+++ b/orix/tests/sampling/test_sampling.py
@@ -16,20 +16,19 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
+from diffpy.structure import Atom, Lattice, Structure
 import numpy as np
 import pytest
 
-from diffpy.structure import Atom, Lattice, Structure
-
-from orix.quaternion import Rotation
 from orix.crystal_map import Phase
+from orix.quaternion import Rotation
 from orix.quaternion.symmetry import C1, C2, C4, C6, D6, get_point_group
 from orix.sampling import (
     get_sample_fundamental,
     get_sample_local,
-    uniform_SO3_sample,
     get_sample_reduced_fundamental,
     get_sample_zone_axis,
+    uniform_SO3_sample,
 )
 from orix.sampling.SO3_sampling import _resolution_to_num_steps
 from orix.sampling._polyhedral_sampling import (
@@ -201,7 +200,7 @@ class TestSampleFundamental:
             np.abs(rotations.size / rotations6.size) - 6 < 0.1
         )  # about 6 times more rotations
 
-    @pytest.mark.parametrize("density", ("3", "7"))
+    @pytest.mark.parametrize("density", ("3", "7", "5"))
     @pytest.mark.parametrize("get_directions", (True, False))
     def test_get_zone_axis(self, density, get_directions):
         a = 5.431
@@ -217,10 +216,14 @@ class TestSampleFundamental:
             )  # Motif part B
         struct = Structure(atoms=atom_list, lattice=latt)
         p = Phase(structure=struct, space_group=227)
-        if get_directions:
-            rot, _ = get_sample_zone_axis(
-                phase=p, density=density, return_directions=True
-            )
+        if density == "5":
+            with pytest.raises(ValueError):
+                get_sample_zone_axis(phase=p, density=density)
         else:
-            rot = get_sample_zone_axis(phase=p, density=density)
-        assert isinstance(rot, Rotation)
+            if get_directions:
+                rot, _ = get_sample_zone_axis(
+                    phase=p, density=density, return_directions=True
+                )
+            else:
+                rot = get_sample_zone_axis(phase=p, density=density)
+            assert isinstance(rot, Rotation)


### PR DESCRIPTION
#### Description of the change

Add in Sampling using reduced symmetry sampling.

Sampling Methods Added:
--------------------------
The first sampling functionality mirrors the S_2 sampling tutorial, but is more explicit such that  given some point group the rotations which rotate some vector [0,0,1] to each sampling vector is returned.  This is used when fast template matching in `pyxem`.

The second sampling method is just a simple method for finding zone axes in simple systems.  I think there are __much better__ ways of doing this and I'd like to improve this method from the old `diffsims` one (and I think kikuchipy already does some of that).


#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
from orix.symmetry import C2
from orix.sampling import get_sample_zone_axis
sampling = get_sample_zone_axis(2.0, point_group=C2)
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [x] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.