### PR TITLE
Performance: Speed up of deepcopy for Miller

### DIFF
--- a/orix/vector/miller.py
+++ b/orix/vector/miller.py
@@ -426,7 +426,10 @@ class Miller(Vector3d):
 
     def deepcopy(self) -> Miller:
         """Return a deepcopy of the instance."""
-        return deepcopy(self)
+        data = deepcopy(self.data)  # Otherwise, data is a view
+        copied = self.__class__(xyz=data, phase=self.phase) # deepcopy is slow.
+        copied.coordinate_format = self.coordinate_format
+        return copied
 
     def round(self, max_index: int = 20) -> Miller:
         """Round a set of index triplet (Miller) or quartet


### PR DESCRIPTION
#### Description of the change

Speeds up deep copy for `Miller` class.  Current deep copy is slowed down by using the `deepcopy` function. 

This causes issues in `diffsims` when we have to repeatedly copy and rotate some `ReciprocalLatticeVector`

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.