### PR TITLE
Ensure atom positions are expressed in the new basis when initializing Phase with structure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Fixed
 -----
 - Transparency of polar stereographic grid lines can now be controlled by Matplotlib's
   ``grid.alpha``, just like the azimuth grid lines.
+- Previously ``Phase`` was failing to adjust atom position to accomodate for the change of basis. This is now fixed.
 
 2023-03-14 - version 0.11.1
 ===========================

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -135,7 +135,10 @@ class Phase:
             old_matrix = value.lattice.base
             new_matrix = _new_structure_matrix_from_alignment(old_matrix, x="a", z="c*")
             value = copy.deepcopy(value)
+            # Ensure atom positions are expressed in the new basis
+            old_xyz_cartn = value.xyz_cartn
             value.lattice.setLatBase(new_matrix)
+            value.xyz_cartn = old_xyz_cartn
             if value.title == "" and hasattr(self, "_structure"):
                 value.title = self.name
             self._structure = value

--- a/orix/tests/test_phase_list.py
+++ b/orix/tests/test_phase_list.py
@@ -367,7 +367,7 @@ class TestPhase:
         phase = Phase(structure=structure)
         # xyz_cartn is independent of basis
         assert np.allclose(phase.structure.xyz_cartn, structure.xyz_cartn)
-        
+
         # however, Phase should (in many cases) change the basis.
         if np.allclose(structure.lattice.base, phase.structure.lattice.base):
             # In this branch we are in the same basis & all atoms should be the same

--- a/orix/tests/test_phase_list.py
+++ b/orix/tests/test_phase_list.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-from diffpy.structure import Lattice, Structure, Atom
+from diffpy.structure import Atom, Lattice, Structure
 from diffpy.structure.spacegroups import GetSpaceGroup
 import numpy as np
 import pytest

--- a/orix/tests/test_phase_list.py
+++ b/orix/tests/test_phase_list.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-from diffpy.structure import Lattice, Structure
+from diffpy.structure import Lattice, Structure, Atom
 from diffpy.structure.spacegroups import GetSpaceGroup
 import numpy as np
 import pytest
@@ -332,6 +332,48 @@ class TestPhase:
         assert np.allclose(ar.data, [0.588, 0.340, 0], atol=1e-3)
         assert np.allclose(br.data, [0, 0.679, 0], atol=1e-3)
         assert np.allclose(cr.data, [0, 0, 0.714], atol=1e-3)
+
+    @pytest.mark.parametrize(
+        ["lat", "atoms"],
+        [
+            [
+                Lattice(1, 1, 1, 90, 90, 90),
+                [
+                    Atom("C", [0, 0, 0]),
+                    Atom("C", [0.5, 0.5, 0.5]),
+                    Atom("C", [0.5, 0, 0]),
+                ],
+            ],
+            [
+                Lattice(1, 1, 1, 90, 90, 120),
+                [
+                    Atom("C", [0, 0, 0]),
+                    Atom("C", [0.5, 0, 0]),
+                    Atom("C", [0.5, 0.5, 0.5]),
+                ],
+            ],
+            [
+                Lattice(1, 2, 3, 90, 90, 60),
+                [
+                    Atom("C", [0, 0, 0]),
+                    Atom("C", [0.1, 0.1, 0.6]),
+                    Atom("C", [0.5, 0, 0]),
+                ],
+            ],
+        ],
+    )
+    def test_atom_positions(self, lat, atoms):
+        structure = Structure(atoms, lat)
+        phase = Phase(structure=structure)
+
+        assert np.allclose(phase.structure.xyz_cartn, structure.xyz_cartn)
+
+        if not np.allclose(structure.lattice.base, phase.structure.lattice.base):
+            # Not all atoms are necessarily changed. Therefore assert any
+            assert any(
+                not np.allclose(a.xyz, b.xyz)
+                for a, b in zip(structure, phase.structure)
+            )
 
     def test_from_cif(self, cif_file):
         """CIF files parsed correctly with space group and all."""


### PR DESCRIPTION
Fixes (part of) https://github.com/pyxem/diffsims/issues/203
#### Description of the change
When initializing a `Phase` with a `diffpy.structure.Structure`, the lattice is transformed to orix's standard coordinate system. However, the atoms are still expressed as if they were in the old lattice. 
By taking the cartesian positions of the atoms before changing the lattice, and using those to set the new positions, the change of basis is accounted for.

All tests pass, but I don't think this was tested for previously. It probably should.

#### Progress of the PR
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### Minimal example of the bug fix or new feature
```python
from diffpy.structure import lattice, atom, Structure
from orix.crystal_map import Phase
import numpy as np

# Graphite
latt = lattice.Lattice(2.464, 2.464, 6.711, 90, 90, 120)
atoms = [atom.Atom(atype='C', xyz=[0.0, 0.0, 0.25], lattice=latt),
         atom.Atom(atype='C', xyz=[0.0, 0.0, 0.75], lattice=latt),
         atom.Atom(atype='C', xyz=[1/3, 2/3, 0.25], lattice=latt),
         atom.Atom(atype='C', xyz=[2/3, 1/3, 0.75], lattice=latt),
         ]
structure = Structure(atoms=atoms, lattice=latt)

phase = Phase("Graphite", point_group="6/mmm",  structure=structure)

# The lattice has been transformed
assert not np.allclose(structure.lattice.base, phase.structure.lattice.base)

for i in range(len(atoms)):
    print("xyz-basis:  ", structure[i])
    print("phase-basis:", phase.structure[i])
    print()
```
Output before:
```
xyz-basis:   C    0.000000 0.000000 0.250000 1.0000
phase-basis: C    0.000000 0.000000 0.250000 1.0000

xyz-basis:   C    0.000000 0.000000 0.750000 1.0000
phase-basis: C    0.000000 0.000000 0.750000 1.0000

xyz-basis:   C    0.333333 0.666667 0.250000 1.0000
phase-basis: C    0.333333 0.666667 0.250000 1.0000

xyz-basis:   C    0.666667 0.333333 0.750000 1.0000
phase-basis: C    0.666667 0.333333 0.750000 1.0000
```
Output with this PR:
```
xyz-basis:   C    0.000000 0.000000 0.250000 1.0000
phase-basis: C    0.000000 0.000000 0.250000 1.0000

xyz-basis:   C    0.000000 0.000000 0.750000 1.0000
phase-basis: C    0.000000 0.000000 0.750000 1.0000

xyz-basis:   C    0.333333 0.666667 0.250000 1.0000
phase-basis: C    0.577350 0.577350 0.250000 1.0000

xyz-basis:   C    0.666667 0.333333 0.750000 1.0000
phase-basis: C    0.577350 -0.000000 0.750000 1.0000
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.