### PR TITLE
CI: Add pre-commit CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,7 @@ repos:
         name: isort (python)
         args:
           [--profile=black, --filter-files, --force-sort-within-sections]
+ci:
+  # Don't run automatically on PRs, instead add the comment
+  # "pre-commit.ci autofix" on a pull request to manually trigger auto-fixing
+  autofix_prs: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 24.3.0
     hooks:
       - id: black
       - id: black-jupyter

--- a/orix/_base.py
+++ b/orix/_base.py
@@ -196,9 +196,7 @@ class Object3d:
         obj._data = self._data.T.reshape(real_dim, -1).T
         return obj
 
-    def unique(
-        self, return_index: bool = False, return_inverse: bool = False
-    ) -> Union[
+    def unique(self, return_index: bool = False, return_inverse: bool = False) -> Union[
         Tuple[Object3d, np.ndarray, np.ndarray],
         Tuple[Object3d, np.ndarray],
         Object3d,


### PR DESCRIPTION
#### CI: Add pre-commit CI

This adds lines to pre-commit for CI to run isort and black from a comment to a PR.

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [x] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.