### PR TITLE
Numpy 2.0.0 Fixes

### DIFF
--- a/orix/quaternion/symmetry.py
+++ b/orix/quaternion/symmetry.py
@@ -417,7 +417,7 @@ class Symmetry(Rotation):
     def get_highest_order_axis(self) -> Tuple[Vector3d, np.ndarray]:
         axis_orders = self.get_axis_orders()
         if len(axis_orders) == 0:
-            return Vector3d.zvector(), np.infty
+            return Vector3d.zvector(), np.inf
         highest_order = max(axis_orders.values())
         axes = Vector3d.stack(
             [ao for ao in axis_orders if axis_orders[ao] == highest_order]


### PR DESCRIPTION
#### Description of the change
Running:
```ruff orix/ --select NPY201 --preview```

```
orix/quaternion/symmetry.py:420:40: NPY201 [*] `np.infty` will be removed in NumPy 2.0. Use `numpy.inf` instead.
Found 1 error.
```