### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,8 +65,8 @@ jobs:
         python-version: ['3.10', '3.11']
         include:
           - os: ubuntu-latest
-            python-version: 3.7
-            DEPENDENCIES: diffpy.structure==3  matplotlib==3.5
+            python-version: 3.8
+            DEPENDENCIES: diffpy.structure==3.0.2  matplotlib==3.5
             LABEL: -oldest
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,10 @@ Changed
 - ``random()`` methods no longer accept a list as a valid shape: pass a tuple instead.
 - Increase minimal version of Matplotlib to >= 3.5.
 
+Removed
+-------
+- Support for Python 3.7.
+
 Deprecated
 ----------
 - Creating quaternions from neo-eulerian vectors via ``from_neo_euler()`` is deprecated

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -4,7 +4,8 @@ Installation
 
 orix can be installed with `pip <https://pypi.org/project/orix/>`__,
 `conda <https://anaconda.org/conda-forge/orix>`__ or from source, and supports Python
->= 3.7. All alternatives are available on Windows, macOS and Linux.
+>= 3.8.
+All alternatives are available on Windows, macOS and Linux.
 
 .. _install-with-pip:
 

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ setup(
     long_description_content_type="text/x-rst",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -79,7 +78,7 @@ setup(
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Physics",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     packages=find_packages(exclude=["orix/tests"]),
     extras_require=extra_feature_requirements,
     # fmt: off


### PR DESCRIPTION
#### Description of the change
Drops support for Python 3.7. Closes #482.

The changes I've made I did after searching for "3.7" in the source code. I didn't search very long, but I could not find any code which could be removed or simplified.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.