### PR TITLE
Update README to use status badge table, rephrase reference to MTEX

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,41 +11,72 @@
 .. in the source distributions uploaded to PyPI
 .. EXCLUDE
 
-|binder|_ |build_status|_ |Coveralls|_ |docs|_ |pypi_version|_  |downloads|_ |black|_ |doi|_
-
-.. |binder| image:: https://mybinder.org/badge_logo.svg
-.. _binder: https://mybinder.org/v2/gh/pyxem/orix/HEAD
-
-.. |build_status| image:: https://github.com/pyxem/orix/workflows/build/badge.svg
-.. _build_status: https://github.com/pyxem/orix/actions
-
-.. |Coveralls| image:: https://coveralls.io/repos/github/pyxem/orix/badge.svg?branch=develop
-.. _Coveralls: https://coveralls.io/github/pyxem/orix?branch=develop
-
-.. |docs| image:: https://readthedocs.org/projects/orix/badge/?version=latest
-.. _docs: https://orix.readthedocs.io/en/latest
-
-.. |pypi_version| image:: https ://img.shields.io/pypi/v/orix.svg?style=flat
-.. _pypi_version: https://pypi.python.org/pypi/orix
-
-.. |downloads| image:: https://anaconda.org/conda-forge/orix/badges/downloads.svg
-.. _downloads: https://anaconda.org/conda-forge/orix
-
-.. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
-.. _black: https://github.com/psf/black
-
-.. |doi| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3459662.svg
-.. _doi: https://doi.org/10.5281/zenodo.3459662
-
 orix is an open-source Python library for analysing orientations and crystal symmetry.
 
 The package defines objects and functions for the analysis of orientations represented
-as quaternions or 3D rotation vectors accounting for crystal symmetry. Functionality
-builds primarily on `NumPy <https://www.numpy.org>`_ and `Matplotlib
-<https://matplotlib.org>`_ and is heavily inspired by the MATLAB package `MTEX
-<https://mtex-toolbox.github.io>`_.
+as quaternions and 3D rotation vectors, accounting for crystal symmetry.
+Functionality builds primarily on `NumPy <https://www.numpy.org>`_ and `Matplotlib
+<https://matplotlib.org>`_.
+Initiation of the package was inspired by `MTEX <https://mtex-toolbox.github.io>`_.
 
 orix is released under the GPL v3 license.
+
+.. |pypi_version| image:: https://img.shields.io/pypi/v/orix.svg?style=flat
+   :target: https://pypi.python.org/pypi/orix
+
+.. |conda| image:: https://img.shields.io/conda/vn/conda-forge/orix.svg?logo=conda-forge&logoColor=white
+   :target: https://anaconda.org/conda-forge/orix
+
+.. |build_status| image:: https://github.com/pyxem/orix/workflows/build/badge.svg
+   :target: https://github.com/pyxem/orix/actions/workflows/build.yml
+
+.. |python| image:: https://img.shields.io/badge/python-3.8+-blue.svg
+   :target: https://www.python.org/downloads/
+
+.. |Coveralls| image:: https://coveralls.io/repos/github/pyxem/orix/badge.svg?branch=develop
+   :target: https://coveralls.io/github/pyxem/orix?branch=develop
+
+.. |pypi_downloads| image:: https://img.shields.io/pypi/dm/orix.svg?label=PyPI%20downloads
+   :target: https://pypi.org/project/orix/
+
+.. |conda_downloads| image:: https://img.shields.io/conda/dn/conda-forge/orix.svg?label=Conda%20downloads
+   :target: https://anaconda.org/conda-forge/orix
+
+.. |doi| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3459662.svg
+   :target: https://doi.org/10.5281/zenodo.3459662
+
+.. |GPLv3| image:: https://img.shields.io/github/license/pyxem/orix
+   :target: https://opensource.org/license/GPL-3.0
+
+.. |GH-discuss| image:: https://img.shields.io/badge/GitHub-Discussions-green?logo=github
+   :target: https://github.com/pyxem/orix/discussions
+
+.. |binder| image:: https://mybinder.org/badge_logo.svg
+   :target: https://mybinder.org/v2/gh/pyxem/orix/HEAD
+
+.. |docs| image:: https://readthedocs.org/projects/orix/badge/?version=latest
+   :target: https://orix.readthedocs.io/en/latest
+
+.. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
+   :target: https://github.com/psf/black
+
++----------------------+------------------------------------------------+
+| Deployment           | |pypi_version| |conda|                         |
++----------------------+------------------------------------------------+
+| Build status         | |build_status| |docs| |python|                 |
++----------------------+------------------------------------------------+
+| Metrics              | |Coveralls|                                    |
++----------------------+------------------------------------------------+
+| Activity             | |pypi_downloads| |conda_downloads|             |
++----------------------+------------------------------------------------+
+| Citation             | |doi|                                          |
++----------------------+------------------------------------------------+
+| License              | |GPLv3|                                        |
++----------------------+------------------------------------------------+
+| Community            | |GH-discuss|                                   |
++----------------------+------------------------------------------------+
+| Formatter            | |black|                                        |
++----------------------+------------------------------------------------+
 
 Documentation
 -------------
@@ -65,17 +96,17 @@ or ``conda``::
 
     conda install orix -c conda-forge
 
-You can also visit `PyPI <https://pypi.org/project/orix>`_, `Anaconda
-<https://anaconda.org/conda-forge/orix>`_ or `GitHub <https://github.com/pyxem/orix>`_
-to download the source.
+The source code is hosted in `GitHub <https://github.com/pyxem/orix>`_, and can also be
+downloaded from `PyPI <https://pypi.org/project/orix>`_ and
+`Anaconda <https://anaconda.org/conda-forge/orix>`_.
 
-Further details are available in the `installation guide
-<https://orix.readthedocs.io/en/latest/user/installation.html>`_.
+Further details are available in the
+`installation guide <https://orix.readthedocs.io/en/latest/user/installation.html>`_.
 
 Citing orix
 -----------
 
 If analysis using orix forms a part of published work please cite the paper (`journal
 <https://doi.org/10.1107/S1600576720011103>`_, `arXiv
-<https://arxiv.org/abs/2001.02716>`_) and/or `the software
+<https://arxiv.org/abs/2001.02716>`_) and `the software
 <https://doi.org/10.5281/zenodo.3459662>`_.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -5,9 +5,10 @@ orix |release| documentation
 orix is an open-source Python library for analysing orientations and crystal symmetry.
 
 The package defines objects and functions for the analysis of orientations accounting
-for crystal symmetry. Functionality builds primarily on `NumPy <https://www.numpy.org>`_
-and `Matplotlib <https://matplotlib.org>`_, and is heavily inspired by the MATLAB
-package `MTEX <https://mtex-toolbox.github.io>`_.
+for crystal symmetry.
+Functionality builds primarily on `NumPy <https://www.numpy.org>`_ and `Matplotlib
+<https://matplotlib.org>`_.
+Initiation of the package was inspired by `MTEX <https://mtex-toolbox.github.io>`_.
 
 .. toctree::
     :hidden:


### PR DESCRIPTION
#### Description of the change
The current README.rst have started to show underscores after badges. Should be fine now.

1. Given how much this project has moved on from its beginning, I've rephrased the reference to MTEX in the README from

> [...] heavily inspired by the MATLAB package [MTEX](https://mtex-toolbox.github.io/).

to

> Initiation of the package was inspired by [MTEX](https://mtex-toolbox.github.io).

2. I've organized badges in a table similar to how we do it in [kikuchipy](https://github.com/pyxem/kikuchipy), which was inspired by [PyVista](https://github.com/pyvista/pyvista).

3. And, I've changed the phrasing under "Citing orix" slightly to more strongly encourage citation of both the 2020 paper *and* the software (Zenodo DOI).

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.