### PR TITLE
Discrepancy between Phase.from_cif and Phase(structure)

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -47,6 +47,10 @@
       "affiliation": "Norwegian University of Science and Technology"
     },
     {
+      "name": "Alessandra da Silva",
+      "orcid": "0000-0003-0465-504X"
+    },
+    {
       "name": "Alexander Clausen",
       "orcid": "0000-0002-9555-7455",
       "affiliation": "Jülich Research Centre, Ernst Ruska Centre"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,9 +11,9 @@ its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>
 
 Fixed
 -----
-- ``Phase.from_cif()`` now correctly adjust atom positions when forcing
+- ``Phase.from_cif()`` now correctly adjusts atom positions when forcing
   ``Phase.structure.lattice.base`` to use the crystal axes alignment ``e1 || a``,
-  ``e3 || c*``.
+  ``e3 || c*``. This bug was introduced in 0.12.0.
 
 2024-04-13 - version 0.12.0
 ===========================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,24 +6,14 @@ All user facing changes to this project are documented in this file. The format 
 on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`__, and this project tries
 its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`__.
 
-Unreleased
-==========
-
-Added
------
-
-Changed
--------
-
-Removed
--------
-
-Deprecated
-----------
+2024-04-20 - version 0.12.1
+===========================
 
 Fixed
 -----
-
+- ``Phase.from_cif()`` now correctly adjust atom positions when forcing
+  ``Phase.structure.lattice.base`` to use the crystal axes alignment ``e1 || a``,
+  ``e3 || c*``.
 
 2024-04-13 - version 0.12.0
 ===========================

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -16,5 +16,6 @@ __credits__ = [
     "Carter Francis",
     "Simon Høgås",
     "Viljar Johan Femoen",
+    "Alessandra da Silva", 
     "Alexander Clausen",
 ]

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -16,6 +16,6 @@ __credits__ = [
     "Carter Francis",
     "Simon Høgås",
     "Viljar Johan Femoen",
-    "Alessandra da Silva", 
+    "Alessandra da Silva",
     "Alexander Clausen",
 ]

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -1,5 +1,5 @@
 __name__ = "orix"
-__version__ = "0.13.dev0"
+__version__ = "0.12.1"
 __author__ = "orix developers"
 __author_email__ = "pyxem.team@gmail.com"
 __description__ = "orix is an open-source Python library for handling crystal orientation mapping data."

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -339,9 +339,6 @@ class Phase:
         parser = p_cif.P_cif()
         name = os.path.splitext(os.path.split(filename)[1])[0]
         structure = parser.parseFile(filename)
-        lattice = structure.lattice
-        new_base = _new_structure_matrix_from_alignment(lattice.base, x="a", z="c*")
-        lattice.setLatBase(new_base)
         space_group = parser.spacegroup.number
         return cls(name, space_group, structure=structure)
 

--- a/orix/tests/test_phase_list.py
+++ b/orix/tests/test_phase_list.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-from diffpy.structure import Atom, Lattice, Structure
+from diffpy.structure import Atom, Lattice, Structure, loadStructure
 from diffpy.structure.spacegroups import GetSpaceGroup
 import numpy as np
 import pytest
@@ -395,6 +395,12 @@ class TestPhase:
         assert np.allclose(
             lattice.base, [[15.5, 0, 0], [0, 4.05, 0], [-1.779, 0, 6.501]], atol=1e-3
         )
+        # check result is the same when defining structure directly
+        structure = loadStructure(cif_file)
+        phase2 = Phase(structure=structure)
+        assert np.allclose(phase.structure.lattice.base, phase2.structure.lattice.base)
+        assert np.allclose(phase.structure.xyz, phase2.structure.xyz)
+        assert np.allclose(phase.structure.xyz_cartn, phase2.structure.xyz_cartn)
 
 
 class TestPhaseList:

--- a/orix/tests/test_phase_list.py
+++ b/orix/tests/test_phase_list.py
@@ -395,12 +395,13 @@ class TestPhase:
         assert np.allclose(
             lattice.base, [[15.5, 0, 0], [0, 4.05, 0], [-1.779, 0, 6.501]], atol=1e-3
         )
-        # check result is the same when defining structure directly
+
+    def test_from_cif_same_structure(self, cif_file):
+        phase1 = Phase.from_cif(cif_file)
         structure = loadStructure(cif_file)
         phase2 = Phase(structure=structure)
-        assert np.allclose(phase.structure.lattice.base, phase2.structure.lattice.base)
-        assert np.allclose(phase.structure.xyz, phase2.structure.xyz)
-        assert np.allclose(phase.structure.xyz_cartn, phase2.structure.xyz_cartn)
+        assert np.allclose(phase1.structure.lattice.base, phase2.structure.lattice.base)
+        assert np.allclose(phase1.structure.xyz, phase2.structure.xyz)
 
 
 class TestPhaseList:


### PR DESCRIPTION
#### Description of the change
Hello,

there appears to be a discrepancy in the atom xyz positions between creating a Phase using from_cif and assigning a structure directly (Phase(structure)).

This appears to be because lattice alignment is perfomed twice when using from_cif, once in the method itself and once in the Phase.structure setter.

I have removed the alignment in Phase.from_cif, as it will be called in the Phase constructor and added some checks to the test below, which were previously failing with the double lattice alignment.

#### Progress of the PR
- [-] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### Minimal example of the bug fix or new feature
```python
from tempfile import NamedTemporaryFile

from orix.crystal_map import Phase
from diffpy.structure import loadStructure
import numpy as np

# from test
file_contents = """
#======================================================================

# CRYSTAL DATA

#----------------------------------------------------------------------

data_VESTA_phase_1


_chemical_name_common                  ''
_cell_length_a                         15.50000
_cell_length_b                         4.05000
_cell_length_c                         6.74000
_cell_angle_alpha                      90
_cell_angle_beta                       105.30000
_cell_angle_gamma                      90
_space_group_name_H-M_alt              'C 2/m'
_space_group_IT_number                 12

loop_
_space_group_symop_operation_xyz
   'x, y, z'
   '-x, -y, -z'
   '-x, y, -z'
   'x, -y, z'
   'x+1/2, y+1/2, z'
   '-x+1/2, -y+1/2, -z'
   '-x+1/2, y+1/2, -z'
   'x+1/2, -y+1/2, z'

loop_
   _atom_site_label
   _atom_site_occupancy
   _atom_site_fract_x
   _atom_site_fract_y
   _atom_site_fract_z
   _atom_site_adp_type
   _atom_site_B_iso_or_equiv
   _atom_site_type_symbol
   Mg(1)      1.0     0.000000      0.000000      0.000000     Biso  1.000000 Mg
   Mg(2)      1.0     0.347000      0.000000      0.089000     Biso  1.000000 Mg
   Mg(3)      1.0     0.423000      0.000000      0.652000     Biso  1.000000 Mg
   Si(1)      1.0     0.054000      0.000000      0.649000     Biso  1.000000 Si
   Si(2)      1.0     0.190000      0.000000      0.224000     Biso  1.000000 Si
   Al         1.0     0.211000      0.000000      0.626000     Biso  1.000000 Al"
"""

with NamedTemporaryFile(suffix=".cif", mode="w+", dir=".", delete=False) as f:
    f.write(file_contents)

structure = loadStructure(f.name)
phase = Phase(structure=structure)
phase_cif = Phase.from_cif(f.name)


# before fix
np.allclose(phase.structure.xyz, phase_cif.structure.xyz)
False

np.allclose(phase.structure.xyz_cartn, phase_cif.structure.xyz_cartn)
False
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [x] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.