### PR TITLE
Main into develop after 0.12.1.post0

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -18,6 +18,7 @@ clean:
 	rm -rf $(BUILDDIR)
 	rm -rf $(SOURCEDIR)/examples
 	rm -rf $(SOURCEDIR)/reference/generated
+	rm sg_execution_times.rst
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -20,7 +20,7 @@ build:
 # Doc formats
 formats:
   - htmlzip
-#  - pdf
+  - pdf
 
 conda:
   environment: doc/environment.yml

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,9 @@ extra_feature_requirements = {
     "doc": [
         "ipykernel",  # Used by nbsphinx to execute notebooks
         "memory_profiler",
+        # TODO: Remove nbconvert pin once
+        #  https://github.com/pyxem/orix/issues/494 is resolved
+        "nbconvert                      < 7.14",
         "nbsphinx                       >= 0.7",
         "numpydoc",
         "pydata-sphinx-theme",


### PR DESCRIPTION
#### Description of the change
Bring changes in main into develop after release of 0.12.1.post0.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.