### PR TITLE
BugFix: Allow get_kwargs for setting kwargs on __mul__

### DIFF
--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -240,7 +240,8 @@ class Quaternion(Object3d):
                 m.coordinate_format = other.coordinate_format
                 return m
             else:
-                return other.__class__(v)
+                kwargs = other.get_kwargs(self)
+                return other.__class__(v, **kwargs)
         return NotImplemented
 
     def __neg__(self) -> Quaternion:

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -240,8 +240,8 @@ class Quaternion(Object3d):
                 m.coordinate_format = other.coordinate_format
                 return m
             else:
-                kwargs = other.get_kwargs(self)
-                return other.__class__(v, **kwargs)
+                kwargs = other.get_kwargs(v, self)
+                return other.__class__(**kwargs)
         return NotImplemented
 
     def __neg__(self) -> Quaternion:

--- a/orix/vector/miller.py
+++ b/orix/vector/miller.py
@@ -161,6 +161,10 @@ class Miller(Vector3d):
         """
         return _transform_space(self.data, "c", "r", self.phase.structure.lattice)
 
+    def get_kwargs(self, new_data, *args, **kwargs) -> dict:
+        """Return the keyword arguments to create the instance."""
+        return dict(xyz=new_data)
+
     @hkl.setter
     def hkl(self, value: np.ndarray):
         """Set the reciprocal lattice vectors."""

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -219,31 +219,36 @@ class Vector3d(Object3d):
     # ------------------------ Dunder methods ------------------------ #
 
     def __neg__(self) -> Vector3d:
-        return self.__class__(-self.data)
+        kwargs = self.get_kwargs(new_data=-self.data)
+        return self.__class__(**kwargs)
 
     def __add__(
         self, other: Union[int, float, List, Tuple, np.ndarray, Vector3d]
     ) -> Vector3d:
         if isinstance(other, Vector3d):
-            return self.__class__(self.data + other.data)
+            kwargs = self.get_kwargs(new_data=self.data + other.data)
+            return self.__class__(**kwargs)
         elif isinstance(other, (int, float)):
-            return self.__class__(self.data + other)
+            kwargs = self.get_kwargs(new_data=self.data + other)
+            return self.__class__(**kwargs)
         elif isinstance(other, (list, tuple)):
             other = np.array(other)
-
         if isinstance(other, np.ndarray):
-            return self.__class__(self.data + other[..., np.newaxis])
+            kwargs = self.get_kwargs(new_data=self.data + other[..., np.newaxis])
+            return self.__class__(**kwargs)
 
         return NotImplemented
 
     def __radd__(self, other: Union[int, float, List, Tuple, np.ndarray]) -> Vector3d:
         if isinstance(other, (int, float)):
-            return self.__class__(other + self.data)
+            kwargs = self.get_kwargs(new_data=other + self.data)
+            return self.__class__(**kwargs)
         elif isinstance(other, (list, tuple)):
             other = np.array(other)
 
         if isinstance(other, np.ndarray):
-            return self.__class__(other[..., np.newaxis] + self.data)
+            kwargs = self.get_kwargs(new_data=other[..., np.newaxis] + self.data)
+            return self.__class__(**kwargs)
 
         return NotImplemented
 
@@ -251,14 +256,17 @@ class Vector3d(Object3d):
         self, other: Union[int, float, List, Tuple, np.ndarray, Vector3d]
     ) -> Vector3d:
         if isinstance(other, Vector3d):
-            return self.__class__(self.data - other.data)
+            kwargs = self.get_kwargs(new_data=self.data - other.data)
+            return self.__class__(**kwargs)
         elif isinstance(other, (int, float)):
-            return self.__class__(self.data - other)
+            kwargs = self.get_kwargs(self.data - other)
+            return self.__class__(**kwargs)
         elif isinstance(other, (list, tuple)):
             other = np.array(other)
 
         if isinstance(other, np.ndarray):
-            return self.__class__(self.data - other[..., np.newaxis])
+            kwargs = self.get_kwargs(self.data - other[..., np.newaxis])
+            return self.__class__(**kwargs)
 
         return NotImplemented
 
@@ -282,23 +290,27 @@ class Vector3d(Object3d):
                 "Try `.dot` or `.cross` instead."
             )
         elif isinstance(other, (int, float)):
-            return self.__class__(self.data * other)
+            kwargs = self.get_kwargs(new_data=self.data * other)
+            return self.__class__(**kwargs)
         elif isinstance(other, (list, tuple)):
             other = np.array(other)
 
         if isinstance(other, np.ndarray):
-            return self.__class__(self.data * other[..., np.newaxis])
+            kwargs = self.get_kwargs(new_data=self.data * other[..., np.newaxis])
+            return self.__class__(**kwargs)
 
         return NotImplemented
 
     def __rmul__(self, other: Union[int, float, List, Tuple, np.ndarray]) -> Vector3d:
         if isinstance(other, (int, float)):
-            return self.__class__(other * self.data)
+            kwargs = self.get_kwargs(new_data=other * self.data)
+            return self.__class__(**kwargs)
         elif isinstance(other, (list, tuple)):
             other = np.array(other)
 
         if isinstance(other, np.ndarray):
-            return self.__class__(other[..., np.newaxis] * self.data)
+            kwargs = self.get_kwargs(new_data=other[..., np.newaxis] * self.data)
+            return self.__class__(**kwargs)
 
         return NotImplemented
 
@@ -308,12 +320,14 @@ class Vector3d(Object3d):
         if isinstance(other, Vector3d):
             raise ValueError("Dividing vectors is undefined")
         elif isinstance(other, (int, float)):
-            return self.__class__(self.data / other)
+            kwargs = self.get_kwargs(new_data=self.data / other)
+            return self.__class__(**kwargs)
         elif isinstance(other, (list, tuple)):
             other = np.array(other)
 
         if isinstance(other, np.ndarray):
-            return self.__class__(self.data / other[..., np.newaxis])
+            kwargs = self.get_kwargs(new_data=self.data / other[..., np.newaxis])
+            return self.__class__(**kwargs)
 
         return NotImplemented
 
@@ -731,10 +745,10 @@ class Vector3d(Object3d):
             polar = np.rad2deg(polar)
         return azimuth, polar, self.radial
 
-    def get_kwargs(self, *args, **kwargs) -> Dict[str, Any]:
+    def get_kwargs(self, new_data, *args, **kwargs) -> Dict[str, Any]:
         """Return the dictionary of attributes to be used in the
         constructor when applying an ufunc."""
-        return {}
+        return dict(data=new_data)
 
     def in_fundamental_sector(self, symmetry: "Symmetry") -> Vector3d:
         """Project vectors to a symmetry's fundamental sector (inverse

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -731,6 +731,11 @@ class Vector3d(Object3d):
             polar = np.rad2deg(polar)
         return azimuth, polar, self.radial
 
+    def get_kwargs(self, *args, **kwargs) -> Dict[str, Any]:
+        """Return the dictionary of attributes to be used in the
+        constructor when applying an ufunc."""
+        return {}
+
     def in_fundamental_sector(self, symmetry: "Symmetry") -> Vector3d:
         """Project vectors to a symmetry's fundamental sector (inverse
         pole figure).


### PR DESCRIPTION
#### Description of the change
This should fix (part) of the problems upstream with https://github.com/pyxem/diffsims/issues/211 by allowing the function `get_kwargs` to be overwritten in subclasses and change the order/what is passed to the __init__ fuction.


#### Minimal example of the bug fix or new feature (This now works)
```python
from orix.crystal_map import Phase
from orix.quaternion import Rotation
from diffsims.crystallography import ReciprocalLatticeVector


phase = Phase(point_group="m-3m")
g = ReciprocalLatticeVector(phase, [1, 1, 1])

R = Rotation.random()
g1 = R * g

# CHanges to RLV
# ---------------- 

    def get_kwargs(self, new_data, *args, **kwargs):
        return dict(phase=self.phase, xyz=new_data)
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.