### PR TITLE
Update valid nbconvert versions to < 7.14, >= 7.16.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,7 @@ extra_feature_requirements = {
     "doc": [
         "ipykernel",  # Used by nbsphinx to execute notebooks
         "memory_profiler",
-        # TODO: Remove nbconvert pin once
-        #  https://github.com/pyxem/orix/issues/494 is resolved
-        "nbconvert                      < 7.14",
+        "nbconvert                      >= 7.16.4",
         "nbsphinx                       >= 0.7",
         "numpydoc",
         "pydata-sphinx-theme",


### PR DESCRIPTION
#### Description of the change
Solves https://github.com/pyxem/orix/issues/494.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.