### PR TITLE
Minor dev updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: build
 
 on:
   push:
-    branches:
-      - '*'
     branches-ignore:
       - 'pre-commit-ci-update-config'
   pull_request:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,12 @@ on:
   push:
     branches:
       - '*'
+    branches-ignore:
+      - 'pre-commit-ci-update-config'
   pull_request:
     branches:
       - '*'
   workflow_dispatch:
-    workflow: '*'
 
 jobs:
   code:

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -35,6 +35,11 @@
       "affiliation": "Norwegian University of Science and Technology"
     },
     {
+      "name": "Zhou Xu",
+      "orcid": "0000-0002-7599-1166",
+      "affiliation": "Monash Centre for Electron Microscopy"
+    },
+    {
       "name": "Carter Francis",
       "orcid": "0000-0003-2564-1851",
       "affiliation": "University of Wisconsin Madison"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,10 @@ Changed
 
 Removed
 -------
+- Removed deprecated ``from_neo_euler()`` method for ``Quaternion`` and its subclasses.
+- Removed deprecated argument ``convention`` in ``from_euler()`` and ``to_euler()``
+  methods for ``Quaternion`` and its subclasses. Use ``direction`` instead. Passing
+  ``convention`` will now raise an error.
 
 Deprecated
 ----------

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -13,6 +13,7 @@ __credits__ = [
     "Duncan Johnstone",
     "Niels Cautaerts",
     "Anders Christian Mathisen",
+    "Zhou Xu",
     "Carter Francis",
     "Simon Høgås",
     "Viljar Johan Femoen",

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -29,11 +29,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 from scipy.spatial.transform import Rotation as SciPyRotation
 
-from orix._util import deprecated
 from orix.quaternion.misorientation import Misorientation
 from orix.quaternion.rotation import Rotation
 from orix.quaternion.symmetry import C1, Symmetry, _get_unique_symmetry_elements
-from orix.vector import Miller, NeoEuler, Vector3d
+from orix.vector import Miller, Vector3d
 
 
 class Orientation(Misorientation):
@@ -107,7 +106,6 @@ class Orientation(Misorientation):
 
     # ------------------------ Class methods ------------------------- #
 
-    # TODO: Remove use of **kwargs in 1.0
     @classmethod
     def from_euler(
         cls,
@@ -115,7 +113,6 @@ class Orientation(Misorientation):
         symmetry: Optional[Symmetry] = None,
         direction: str = "lab2crystal",
         degrees: bool = False,
-        **kwargs,
     ) -> Orientation:
         """Create orientations from sets of Euler angles
         :cite:`rowenhorst2015consistent`.
@@ -141,7 +138,7 @@ class Orientation(Misorientation):
         O
             Orientations.
         """
-        O = super().from_euler(euler, direction=direction, degrees=degrees, **kwargs)
+        O = super().from_euler(euler, direction=direction, degrees=degrees)
         if symmetry:
             O.symmetry = symmetry
         return O
@@ -257,32 +254,6 @@ class Orientation(Misorientation):
             Orientations.
         """
         O = super().from_matrix(matrix)
-        if symmetry:
-            O.symmetry = symmetry
-        return O
-
-    # TODO: Remove before 0.13.0
-    @classmethod
-    @deprecated(since="0.12", removal="0.13", alternative="from_axes_angles")
-    def from_neo_euler(
-        cls, neo_euler: NeoEuler, symmetry: Optional[Symmetry] = None
-    ) -> Orientation:
-        """Create orientations from a neo-euler (vector) representation.
-
-        Parameters
-        ----------
-        neo_euler
-            Vector parametrization of orientation(s).
-        symmetry
-            Symmetry of orientation(s). If not given (default), no
-            symmetry is set.
-
-        Returns
-        -------
-        O
-            Orientations.
-        """
-        O = super().from_neo_euler(neo_euler)
         if symmetry:
             O.symmetry = symmetry
         return O

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -28,12 +28,8 @@ import quaternion
 from scipy.spatial.transform import Rotation as SciPyRotation
 
 from orix._base import Object3d
-from orix._util import deprecated, deprecated_argument
 from orix.quaternion import _conversions
 from orix.vector import AxAngle, Homochoric, Miller, Rodrigues, Vector3d
-
-# Used to round values below 1e-16 to zero
-_FLOAT_EPS = np.finfo(float).eps
 
 
 class Quaternion(Object3d):
@@ -259,31 +255,6 @@ class Quaternion(Object3d):
 
     # ------------------------ Class methods ------------------------- #
 
-    # TODO: Remove before 0.13.0
-    @classmethod
-    @deprecated(since="0.12", removal="0.13", alternative="from_axes_angles")
-    def from_neo_euler(cls, neo_euler: "NeoEuler") -> Quaternion:
-        """Create unit quaternion(s) from a neo-euler (vector)
-        representation.
-
-        Parameters
-        ----------
-        neo_euler
-            Vector parametrization of quaternions.
-
-        Returns
-        -------
-        Q
-            Unit quaternion(s).
-        """
-        s = np.sin(neo_euler.angle / 2)
-        a = np.cos(neo_euler.angle / 2)
-        b = s * neo_euler.axis.x
-        c = s * neo_euler.axis.y
-        d = s * neo_euler.axis.z
-        Q = cls(np.stack([a, b, c, d], axis=-1)).unit
-        return Q
-
     @classmethod
     def from_axes_angles(
         cls,
@@ -485,15 +456,12 @@ class Quaternion(Object3d):
 
         return Q
 
-    # TODO: Remove decorator, **kwargs, and use of "convention" in 0.13
     @classmethod
-    @deprecated_argument("convention", "0.9", "0.13", "direction")
     def from_euler(
         cls,
         euler: Union[np.ndarray, tuple, list],
         direction: str = "lab2crystal",
         degrees: bool = False,
-        **kwargs,
     ) -> Quaternion:
         """Create unit quaternions from Euler angle sets
         :cite:`rowenhorst2015consistent`.
@@ -517,9 +485,7 @@ class Quaternion(Object3d):
             Unit quaternions.
         """
         direction = direction.lower()
-        if direction == "mtex" or (
-            "convention" in kwargs and kwargs["convention"] == "mtex"
-        ):
+        if direction == "mtex":
             # MTEX' rotations are transformations from the crystal to
             # the lab reference frames. See
             # https://mtex-toolbox.github.io/MTEXvsBungeConvention.html
@@ -804,9 +770,7 @@ class Quaternion(Object3d):
 
     # ---------------------- All "to_*" methods- --------------------- #
 
-    # TODO: Remove decorator and **kwargs in 0.13
-    @deprecated_argument("convention", since="0.9", removal="0.13")
-    def to_euler(self, degrees: bool = False, **kwargs) -> np.ndarray:
+    def to_euler(self, degrees: bool = False) -> np.ndarray:
         r"""Return the unit quaternions as Euler angles in the Bunge
         convention :cite:`rowenhorst2015consistent`.
 

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -28,9 +28,6 @@ from scipy.special import hyp0f1
 from orix.quaternion import Quaternion
 from orix.vector import Vector3d
 
-# Used to round values below 1e-16 to zero
-_FLOAT_EPS = np.finfo(float).eps
-
 
 class Rotation(Quaternion):
     r"""Rotations of coordinate systems, leaving objects in place.

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-import warnings
-
 from diffpy.structure import Lattice, Structure
 import matplotlib.pyplot as plt
 import numpy as np
@@ -43,7 +41,7 @@ from orix.quaternion.symmetry import (
     _groups,
     _proper_groups,
 )
-from orix.vector import AxAngle, Miller, Vector3d 
+from orix.vector import Miller, Vector3d 
 # isort: on
 # fmt: on
 
@@ -522,22 +520,7 @@ class TestOrientationInitialization:
         ):
             _ = Orientation.from_align_vectors(a, b)
 
-    def test_from_neo_euler_symmetry(self):
-        v = AxAngle.from_axes_angles(axes=Vector3d.zvector(), angles=np.pi / 2)
-        with pytest.warns(np.VisibleDeprecationWarning):
-            o1 = Orientation.from_neo_euler(v)
-        assert np.allclose(o1.data, [0.7071, 0, 0, 0.7071])
-        assert o1.symmetry.name == "1"
-        with pytest.warns(np.VisibleDeprecationWarning):
-            o2 = Orientation.from_neo_euler(v, symmetry=Oh)
-        o2 = o2.map_into_symmetry_reduced_zone()
-        assert np.allclose(o2.data, [-1, 0, 0, 0])
-        assert o2.symmetry.name == "m-3m"
-        o3 = Orientation(o1.data, symmetry=Oh)
-        o3 = o3.map_into_symmetry_reduced_zone()
-        assert np.allclose(o3.data, o2.data)
-
-    def test_from_axes_angles(self, rotations):
+    def test_from_axes_angles(self):
         axis = Vector3d.xvector() - Vector3d.yvector()
         angle = np.pi / 2
         o1 = Orientation.from_axes_angles(axis, angle, Oh)
@@ -586,58 +569,6 @@ class TestOrientationInitialization:
         # Raises an appropriate error message
         with pytest.raises(TypeError, match="Value must be an instance of"):
             _ = Orientation.from_scipy_rotation(r_scipy, (Oh, Oh))
-
-    # TODO: Remove in 0.13
-    def test_from_euler_warns(self):
-        """Orientation.from_euler() warns only once when "convention"
-        argument is passed.
-        """
-        euler = np.random.rand(10, 3)
-
-        with warnings.catch_warnings():
-            warnings.filterwarnings("error")
-            _ = Orientation.from_euler(euler)
-
-        msg = (
-            r"Argument `convention` is deprecated and will be removed in version 0.13. "
-            r"To avoid this warning, please do not use `convention`. "
-            r"Use `direction` instead. See the documentation of `from_euler\(\)` for "
-            "more details."
-        )
-        with pytest.warns(np.VisibleDeprecationWarning, match=msg) as record2:
-            _ = Orientation.from_euler(euler, convention="whatever")
-        assert len(record2) == 1
-
-    # TODO: Remove in 0.13
-    def test_from_euler_convention_mtex(self):
-        """Passing convention="mtex" to Orientation.from_euler() works
-        but warns once.
-        """
-        euler = np.random.rand(10, 3)
-        ori1 = Orientation.from_euler(euler, direction="crystal2lab")
-        with pytest.warns(np.VisibleDeprecationWarning, match=r"Argument `convention`"):
-            ori2 = Orientation.from_euler(euler, convention="mtex")
-        assert np.allclose(ori1.data, ori2.data)
-
-    # TODO: Remove in 0.13
-    def test_to_euler_convention_warns(self):
-        """Orientation.to_euler() warns only once when "convention"
-        argument is passed.
-        """
-        ori1 = Orientation.from_euler(np.random.rand(10, 3))
-
-        with warnings.catch_warnings():
-            warnings.filterwarnings("error")
-            ori2 = ori1.to_euler()
-
-        msg = (
-            r"Argument `convention` is deprecated and will be removed in version 0.13. "
-            r"To avoid this warning, please do not use `convention`. "
-            r"See the documentation of `to_euler\(\)` for more details."
-        )
-        with pytest.warns(np.VisibleDeprecationWarning, match=msg):
-            ori3 = ori1.to_euler(convention="whatever")
-        assert np.allclose(ori2, ori3)
 
 
 class TestOrientation:

--- a/orix/tests/test_vector3d.py
+++ b/orix/tests/test_vector3d.py
@@ -460,6 +460,16 @@ def test_zero_perpendicular():
         _ = Vector3d.zero((1,)).perpendicular
 
 
+def test_get_nearest():
+    v_ref = Vector3d.zvector()
+    v = Vector3d([[0, 0, 0.9], [0, 0, 0.8], [0, 0, 1.1]])
+    v_nearest = v_ref.get_nearest(v)
+    assert np.allclose(v_nearest.data, [0, 0, 0.9])
+
+    with pytest.raises(AttributeError, match="`get_nearest` only works for "):
+        v.get_nearest(v_ref)
+
+
 class TestSpareNotImplemented:
     def test_radd_notimplemented(self, vector):
         with pytest.raises(TypeError):

--- a/orix/vector/neo_euler.py
+++ b/orix/vector/neo_euler.py
@@ -30,11 +30,14 @@ about a fixed axis.
 from __future__ import annotations
 
 import abc
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 import numpy as np
 
 from orix.vector import Vector3d
+
+if TYPE_CHECKING:  # pragma: no cover
+    from orix.quaternion import Rotation
 
 
 class NeoEuler(Vector3d, abc.ABC):

--- a/orix/vector/neo_euler.py
+++ b/orix/vector/neo_euler.py
@@ -140,7 +140,7 @@ class Rodrigues(NeoEuler):
         --------
         Quaternion.to_rodrigues
         """
-        a = np.float64(rotation.a)
+        a = rotation.a.astype(np.float64)
         with np.errstate(divide="ignore", invalid="ignore"):
             data = np.stack((rotation.b / a, rotation.c / a, rotation.d / a), axis=-1)
         data[np.isnan(data)] = 0

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -676,7 +676,8 @@ class Vector3d(Object3d):
         Vector3d (1,)
         [[0.6 0.  0. ]]
         """
-        assert self.size == 1, "`get_nearest` only works for single vectors."
+        if self.size != 1:
+            raise AttributeError("`get_nearest` only works for single vectors")
         tiebreak = Vector3d.zvector() if tiebreak is None else tiebreak
         eps = 1e-9 if inclusive else 0
         cosines = x.dot(self)


### PR DESCRIPTION
#### Description of the change
* List @IMBalENce among contributors. @IMBalENce, is this listing OK with you? I've added your affiliation and ORCID in the Zenodo JSON file.
* Prevent CI from running on branches created by pre-commit CI bot named *pre-commit-ci-update-config*. They will still run on PRs the bot opens.
* Improve some type hinting in the Miller class
* Replace an "assert check, raise" with "if, check, raise" in `Vector3d.get_nearest()`, add simple test
* Silence a NumPy warning (test suite is now free of warnings on my machine)
* Removed deprecated methods `from_neo_euler()` and the `convention` parameter to `from_euler()` and `to_euler()`

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.