### PR TITLE
Replace numpy-quaternion with quaternionic.

### DIFF
--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -122,6 +122,10 @@ class Quaternion(Object3d):
 
     dim = 4
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._data = quaternion.array(self.data)
+
     # -------------------------- Properties -------------------------- #
 
     @property
@@ -133,12 +137,12 @@ class Quaternion(Object3d):
         value : numpy.ndarray
             Scalar quaternion component.
         """
-        return self.data[..., 0]
+        return self.data.w
 
     @a.setter
     def a(self, value: np.ndarray):
         """Set the scalar quaternion component."""
-        self.data[..., 0] = value
+        self.data.w = value
 
     @property
     def b(self) -> np.ndarray:
@@ -149,12 +153,12 @@ class Quaternion(Object3d):
         value : numpy.ndarray
             First vector quaternion component.
         """
-        return self.data[..., 1]
+        return self.data.x
 
     @b.setter
     def b(self, value: np.ndarray):
         """Set the first vector quaternion component."""
-        self.data[..., 1] = value
+        self.data.x = value
 
     @property
     def c(self) -> np.ndarray:
@@ -165,12 +169,12 @@ class Quaternion(Object3d):
         value : numpy.ndarray
             Second vector quaternion component.
         """
-        return self.data[..., 2]
+        return self.data.y
 
     @c.setter
     def c(self, value: np.ndarray):
         """Set the second vector quaternion component."""
-        self.data[..., 2] = value
+        self.data.y = value
 
     @property
     def d(self) -> np.ndarray:
@@ -181,12 +185,12 @@ class Quaternion(Object3d):
         value : numpy.ndarray
             Third vector quaternion component.
         """
-        return self.data[..., 3]
+        return self.data.z
 
     @d.setter
     def d(self, value: np.ndarray):
         """Set the third vector quaternion component."""
-        self.data[..., 3] = value
+        self.data.z = value
 
     @property
     def axis(self) -> Vector3d:
@@ -484,6 +488,11 @@ class Quaternion(Object3d):
         Q = Q.unit
 
         return Q
+
+    def flatten(self):
+        """Return a new object with the same data in a single column."""
+        obj = self.__class__(self.data.flattened)
+        return obj
 
     # TODO: Remove decorator, **kwargs, and use of "convention" in 0.13
     @classmethod

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -23,6 +23,7 @@ from typing import Any, Tuple, Union
 import dask.array as da
 from dask.diagnostics import ProgressBar
 import numpy as np
+import quaternionic as quaternion
 from scipy.special import hyp0f1
 
 from orix.quaternion import Quaternion
@@ -96,7 +97,7 @@ class Rotation(Quaternion):
 
     @improper.setter
     def improper(self, value: np.ndarray):
-        self._data[..., -1] = value
+        self._data[..., -1] = quaternion.array(value)
 
     @property
     def antipodal(self) -> Rotation:

--- a/orix/tests/quaternion/test_quaternion.py
+++ b/orix/tests/quaternion/test_quaternion.py
@@ -84,7 +84,9 @@ class TestQuaternion:
         assert np.allclose((-quaternion).data, (-quaternion.data))
 
     def test_norm(self, quaternion):
-        assert np.allclose(quaternion.norm, (quaternion.data**2).sum(axis=-1) ** 0.5)
+        assert np.allclose(
+            quaternion.norm, (quaternion.data.ndarray**2).sum(axis=-1) ** 0.5
+        )
 
     def test_unit(self, quaternion):
         assert np.allclose(quaternion.unit.norm, 1)

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
         "matplotlib-scalebar",
         "numba",
         "numpy",
-        "numpy-quaternion",
+        "quaternionic",
         "pooch                  >= 0.13",
         "scipy",
         "tqdm",


### PR DESCRIPTION
#### Description of the change
As per #506.

I'm running into some problems making this change becuase I'm not really sure what the  improper `setter` functions works with the `_data` attribute.

The difference arrises from quaternionic forcing having 4 as the last shape and not automatically casting as the numpy-quaternion package does.


```python

import quaternionic as quaternion2
import quaternion
import numpy as np

quaternion.as_float_array(np.ones((10,4))).shape 
# (10, 4, 4)

quaternion2.array(np.ones((10,4))).shape
# (10,4)
```

@hakonanes any advice for what might need to change as a result?


#### Progress of the PR
- [ ] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [ ] Unit tests with pytest for all lines
- [ ] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.