### PR TITLE
Update Python version compatibility to range 3.10-12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,11 +47,11 @@ jobs:
         python-version: ['3.11', '3.12']
         include:
           - os: ubuntu-latest
-            python-version: 3.10
+            python-version: '3.10'
             DEPENDENCIES: diffpy.structure==3.0.2 matplotlib==3.6.1
             LABEL: -oldest
           - os: ubuntu-latest
-            python-version: 3.12
+            python-version: '3.12'
             LABEL: -minimum_requirement
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - uses: isort/isort-action@master
         with:
@@ -44,14 +44,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10', '3.11']
+        python-version: ['3.11', '3.12']
         include:
           - os: ubuntu-latest
-            python-version: 3.8
-            DEPENDENCIES: diffpy.structure==3.0.2  matplotlib==3.5
+            python-version: 3.10
+            DEPENDENCIES: diffpy.structure==3.0.2 matplotlib==3.6.1
             LABEL: -oldest
           - os: ubuntu-latest
-            python-version: 3.11
+            python-version: 3.12
             LABEL: -minimum_requirement
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,15 +11,19 @@ Unreleased
 
 Added
 -----
+- Support for Python 3.12.
 
 Changed
 -------
+- numpy-quaternion is now an optional dependency and will not be installed with ``pip``
+  unless ``pip install orix[all]`` is used.
 
 Deprecated
 ----------
 
 Removed
 -------
+- Support for Python 3.8 and 3.9.
 
 Fixed
 -----

--- a/doc/dev/running_writing_tests.rst
+++ b/doc/dev/running_writing_tests.rst
@@ -4,7 +4,8 @@ Run and write tests
 All functionality in orix is tested with :doc:`pytest <pytest:index>`.
 The tests reside in a ``tests`` module.
 Tests are short methods that call functions in ``orix`` and compare resulting output
-values with known answers. Install necessary dependencies to run the tests::
+values with known answers.
+Install necessary dependencies to run the tests::
 
    pip install --editable ".[tests]"
 
@@ -15,23 +16,24 @@ Some useful :doc:`fixtures <pytest:explanation/fixtures>` are available in the
 
     Some :mod:`orix.data` module tests check that data not part of the package
     distribution can be downloaded from the web, thus downloading some small datasets to
-    your local cache. See the section on the
-    :ref:`data module <adding-data-to-data-module>` for more details.
+    your local cache.
+    See the section on the :ref:`data module <adding-data-to-data-module>` for more
+    details.
 
 To run the tests::
 
    pytest --cov --pyargs orix
 
-The ``--cov`` flag makes :doc:`coverage.py <coverage:index>` prints a nice report in the
-terminal.
+The ``--cov`` flag makes :doc:`coverage.py <coverage:index>` print a nice report.
 For an even nicer presentation, you can use ``coverage.py`` directly::
 
    coverage html
 
-Then, you can open the created ``htmlcov/index.html`` in the browser and inspect the
-coverage in more detail.
+Coverage can then be inspected in the browser by opening ``htmlcov/index.html``.
 
-Docstring examples are tested :doc:`with pytest <pytest:how-to/doctest>` as well.
+We strive for 100% test coverage of lines when all dependencies are installed.
+
+Docstring examples are tested with :doc:`pytest <pytest:how-to/doctest>` as well.
 :mod:`numpy` and :mod:`matplotlib.pyplot` should not be imported in examples as they are
 already available in the namespace as ``np`` and ``plt``, respectively.
 The docstring tests can be run from the top directory::

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -4,7 +4,7 @@ Installation
 
 orix can be installed with `pip <https://pypi.org/project/orix/>`__,
 `conda <https://anaconda.org/conda-forge/orix>`__ or from source, and supports Python
->= 3.8.
+>= 3.10.
 All alternatives are available on Windows, macOS and Linux.
 
 .. _install-with-pip:
@@ -29,9 +29,9 @@ To update orix to the latest release::
 
     pip install --upgrade orix
 
-To install a specific version of orix (say version 0.8.1)::
+To install a specific version of orix (say version 0.12.1)::
 
-    pip install orix==0.8.1
+    pip install orix==0.12.1
 
 .. _install-with-anaconda:
 
@@ -43,7 +43,7 @@ To install with Anaconda, we recommend you install it in a `conda environment
 with the `Miniconda distribution <https://docs.conda.io/en/latest/miniconda.html>`__.
 To create an environment and activate it, run the following::
 
-   conda create --name orix-env python=3.11
+   conda create --name orix-env python=3.12
    conda activate orix-env
 
 If you prefer a graphical interface to manage packages and environments, you can install
@@ -64,9 +64,9 @@ To update orix to the latest release::
 
     conda update orix
 
-To install a specific version of orix (say version 0.8.1)::
+To install a specific version of orix (say version 0.12.1)::
 
-    conda install orix==0.8.1 -c conda-forge
+    conda install orix==0.12.1 -c conda-forge
 
 .. _install-from-source:
 

--- a/orix/_base.py
+++ b/orix/_base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/_util.py
+++ b/orix/_util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/constants.py
+++ b/orix/constants.py
@@ -26,7 +26,7 @@ for pkg in optional_deps:
     try:
         _ = version(pkg)
         installed[pkg] = True
-    except ImportError:
+    except ImportError:  # pragma: no cover
         installed[pkg] = False
 
 # Typical tolerances for comparisons in need of a precision. We

--- a/orix/crystal_map/__init__.py
+++ b/orix/crystal_map/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/crystal_map/crystal_map_properties.py
+++ b/orix/crystal_map/crystal_map_properties.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/data/__init__.py
+++ b/orix/data/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/data/_registry.py
+++ b/orix/data/_registry.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/io/__init__.py
+++ b/orix/io/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/io/plugins/__init__.py
+++ b/orix/io/plugins/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/io/plugins/_h5ebsd.py
+++ b/orix/io/plugins/_h5ebsd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/io/plugins/ang.py
+++ b/orix/io/plugins/ang.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/io/plugins/ang.py
+++ b/orix/io/plugins/ang.py
@@ -107,7 +107,7 @@ def file_reader(filename: str) -> CrystalMap:
     data_dict["phase_list"] = PhaseList(**phases)
 
     # Set which data points are not indexed
-    # TODO: Add not-indexed convention for INDEX ASTAR
+    # TODO: Add not-indexed convention for ASTAR INDEX
     if vendor in ["orix", "tsl"]:
         not_indexed = data_dict["prop"]["ci"] == -1
         data_dict["phase_id"][not_indexed] = -1

--- a/orix/io/plugins/bruker_h5ebsd.py
+++ b/orix/io/plugins/bruker_h5ebsd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/io/plugins/ctf.py
+++ b/orix/io/plugins/ctf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/io/plugins/emsoft_h5ebsd.py
+++ b/orix/io/plugins/emsoft_h5ebsd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/io/plugins/orix_hdf5.py
+++ b/orix/io/plugins/orix_hdf5.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/measure/__init__.py
+++ b/orix/measure/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/measure/pole_density_function.py
+++ b/orix/measure/pole_density_function.py
@@ -33,7 +33,7 @@ def pole_density_function(
     hemisphere: str = "upper",
     symmetry: Optional[Symmetry] = None,
     log: bool = False,
-    mrd: bool = True
+    mrd: bool = True,
 ) -> Tuple[np.ma.MaskedArray, Tuple[np.ndarray, np.ndarray]]:
     """Compute the Pole Density Function (PDF) of vectors in the
     stereographic projection. See :cite:`rohrer2004distribution`.

--- a/orix/measure/pole_density_function.py
+++ b/orix/measure/pole_density_function.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/plot/__init__.py
+++ b/orix/plot/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/plot/_symmetry_marker.py
+++ b/orix/plot/_symmetry_marker.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/plot/_util.py
+++ b/orix/plot/_util.py
@@ -18,6 +18,7 @@
 from typing import Tuple, Union
 
 from matplotlib.patches import FancyArrowPatch
+from mpl_toolkits.mplot3d import proj3d
 import numpy as np
 
 
@@ -31,6 +32,12 @@ class Arrow3D(FancyArrowPatch):
     def __init__(self, xs, ys, zs, *args, **kwargs):
         super().__init__((0, 0), (0, 0), *args, **kwargs)
         self._verts3d = xs, ys, zs
+
+    def do_3d_projection(self, renderer=None):
+        xs3d, ys3d, zs3d = self._verts3d
+        xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)
+        self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
+        return np.min(zs)
 
 
 def format_labels(

--- a/orix/plot/_util.py
+++ b/orix/plot/_util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/plot/_util.py
+++ b/orix/plot/_util.py
@@ -18,7 +18,6 @@
 from typing import Tuple, Union
 
 from matplotlib.patches import FancyArrowPatch
-from mpl_toolkits.mplot3d import proj3d
 import numpy as np
 
 
@@ -32,12 +31,6 @@ class Arrow3D(FancyArrowPatch):
     def __init__(self, xs, ys, zs, *args, **kwargs):
         super().__init__((0, 0), (0, 0), *args, **kwargs)
         self._verts3d = xs, ys, zs
-
-    def do_3d_projection(self, renderer=None):
-        xs3d, ys3d, zs3d = self._verts3d
-        xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)
-        self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
-        return np.min(zs)
 
 
 def format_labels(

--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/plot/crystal_map_plot.py
+++ b/orix/plot/crystal_map_plot.py
@@ -427,8 +427,6 @@ class CrystalMapPlot(Axes):
         n_rows, n_cols = self._data_shape
 
         # Get rotations, ensuring correct masking
-        # TODO: Show orientations in Euler angles (computationally
-        #  intensive...)
         r = crystal_map.get_map_data("rotations", decimals=3)
 
         # Get image data, overwriting potentially masked regions set to 0.0

--- a/orix/plot/direction_color_keys/__init__.py
+++ b/orix/plot/direction_color_keys/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/plot/direction_color_keys/_util.py
+++ b/orix/plot/direction_color_keys/_util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/plot/direction_color_keys/direction_color_key.py
+++ b/orix/plot/direction_color_keys/direction_color_key.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/plot/direction_color_keys/direction_color_key_tsl.py
+++ b/orix/plot/direction_color_keys/direction_color_key_tsl.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/plot/inverse_pole_figure_plot.py
+++ b/orix/plot/inverse_pole_figure_plot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/plot/orientation_color_keys/__init__.py
+++ b/orix/plot/orientation_color_keys/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/plot/orientation_color_keys/euler_color_key.py
+++ b/orix/plot/orientation_color_keys/euler_color_key.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/plot/orientation_color_keys/ipf_color_key.py
+++ b/orix/plot/orientation_color_keys/ipf_color_key.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/plot/orientation_color_keys/ipf_color_key_tsl.py
+++ b/orix/plot/orientation_color_keys/ipf_color_key_tsl.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/plot/rotation_plot.py
+++ b/orix/plot/rotation_plot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/plot/stereographic_plot.py
+++ b/orix/plot/stereographic_plot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/plot/unit_cell_plot.py
+++ b/orix/plot/unit_cell_plot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/projections/__init__.py
+++ b/orix/projections/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/projections/stereographic.py
+++ b/orix/projections/stereographic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/quaternion/__init__.py
+++ b/orix/quaternion/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/quaternion/_conversions.py
+++ b/orix/quaternion/_conversions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/quaternion/misorientation.py
+++ b/orix/quaternion/misorientation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/quaternion/orientation_region.py
+++ b/orix/quaternion/orientation_region.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -181,7 +181,7 @@ class Quaternion(Object3d):
 
             qu2 = quaternion.from_float_array(self.data).conj()
             qu2 = quaternion.as_float_array(qu2)
-        else:
+        else:  # pragma: no cover
             qu1 = self.data.astype(np.float64)
             qu2 = np.empty_like(qu1)
             qu_conj_gufunc(qu1, qu2)
@@ -203,7 +203,7 @@ class Quaternion(Object3d):
                 qu1 = quaternion.from_float_array(self.data)
                 qu2 = quaternion.from_float_array(other.data)
                 qu12 = quaternion.as_float_array(qu1 * qu2)
-            else:
+            else:  # pragma: no cover
                 qu12 = qu_multiply(self.data, other.data)
             Q = self.__class__(qu12)
             return Q
@@ -218,7 +218,7 @@ class Quaternion(Object3d):
                 v = quaternion.as_vector_part(
                     (qu * quaternion.from_vector_part(other.data)) * ~qu
                 )
-            else:
+            else:  # pragma: no cover
                 v = qu_rotate_vec(self.unit.data, other.data)
             if isinstance(other, Miller):
                 m = other.__class__(xyz=v, phase=other.phase)
@@ -1081,7 +1081,7 @@ class Quaternion(Object3d):
                     # np.outer works with flattened array
                     qu12 = np.outer(qu1, qu2).reshape(*qu1.shape, *qu2.shape)
                     qu = quaternion.as_float_array(qu12)
-                else:
+                else:  # pragma: no cover
                     Q12 = Quaternion(self).reshape(-1, 1) * other.reshape(1, -1)
                     qu = Q12.data.reshape(*self.shape, *other.shape, 4)
             return other.__class__(qu)
@@ -1100,7 +1100,7 @@ class Quaternion(Object3d):
 
                     qu = quaternion.from_float_array(self.data)
                     v_arr = quaternion.rotate_vectors(qu, other.data)
-                else:
+                else:  # pragma: no cover
                     v = Quaternion(self).reshape(-1, 1) * other.reshape(1, -1)
                     v_arr = v.reshape(*self.shape, *other.shape).data
             if isinstance(other, Miller):
@@ -1272,7 +1272,7 @@ def qu_multiply_gufunc(
     qu12[3] = qu1[3] * qu2[0] - qu1[2] * qu2[1] + qu1[1] * qu2[2] + qu1[0] * qu2[3]
 
 
-def qu_multiply(qu1: np.ndarray, qu2: np.ndarray) -> np.ndarray:
+def qu_multiply(qu1: np.ndarray, qu2: np.ndarray) -> np.ndarray:  # pragma: no cover
     shape = np.broadcast_shapes(qu1.shape, qu2.shape)
     if not np.issubdtype(qu1.dtype, np.float64):
         qu1 = qu1.astype(np.float64)
@@ -1297,7 +1297,7 @@ def qu_rotate_vec_gufunc(
     v2[2] = z - c * tx + b * ty + a * tz
 
 
-def qu_rotate_vec(qu: np.ndarray, v: np.ndarray) -> np.ndarray:
+def qu_rotate_vec(qu: np.ndarray, v: np.ndarray) -> np.ndarray:  # pragma: no cover
     qu = np.atleast_2d(qu)
     v = np.atleast_2d(v)
     shape = np.broadcast_shapes(qu.shape[:-1], v.shape[:-1]) + (3,)

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/quaternion/symmetry.py
+++ b/orix/quaternion/symmetry.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/sampling/S2_sampling.py
+++ b/orix/sampling/S2_sampling.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/sampling/SO3_sampling.py
+++ b/orix/sampling/SO3_sampling.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/sampling/SO3_sampling.py
+++ b/orix/sampling/SO3_sampling.py
@@ -30,7 +30,7 @@ def uniform_SO3_sample(
     resolution: Union[int, float],
     method: str = "cubochoric",
     unique: bool = True,
-    **kwargs
+    **kwargs,
 ) -> Rotation:
     r"""Uniform sampling of *SO(3)* by a number of methods.
 

--- a/orix/sampling/__init__.py
+++ b/orix/sampling/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/sampling/_cubochoric_sampling.py
+++ b/orix/sampling/_cubochoric_sampling.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/sampling/_polyhedral_sampling.py
+++ b/orix/sampling/_polyhedral_sampling.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/sampling/sample_generators.py
+++ b/orix/sampling/sample_generators.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/sampling/sample_generators.py
+++ b/orix/sampling/sample_generators.py
@@ -31,7 +31,7 @@ def get_sample_fundamental(
     point_group: Optional[Symmetry] = None,
     space_group: Optional[int] = None,
     method: str = "cubochoric",
-    **kwargs
+    **kwargs,
 ) -> Rotation:
     """Return an equispaced grid of rotations within a fundamental zone.
 
@@ -95,7 +95,7 @@ def get_sample_local(
     center: Optional[Rotation] = None,
     grid_width: Union[int, float] = 10,
     method: str = "cubochoric",
-    **kwargs
+    **kwargs,
 ) -> Rotation:
     """Return a grid of rotations about a given rotation.
 

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/data/__init__.py
+++ b/orix/tests/data/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/data/test_data.py
+++ b/orix/tests/data/test_data.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/io/__init__.py
+++ b/orix/tests/io/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/io/test_ang.py
+++ b/orix/tests/io/test_ang.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/io/test_bruker_h5ebsd.py
+++ b/orix/tests/io/test_bruker_h5ebsd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/io/test_emsoft_h5ebsd.py
+++ b/orix/tests/io/test_emsoft_h5ebsd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/io/test_h5ebsd.py
+++ b/orix/tests/io/test_h5ebsd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/io/test_io.py
+++ b/orix/tests/io/test_io.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/io/test_orix_hdf5.py
+++ b/orix/tests/io/test_orix_hdf5.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/plot/__init__.py
+++ b/orix/tests/plot/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/plot/test_crystal_map_plot.py
+++ b/orix/tests/plot/test_crystal_map_plot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/plot/test_crystal_map_plot.py
+++ b/orix/tests/plot/test_crystal_map_plot.py
@@ -374,7 +374,8 @@ class TestStatusBar:
         fig = plt.figure()
         ax = fig.add_subplot(projection=PLOT_MAP)
         _ = ax.plot_map(crystal_map)
-        assert ax.format_coord(0, 0) == "(x, y) = (0, 0)"
+        # TODO: Remove (x, y) = (0, 0) when requuring matplotlib > 3.8
+        assert ax.format_coord(0, 0) in ["(x, y) = (0, 0)", "x=0 y=0"]
 
         fig = plt.figure()
         ax = fig.add_subplot(projection=PLOT_MAP)

--- a/orix/tests/plot/test_direction_color_keys.py
+++ b/orix/tests/plot/test_direction_color_keys.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/plot/test_inverse_pole_figure_plot.py
+++ b/orix/tests/plot/test_inverse_pole_figure_plot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/plot/test_orientation_color_keys.py
+++ b/orix/tests/plot/test_orientation_color_keys.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/plot/test_plotting_utilities.py
+++ b/orix/tests/plot/test_plotting_utilities.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/plot/test_rotation_plot.py
+++ b/orix/tests/plot/test_rotation_plot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/plot/test_stereographic_plot.py
+++ b/orix/tests/plot/test_stereographic_plot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/plot/test_unit_cell_plot.py
+++ b/orix/tests/plot/test_unit_cell_plot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/quaternion/__init__.py
+++ b/orix/tests/quaternion/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/quaternion/test_conversions.py
+++ b/orix/tests/quaternion/test_conversions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/quaternion/test_orientation_region.py
+++ b/orix/tests/quaternion/test_orientation_region.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/quaternion/test_quaternion.py
+++ b/orix/tests/quaternion/test_quaternion.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/quaternion/test_rotation.py
+++ b/orix/tests/quaternion/test_rotation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/quaternion/test_symmetry.py
+++ b/orix/tests/quaternion/test_symmetry.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/sampling/__init__.py
+++ b/orix/tests/sampling/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/sampling/test_cubochoric_sampling.py
+++ b/orix/tests/sampling/test_cubochoric_sampling.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/sampling/test_s2_sampling.py
+++ b/orix/tests/sampling/test_s2_sampling.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/sampling/test_sampling.py
+++ b/orix/tests/sampling/test_sampling.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/test_axangle.py
+++ b/orix/tests/test_axangle.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/test_crystal_map_properties.py
+++ b/orix/tests/test_crystal_map_properties.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/test_fundamental_sector.py
+++ b/orix/tests/test_fundamental_sector.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/test_measure.py
+++ b/orix/tests/test_measure.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/test_miller.py
+++ b/orix/tests/test_miller.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/test_neoeuler.py
+++ b/orix/tests/test_neoeuler.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/test_object3d.py
+++ b/orix/tests/test_object3d.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/test_phase_list.py
+++ b/orix/tests/test_phase_list.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/test_spherical_region.py
+++ b/orix/tests/test_spherical_region.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/test_stereographic_projection.py
+++ b/orix/tests/test_stereographic_projection.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/test_util.py
+++ b/orix/tests/test_util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/test_vector3d.py
+++ b/orix/tests/test_vector3d.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/tests/test_vector3d.py
+++ b/orix/tests/test_vector3d.py
@@ -762,27 +762,29 @@ class TestPlotting:
     def test_scatter_reproject(self):
         o = Orientation.from_axes_angles((-1, 8, 1), 65, degrees=True)
         v = (symmetry.Oh * o) * Vector3d.zvector()
-        # normal scatter: half of the vectors are shown
-        fig1 = v.scatter(hemisphere="upper", return_figure=True)
-        assert (
-            sum(len(c.get_offsets()) for c in fig1.axes[0].collections) == v.size // 2
-        )
-        # reproject: all of the vectors are shown
-        fig2 = v.scatter(hemisphere="upper", reproject=True, return_figure=True, c="r")
-        assert sum(len(c.get_offsets()) for c in fig2.axes[0].collections) == v.size
-        # (1, 0, 0, 1) is red in RGBA
-        assert all(
-            np.allclose(c.get_edgecolor(), (1, 0, 0, 1))
-            for c in fig2.axes[0].collections
-        )
-        # reproject: all of the vectors are shown
+
+        # Normal scatter: half of the vectors are shown
+        fig1 = v.scatter(return_figure=True)
+        assert fig1.axes[0].collections[0].get_offsets().shape == (v.size // 2, 2)
+
+        # Reproject: all of the vectors are shown
+        fig2 = v.scatter(reproject=True, return_figure=True, c="r")
+        colls = fig2.axes[0].collections[:2]
+        for coll in colls[:2]:
+            assert coll.get_offsets().shape == (v.size // 2, 2)
+            assert np.allclose(coll.get_edgecolor(), (1, 0, 0, 1))
+
+        # Reproject: all of the vectors are shown
         fig3 = v.scatter(hemisphere="lower", reproject=True, return_figure=True)
-        assert sum(len(c.get_offsets()) for c in fig3.axes[0].collections) == v.size
-        # reproject hemisphere="both": reprojection is ignored so
-        # half of the vectors are shown on each axes as normal
+        colls = fig3.axes[0].collections[:2]
+        for coll in colls:
+            assert coll.get_offsets().shape == (v.size // 2, 2)
+
+        # Reproject hemisphere="both": reprojection is ignored so half
+        # of the vectors are shown on each axes as normal
         fig4 = v.scatter(hemisphere="both", reproject=True, return_figure=True)
         for ax in fig4.axes:
-            assert sum(len(c.get_offsets()) for c in ax.collections) == v.size // 2
+            assert ax.collections[0].get_offsets().shape == (v.size // 2, 2)
 
     def test_draw_circle(self):
         v = self.v

--- a/orix/vector/__init__.py
+++ b/orix/vector/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/vector/fundamental_sector.py
+++ b/orix/vector/fundamental_sector.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/vector/miller.py
+++ b/orix/vector/miller.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/vector/neo_euler.py
+++ b/orix/vector/neo_euler.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/vector/spherical_region.py
+++ b/orix/vector/spherical_region.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2024 the orix developers
 #
 # This file is part of orix.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ path = "orix/__init__.py"
 precision = 2
 
 [tool.coverage.run]
-branch = true
+branch = false
 source = ["orix"]
 relative_files = true
 omit = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,11 @@ dependencies = [
     "numba",
     "numpy",
     "pooch                  >= 0.13",
-    # TODO: Remove once https://github.com/diffpy/diffpy.structure/issues/97 is fixed
+    # TODO: Remove once diffpy.structure >= 3.2.1
     "pycifrw",
     "scipy",
     "tqdm",
-    # TODO: Remove once Python 3.11 is the minimal version
+    # TODO: Remove once Python >= 3.11
     "typing_extensions",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,18 +4,17 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orix"
-# conf.py assumes orix developers to be first author
 authors = [{name = "orix developers"}]
 description = "orix is an open-source Python library for handling crystal orientation mapping data"
 license = {file = "LICENSE"}
 readme = {file = "README.rst", content-type = "text/x-rst"}
 dynamic = ["version"]
+requires-python = ">= 3.10"
 classifiers=[
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "dask[array]",
     "diffpy.structure       >= 3.0.2",
     "h5py",
-    "matplotlib             >= 3.5",
+    "matplotlib             >= 3.6.1",
     "matplotlib-scalebar",
     "numba",
     "numpy",


### PR DESCRIPTION
#### Description of the change
Remove explicit compatibility for Python 3.8 and 3.9 and add it for 3.12. Fixes #515.

Test suite on CI is updated to use 3.11 and 3.12, with one runner for 3.10 and minimal version dependencies.

Bump lowest Matplotlib from >= 3.5 to >= 3.6.1 (skip 3.6.0 as it throws a gazillion+1 MatplotlibDeprecationWarnings).

Other changes:
* Remove unnecessary UTF-8 encoding for all files
* Remember to update changelog
* Ensure 100% test coverage with all dependencies installed (mention this in test dev guide)
* ~Remove `do_3d_projection()` in our minimal `Arrow3D` class as it seems (!) to be unnecessary with Matplotlib >= 3.6.1~ Turned out to still be necessary.
* Update Matplotlib tests following >= 3.6.1

#### Progress of the PR
- [x] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [x] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.