### PR TITLE
Update develop after 0.13.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,8 @@ jobs:
         include:
           - os: ubuntu-latest
             python-version: '3.10'
-            DEPENDENCIES: diffpy.structure==3.0.2 matplotlib==3.6.1
+            # Matplotlib 3.6.1 is not compatible with NumPy v2
+            DEPENDENCIES: diffpy.structure==3.0.2 matplotlib==3.6.1 "numpy<2"
             LABEL: -oldest
           - os: ubuntu-latest
             python-version: '3.12'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,13 @@ Deprecated
 Fixed
 -----
 
+2024-09-25 - version 0.13.2
+===========================
+
+Added
+-----
+- Compatibility with NumPy v2.0.
+
 2024-09-20 - version 0.13.1
 ===========================
 

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.14.dev1"
+__version__ = "0.14.dev2"
 # Sorted by line contributions (ideally excluding lines in notebook files)
 __credits__ = [
     "Håkon Wiik Ånes",

--- a/orix/_util.py
+++ b/orix/_util.py
@@ -22,7 +22,7 @@ import functools
 import inspect
 import warnings
 
-import numpy as np
+from orix.constants import VisibleDeprecationWarning
 
 
 class deprecated:
@@ -88,12 +88,12 @@ class deprecated:
         @functools.wraps(func)
         def wrapped(*args, **kwargs):
             warnings.simplefilter(
-                action="always", category=np.VisibleDeprecationWarning, append=True
+                action="always", category=VisibleDeprecationWarning, append=True
             )
             func_code = func.__code__
             warnings.warn_explicit(
                 message=msg,
-                category=np.VisibleDeprecationWarning,
+                category=VisibleDeprecationWarning,
                 filename=func_code.co_filename,
                 lineno=func_code.co_firstlineno + 1,
             )
@@ -141,12 +141,12 @@ class deprecated_argument:
                     msg += f"Use `{self.alternative}` instead. "
                 msg += f"See the documentation of `{func.__name__}()` for more details."
                 warnings.simplefilter(
-                    action="always", category=np.VisibleDeprecationWarning, append=True
+                    action="always", category=VisibleDeprecationWarning, append=True
                 )
                 func_code = func.__code__
                 warnings.warn_explicit(
                     message=msg,
-                    category=np.VisibleDeprecationWarning,
+                    category=VisibleDeprecationWarning,
                     filename=func_code.co_filename,
                     lineno=func_code.co_firstlineno + 1,
                 )

--- a/orix/constants.py
+++ b/orix/constants.py
@@ -35,4 +35,14 @@ for pkg in optional_deps:
 eps9 = 1e-9
 eps12 = 1e-12
 
+# TODO: Remove and use numpy.exceptions.VisibleDeprecationWarning once
+# NumPy 1.25 is minimal supported version
+try:
+    # Added in NumPy 1.25.0
+    from numpy.exceptions import VisibleDeprecationWarning
+except ImportError:  # pragma: no cover
+    # Removed in NumPy 2.0.0
+    from numpy import VisibleDeprecationWarning
+
+
 del optional_deps

--- a/orix/tests/io/test_ang.py
+++ b/orix/tests/io/test_ang.py
@@ -18,6 +18,7 @@
 import numpy as np
 import pytest
 
+from orix.constants import VisibleDeprecationWarning
 from orix.crystal_map import CrystalMap, Phase
 from orix.io import load, loadang, save
 from orix.io.plugins.ang import (
@@ -76,7 +77,7 @@ from orix.tests.conftest import (
     indirect=["angfile_astar"],
 )
 def test_loadang(angfile_astar, expected_data):
-    with pytest.warns(np.VisibleDeprecationWarning):
+    with pytest.warns(VisibleDeprecationWarning):
         loaded_data = loadang(angfile_astar)
     assert np.allclose(loaded_data.data, expected_data)
 

--- a/orix/tests/io/test_io.py
+++ b/orix/tests/io/test_io.py
@@ -27,6 +27,7 @@ from h5py import File
 import numpy as np
 import pytest
 
+from orix.constants import VisibleDeprecationWarning
 from orix.crystal_map import Phase, PhaseList
 from orix.io import _overwrite_or_not, _plugin_from_manufacturer, load, loadctf, save
 from orix.io.plugins import bruker_h5ebsd, emsoft_h5ebsd, orix_hdf5
@@ -151,6 +152,6 @@ def test_loadctf():
     fname = "temp.ctf"
     np.savetxt(fname, z)
 
-    with pytest.warns(np.VisibleDeprecationWarning):
+    with pytest.warns(VisibleDeprecationWarning):
         _ = loadctf(fname)
     os.remove(fname)

--- a/orix/tests/test_util.py
+++ b/orix/tests/test_util.py
@@ -17,10 +17,10 @@
 
 import warnings
 
-import numpy as np
 import pytest
 
 from orix._util import deprecated, deprecated_argument
+from orix.constants import VisibleDeprecationWarning
 
 
 class TestDeprecateFunctionOrProperty:
@@ -58,7 +58,7 @@ class TestDeprecateFunctionOrProperty:
 
         my_foo = Foo()
 
-        with pytest.warns(np.VisibleDeprecationWarning) as record:
+        with pytest.warns(VisibleDeprecationWarning) as record:
             assert my_foo.bar_func1(4) == 5
         desired_msg = (
             "Function `bar_func1()` is deprecated and will be removed in version 0.8. "
@@ -72,7 +72,7 @@ class TestDeprecateFunctionOrProperty:
             f"   {desired_msg}"
         )
 
-        with pytest.warns(np.VisibleDeprecationWarning) as record2:
+        with pytest.warns(VisibleDeprecationWarning) as record2:
             assert my_foo.bar_func2(4) == 6
         desired_msg2 = "Function `bar_func2()` is deprecated."
         assert str(record2[0].message) == desired_msg2
@@ -84,7 +84,7 @@ class TestDeprecateFunctionOrProperty:
             f"   {desired_msg2}"
         )
 
-        with pytest.warns(np.VisibleDeprecationWarning) as record3:
+        with pytest.warns(VisibleDeprecationWarning) as record3:
             assert my_foo.bar_prop == 1
         desired_msg3 = (
             "Property `bar_prop` is deprecated and will be removed in version 1.4. "
@@ -123,7 +123,7 @@ class TestDeprecateArgument:
             assert my_foo.bar_arg(b=1) == {"b": 1}
 
         # Warns
-        with pytest.warns(np.VisibleDeprecationWarning) as record2:
+        with pytest.warns(VisibleDeprecationWarning) as record2:
             assert my_foo.bar_arg(a=2) == {"a": 2}
         assert str(record2[0].message) == (
             r"Argument `a` is deprecated and will be removed in version 1.4. "
@@ -132,7 +132,7 @@ class TestDeprecateArgument:
         )
 
         # Warns with alternative
-        with pytest.warns(np.VisibleDeprecationWarning) as record3:
+        with pytest.warns(VisibleDeprecationWarning) as record3:
             assert my_foo.bar_arg_alt(a=3) == {"a": 3}
         assert str(record3[0].message) == (
             r"Argument `a` is deprecated and will be removed in version 1.4. "


### PR DESCRIPTION
#### Description of the change
Bringing already reviewed changes on main into develop after the release of v0.13.2.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.