### PR TITLE
Avoid expensive deepcopy when rotating Miller

### DIFF
--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -117,8 +117,9 @@ class Rotation(Quaternion):
             return Q
         if isinstance(other, Vector3d):
             v = Quaternion(self) * other
-            improper = (self.improper * np.ones(other.shape)).astype(bool)
-            v[improper] = -v[improper]
+            if np.any(self.improper):
+                improper = (self.improper * np.ones(other.shape)).astype(bool)
+                v[improper] = -v[improper]
             return v
         if isinstance(other, int) or isinstance(other, list):  # abs(1)
             other = np.atleast_1d(other).astype(int)


### PR DESCRIPTION
#### Description of the change

Rotating a Miller instance with a Rotation calls `Miller.__getitem__` to handle improper rotations, regardless of whether any rotations are actually improper.
As  `Miller.__getitem__` involves a deepcopy, avoiding this when not necessary provides a significant speedup, depending on the complexity of the associated Phase.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### Minimal example of the bug fix or new feature
```python
from orix.crystal_map import Phase
from orix.vector import Miller
from orix.quaternion import Rotation

P1 = Phase("P1", 1)
Fm3m = Phase("Fm3m", 225)
P1_vec = Miller.random(P1)
Fm3m_vec = Miller.random(Fm3m)
rot = Rotation.random(2000)


%timeit rot * P1_vec
%timeit rot * Fm3m_vec
```
**Current**
505 μs ± 18.6 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
1.7 ms ± 48.2 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

**New change**
346 μs ± 41.4 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
350 μs ± 16.9 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

Of course, with improper rotations, the runtime is the same:
```python
from orix.crystal_map import Phase
from orix.vector import Miller
from orix.quaternion import Rotation

P1 = Phase("P1", 1)
Fm3m = Phase("Fm3m", 225)
P1_vec = Miller.random(P1)
Fm3m_vec = Miller.random(Fm3m)
rot = Rotation.random(2000) * -1

assert all(rot.improper)

%timeit rot * P1_vec
%timeit rot * Fm3m_vec
```
506 μs ± 26.3 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
1.69 ms ± 44.3 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [x] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.