### PR TITLE
Complete EDAX symmetry aliases

### DIFF
--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -31,10 +31,10 @@ import matplotlib.colors as mcolors
 import numpy as np
 
 from orix.quaternion.symmetry import (
+    _EDAX_POINT_GROUP_ALIASES,
     Symmetry,
     _groups,
     get_point_group,
-    point_group_aliases,
 )
 from orix.vector import Miller, Vector3d
 
@@ -229,9 +229,9 @@ class Phase:
         if isinstance(value, int):
             value = str(value)
         if isinstance(value, str):
-            for correct, aliases in point_group_aliases.items():
+            for key, aliases in _EDAX_POINT_GROUP_ALIASES.items():
                 if value in aliases:
-                    value = correct
+                    value = key
                     break
             for point_group in _groups:
                 if value == point_group.name:

--- a/orix/io/plugins/ang.py
+++ b/orix/io/plugins/ang.py
@@ -30,7 +30,7 @@ import numpy as np
 from orix import __version__
 from orix.crystal_map import CrystalMap, PhaseList, create_coordinate_arrays
 from orix.quaternion import Rotation
-from orix.quaternion.symmetry import point_group_aliases
+from orix.quaternion.symmetry import _EDAX_POINT_GROUP_ALIASES
 
 __all__ = ["file_reader", "file_writer"]
 
@@ -594,9 +594,9 @@ def _get_header_from_phases(xmap: CrystalMap) -> str:
         else:
             proper_point_group = phase.point_group.proper_subgroup
             point_group_name = proper_point_group.name
-            for key, alias in point_group_aliases.items():
+            for key, aliases in _EDAX_POINT_GROUP_ALIASES.items():
                 if point_group_name == key:
-                    point_group_name = alias[0]
+                    point_group_name = aliases[0]
                     break
         header += (
             f"Phase {phase_id}\n"

--- a/orix/quaternion/symmetry.py
+++ b/orix/quaternion/symmetry.py
@@ -818,11 +818,13 @@ def get_point_group(space_group_number: int, proper: bool = False) -> Symmetry:
 # Point group alias mapping. This is needed because in EDAX TSL OIM
 # Analysis 7.2, e.g. point group 432 is entered as 43.
 # Used when reading a phase's point group from an EDAX ANG file header
-point_group_aliases = {
+_EDAX_POINT_GROUP_ALIASES = {
     "121": ["20"],
     "2/m": ["2"],
     "222": ["22"],
     "422": ["42"],
+    "321": ["32"],
+    "622": ["62"],
     "432": ["43"],
     "m-3m": ["m3m"],
 }

--- a/orix/tests/io/test_ang.py
+++ b/orix/tests/io/test_ang.py
@@ -608,7 +608,7 @@ class TestAngWriter:
         del pl[-1]
         assert xmap_reload.phases.names == pl.names
 
-    @pytest.mark.parametrize("point_group", ["432", "121", "222"])
+    @pytest.mark.parametrize("point_group", ["432", "121", "222", "321", "622"])
     def test_point_group_aliases(self, crystal_map, tmp_path, point_group):
         crystal_map.phases[0].point_group = point_group
         fname = tmp_path / "test_point_group_aliases.ang"


### PR DESCRIPTION
#### Description of the change
Fixes #534.

#### Progress of the PR
- [x] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### Minimal example of the bug fix or new feature
```python
>>> from orix import io
>>> xmap = io.load("Ti_single_crystal_scan.ang")
[/Users/hakon/kode/personal/orix/orix/io/plugins/ang.py:285](https://file+.vscode-resource.vscode-cdn.net/Users/hakon/kode/personal/orix/orix/io/plugins/ang.py:285): UserWarning: Number of columns, 13, in the file is not equal to the expected number of columns, [14, 10], for the 
assumed vendor 'tsl'. Will therefore assume the following columns: euler1, euler2, euler3, x, y, unknown1, unknown2, phase_id, unknown3, unknown4, etc.
  warnings.warn(
>>> print(xmap)
Phase    Orientations  Name  Space group  Point group  Proper point group     Color
    0  10324 (100.0%)    Ti         None          622                 622  tab:blue
Properties: unknown1, unknown2, unknown3, unknown4, unknown5, unknown6, unknown7
Scan unit: um
```

(Need to look at the header.)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.