### PR TITLE
Add option to NOT discard zero in `Object3d.unique`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Added
 - Can now convert Quaternions and Rotations to scipy.spatial.transform.Rotation 
   objects via Quaterion.to_scipy_rotation. This also works with Orientations 
   and Misorientations, albiet with a loss of symmetry information.
+- ``ignore_zero`` option for ``Vector3d.unique`` to allow all-zero elements, which were
+  previously discarded. Discarding is still enabled by default.
 
 Changed
 -------

--- a/orix/_base.py
+++ b/orix/_base.py
@@ -195,7 +195,12 @@ class Object3d:
         obj._data = self._data.T.reshape(real_dim, -1).T
         return obj
 
-    def unique(self, return_index: bool = False, return_inverse: bool = False) -> Union[
+    def unique(
+        self,
+        return_index: bool = False,
+        return_inverse: bool = False,
+        ignore_zero: bool = True,
+    ) -> Union[
         Tuple[Object3d, np.ndarray, np.ndarray],
         Tuple[Object3d, np.ndarray],
         Object3d,
@@ -205,7 +210,7 @@ class Object3d:
 
         Unless overridden, this method returns the numerically unique
         entries. It also removes zero-entries which are assumed to be
-        degenerate.
+        degenerate, unless ``ignore_zero`` is ``False``.
 
         Parameters
         ----------
@@ -215,6 +220,8 @@ class Object3d:
         return_inverse
             If ``True``, will also return the indices to reconstruct the
             (flattened) data from the unique data.
+        ignore_zero
+            If ``True``, remove any all-zero elements.
 
         Returns
         -------
@@ -228,7 +235,8 @@ class Object3d:
             ``return_inverse=True``.
         """
         data = self.flatten()._data.round(10)
-        data = data[~np.all(np.isclose(data, 0), axis=1)]  # Remove zeros
+        if ignore_zero:
+            data = data[~np.all(np.isclose(data, 0), axis=1)]  # Remove zeros
         _, idx, inv = np.unique(data, axis=0, return_index=True, return_inverse=True)
         obj = self.__class__(data[np.sort(idx), : self.dim])
         obj._data = data[np.sort(idx)]

--- a/orix/tests/test_object3d.py
+++ b/orix/tests/test_object3d.py
@@ -184,7 +184,7 @@ def test_flatten(object3d):
 
 @pytest.mark.parametrize("test_object3d", [1], indirect=["test_object3d"])
 def test_unique(test_object3d):
-    o3d = test_object3d([[1], [1], [2], [3], [3]])
+    o3d = test_object3d([[1], [1], [2], [3], [3], [0]])
     unique = o3d.unique()
     assert np.allclose(unique.data.flatten(), [1, 2, 3])
     unique, idx = o3d.unique(return_index=True)
@@ -197,6 +197,11 @@ def test_unique(test_object3d):
     assert np.allclose(unique.data.flatten(), [1, 2, 3])
     assert np.allclose(idx, [0, 2, 3])
     assert np.allclose(inv, [0, 0, 1, 2, 2])
+    unique, idx, inv = o3d.unique(
+        return_index=True, return_inverse=True, ignore_zero=False
+    )
+    assert np.allclose(idx, [5, 0, 2, 3])
+    assert np.allclose(inv, [1, 1, 2, 3, 3, 0])
 
 
 @pytest.mark.parametrize("test_object3d", [4], indirect=["test_object3d"])


### PR DESCRIPTION
#### Description of the change
Currently, `Object3d.unique` discards zero-elements. This PR makes that optional (but on by default), which is useful in diffsims where the (0 0 0) reciprocal vector often appears.

#### Progress of the PR
- [x] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### Minimal example of the bug fix or new feature
```python
>>> from orix.vector import Vector3d
>>> v = Vector3d([
    [1, 0, 0],
    [1, 0, 0],
    [0, 0, 0],
    [2, 1, 0]
])
>>> v.unique()
Vector3d (2,)
[[1 0 0]
 [2 1 0]]

>>> v.unique(ignore_zero=False)
Vector3d (3,)
[[1 0 0]
 [0 0 0]
 [2 1 0]]
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.