### PR TITLE
Fix `CrystalMap` with single element that breaks with recent numpy

### DIFF
--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -285,7 +285,7 @@ class CrystalMap:
 
         # Set whether measurements are indexed
         is_indexed = np.ones(data_size, dtype=bool)
-        is_indexed[np.where(phase_id == -1)] = False
+        is_indexed[phase_id == -1] = False
 
         # Add "not_indexed" to phase list and ensure not indexed points
         # have correct phase ID


### PR DESCRIPTION
#### Description of the change
Fix for an error in kikuchipy test suite: [#723](https://github.com/pyxem/kikuchipy/pull/723)

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.