### PR TITLE
update random method to gaussian form.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Added
 
 Changed
 -------
+- For speed and space reasons, vectors and quaternions are now randomly
+  generated using a gaussian method as opposed to rejection-based sampling.
 
 Removed
 -------

--- a/orix/_base.py
+++ b/orix/_base.py
@@ -162,7 +162,23 @@ class Object3d:
 
     @classmethod
     def random(cls, shape: Union[int, tuple] = 1) -> Object3d:
-        """Create object with random data.
+        """Create object with uniformly distributed random data.
+
+        For objects that map to the surfaces of n-dimensional unit spheres
+        (unit vectors, quaternions, octonions, etc), randomly sampling values
+        for each axis gives a non-uniform sampling that coalesces near the
+        poles. One proper method is to instead sample an n-dimensional
+        gaussian distribution for each axis, then normalize the result.
+
+        For Vector3d objects, this would produce a uniform sampling of the 2D
+        surface of the 3D unit sphere.
+
+        For Rotation objects, this would be a uniform sampling of the 3D
+        surface of the 4D quaterion unit sphere.
+
+        Note that this is not the only definition of a "random" sample, but is
+        the one most commonly appropriate when discussing vectors and rotations
+        in crystallography
 
         Parameters
         ----------
@@ -175,12 +191,7 @@ class Object3d:
             Object with random data.
         """
         n = int(np.prod(shape))
-        obj = []
-        while len(obj) < n:
-            r = np.random.uniform(-1, 1, (3 * n, cls.dim))
-            r2 = np.sum(np.square(r), axis=1)
-            r = r[np.logical_and(1e-9**2 < r2, r2 <= 1)]
-            obj += list(r)
+        obj = np.random.normal(size=[n, cls.dim])
         obj = cls(np.array(obj[:n]))
         obj = obj.unit
         obj = obj.reshape(shape)

--- a/orix/_base.py
+++ b/orix/_base.py
@@ -174,7 +174,7 @@ class Object3d:
         surface of the 3D unit sphere.
 
         For Rotation objects, this would be a uniform sampling of the 3D
-        surface of the 4D quaterion unit sphere.
+        surface of the 4D quaternion unit sphere.
 
         Note that this is not the only definition of a "random" sample, but is
         the one most commonly appropriate when discussing vectors and rotations

--- a/orix/tests/test_object3d.py
+++ b/orix/tests/test_object3d.py
@@ -211,19 +211,13 @@ def test_get_random_sample(test_object3d):
 
 @pytest.mark.parametrize("test_object3d", [2, 3, 4], indirect=["test_object3d"])
 def test_random(test_object3d):
-    # a note for future testers: Testing if samples taken from a non-euclidean
-    # space are randomly distributed is difficult. A potentially more robust
-    # method than the one below is to project the random samples into a
-    # equi-volume  Euclidean projection, then test for uniformity.
-    # If/when orix adds quaternion.to_cubochoric, this would be a good test to
-    # add. It could theoretically be done in homochoric, but the curved bounds
-    # make it difficult. Also, either version would only test quaternions,
-    # not 2D and 3D vectors.
-    # Instead, this test creates 1000 objects and tests if their angular
-    # distributions from one another are roughly uniform. This isn't truly the
-    # same as random, but it's close and it tests against the majority
-    # of common sampling errors. Additionally, it works for any hypersphere
-    # surface (vectors and octonions, for example).
+    # A note to future devs: This test does not truly test for randomness,
+    # which is difficult to do in non-euclidean spaces. Instead, it tests all
+    # elements have roughly the same distributions of distances from all other
+    # elements. This works for all objects mapping to hyperspheres (2D/3D
+    # vectors, quaternions, octonions, etc), and catches the majority of
+    # common sampling mistakes. It also makes sure the distributions are not
+    # perfectly identical, as weould happen in a regularly spaced grid.
     data = test_object3d.random(1000).data
     dist = np.tensordot(data, data, axes=(-1, -1))
     # average distance between every object and all others
@@ -234,3 +228,5 @@ def test_random(test_object3d):
     # is low (ie, the distributions are, within reason, identical)
     assert dist_means.std() / dist_means.mean() < 0.05
     assert dist_stds.std() / dist_stds.mean() < 0.05
+    assert dist_means.std() / dist_means.mean() > 1e-7
+    assert dist_stds.std() / dist_stds.mean() > 1e-7

--- a/orix/tests/test_object3d.py
+++ b/orix/tests/test_object3d.py
@@ -217,7 +217,7 @@ def test_random(test_object3d):
     # elements. This works for all objects mapping to hyperspheres (2D/3D
     # vectors, quaternions, octonions, etc), and catches the majority of
     # common sampling mistakes. It also makes sure the distributions are not
-    # perfectly identical, as weould happen in a regularly spaced grid.
+    # perfectly identical, as would happen in a regularly spaced grid.
     data = test_object3d.random(1000).data
     dist = np.tensordot(data, data, axes=(-1, -1))
     # average distance between every object and all others


### PR DESCRIPTION
#### Description of the change

replaces the `while` loop approach currently used in `orix.base.random`  with the more common gaussian sampling used elsewhere. 

functionally identical, but (as shown in #218), is 3 to 5 times faster and removes a `while' loop

#### Progress of the PR
- [x] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

NOTE: While this DOES test every line, I did not write a unit test to prove random variables are uniformly random, as (to my knowledge) such a test does not exist.

I could potentially:
A) calculate the first few spherical harmonics for 10,000 random rotations and vectors, and show the unimodal term dominates
B) calculate the angular distances with `dot_outer` for groups of random objects and show the distributions match (ie, everything is equally far from everything else)

However, I tried both and both are slow (a few seconds each) adding to the already considerable testing time, and I'm not sure they protect against anything. 


#### Minimal example of the bug fix or new feature
```
v = Vector3d.random(10000)
r = Rotation.random(10000)
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.