### PR TITLE
Allow conversion of orix rotations to scipy rotations

### DIFF
--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -945,6 +945,42 @@ class Quaternion(Object3d):
         ho = Homochoric(ho)
         return ho
 
+    def to_scipy_rotation(self) -> SciPyRotation:
+        r"""Return the unit quaternions as
+        :class:`scipy.spatial.transform.Rotation` objects used in scipy's
+        spatial module.
+
+        Returns
+        -------
+        SciPy_Rotation
+            a Rotation object generated from the unit quaternion data
+            (i.e, unaffected by symmetry, phase, or length).
+
+        Notes
+        -----
+        SciPy by default uses the Active rotation convention, as opposed to
+        ORIX's Passive standard. Thus, the quaternion rotatation in orix:
+        :math: `q_{orix} = [q_0, q_1, q_2, q_3]`
+        becomes the following in scipy:
+        :math: `q_{SciPy} = [q_1, q_2, q_3, q_0]`
+
+        See the function description for Quaternion.from_scipy_rotation
+        for an example of how these differing parameterizations still produce
+        identical rotation operations.
+
+        Additionally, note that Orix enforces :math: `q_0 >= 0` whereas
+        SciPy does not. Thus, the operation
+
+        >>> Quaternion.from_scipy_rotation(r).to_scipy_rotation.as_quat()
+
+        will produce an identical rotation representation, but not
+        necessarily an idential quaternion. Look up "quaternion double cover"
+        for more information on why this occurs.
+        """
+        inverter = np.array([[-1, -1, -1, 1]])
+        scipy_rot_data = self.unit.data[:, (1, 2, 3, 0)] * inverter
+        return SciPyRotation.from_quat(scipy_rot_data)
+
     # --------------------- Other public methods --------------------- #
 
     def dot(self, other: Quaternion) -> np.ndarray:

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -959,7 +959,7 @@ class Quaternion(Object3d):
         Notes
         -----
         SciPy by default uses the Active rotation convention, as opposed to
-        ORIX's Passive standard. Thus, the quaternion rotatation in orix:
+        ORIX's Passive standard. Thus, the quaternion rotation in orix:
         :math: `q_{orix} = [q_0, q_1, q_2, q_3]`
         becomes the following in scipy:
         :math: `q_{SciPy} = [q_1, q_2, q_3, q_0]`

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -958,11 +958,12 @@ class Quaternion(Object3d):
 
         Notes
         -----
-        SciPy by default uses the Active rotation convention, as opposed to
-        ORIX's Passive standard. Thus, the quaternion rotation in orix:
+        SciPy by default uses the Active rotation convention along with the
+        vector-scalar quaternion definition, as opposed to ORIX's passive,
+        scalar-vector convention. Thus, the following quaternion in orix:
         :math: `q_{orix} = [q_0, q_1, q_2, q_3]`
-        becomes the following in scipy:
-        :math: `q_{SciPy} = [q_1, q_2, q_3, q_0]`
+        represents the same operations as the following quaternion in scipy:
+        :math: `q_{SciPy} = [-q_1, -q_2, -q_3, q_0]`
 
         See the function description for Quaternion.from_scipy_rotation
         for an example of how these differing parameterizations still produce
@@ -973,10 +974,20 @@ class Quaternion(Object3d):
 
         >>> Quaternion.from_scipy_rotation(r).to_scipy_rotation.as_quat()
 
-        will produce an identical rotation representation, but not
+        will produce an identical rotation operation, but not
         necessarily an idential quaternion. Look up "quaternion double cover"
         for more information on why this occurs.
+
+        Finally, ORIX supports N-dimensional arrays, whereas SciPy
+        currently supports only 1-dimensional vectors. Thus, this function
+        will also flatten arrays when converting to SciPy Rotations.
         """
+        if self.ndim > 1:
+            warnings.warn(
+                "\n    {} dimension greater than 1. ".format(self.__class__.__name__)
+                + "Flattening into a 1-dimensional vector"
+            )
+            self = self.flatten()
         inverter = np.array([[-1, -1, -1, 1]])
         scipy_rot_data = self.unit.data[:, (1, 2, 3, 0)] * inverter
         return SciPyRotation.from_quat(scipy_rot_data)

--- a/orix/tests/quaternion/test_rotation.py
+++ b/orix/tests/quaternion/test_rotation.py
@@ -575,7 +575,7 @@ class TestToFromScipyRotation:
         scipy_ref = SciPyRotation.from_euler("ZXZ", euler)  # Bunge convention
         rot = Rotation.from_euler(euler)
         scipy_rot = rot.to_scipy_rotation()
-        assert np.allclose(scipy_rot.as_quat() - scipy_ref.as_quat())
+        assert np.allclose(scipy_rot.as_quat(), scipy_ref.as_quat())
 
     def test_to_from_scipy_gives_same_rotation(self):
         # use the Fibonacci series to generate some repeatable pseudo-random


### PR DESCRIPTION
#### Description of the change

Adds `Quaternion.to_scipy_rotation` as a method.

this should close out #527  

#### Progress of the PR
- [x] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### Minimal example of the bug fix or new feature
```
>> from scipy.spatial.transform import Rotation as SciPyRotation
>> from orix.quaternion import Quaternion, Rotation

>> euler = np.deg2rad([56, 22, 11])
>> scipy_ref = SciPyRotation.from_euler("ZXZ", euler)  # Bunge convention
>> rot = Rotation.from_euler(euler)
>> scipy_rot = rot.to_scipy_rotation()
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.