### PR TITLE
Add --run-slow and @pytest.mark.slow options for testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,21 @@
+##
+## Copyright 2019-2025 the orix developers
+##
+## This file is part of orix.
+##
+## orix is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## orix is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with orix. If not, see <http://www.gnu.org/licenses/>.
+##
 name: build
 
 on:
@@ -92,7 +110,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest --pyargs orix --run-slow --reruns 2 -n 2 --cov=orix
+          pytest --pyargs orix --runslow --reruns 2 -n 2 --cov=orix
 
       - name: Generate line coverage
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest --pyargs orix --reruns 2 -n 2 --cov=orix
+          pytest --pyargs orix --run-slow --reruns 2 -n 2 --cov=orix
 
       - name: Generate line coverage
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Unreleased
 
 Added
 -----
+- Added the ``@pytest.mark.slow`` marker for slow tests.  Using ``pytest . --run-slow`` will
+  run all tests, including slow ones.
 
 Changed
 -------

--- a/doc/dev/running_writing_tests.rst
+++ b/doc/dev/running_writing_tests.rst
@@ -22,8 +22,9 @@ Some useful :doc:`fixtures <pytest:explanation/fixtures>` are available in the
 
 To run the tests::
 
-   pytest --cov --pyargs orix
+  pytest --cov --pyargs orix -n auto
 
+The ``-n auto`` is an optional flag to enable parallelized testing. 
 The ``--cov`` flag makes :doc:`coverage.py <coverage:index>` print a nice report.
 For an even nicer presentation, you can use ``coverage.py`` directly::
 

--- a/doc/dev/running_writing_tests.rst
+++ b/doc/dev/running_writing_tests.rst
@@ -33,6 +33,17 @@ Coverage can then be inspected in the browser by opening ``htmlcov/index.html``.
 
 We strive for 100% test coverage of lines when all dependencies are installed.
 
+If you have a test that takes a long time to run, you can mark it to skip it from running by default:
+
+.. code-block::
+    @pytest.mark.slow
+    def test_slow_function():
+        pass
+
+Then you can run the tests with the ``--runslow`` option to skip slow tests::
+
+    pytest --runslow
+
 Docstring examples are tested with :doc:`pytest <pytest:how-to/doctest>` as well.
 :mod:`numpy` and :mod:`matplotlib.pyplot` should not be imported in examples as they are
 already available in the namespace as ``np`` and ``plt``, respectively.

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -1,4 +1,5 @@
-# Copyright 2018-2024 the orix developers
+#
+# Copyright 2019-2025 the orix developers
 #
 # This file is part of orix.
 #
@@ -9,11 +10,13 @@
 #
 # orix is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with orix.  If not, see <http://www.gnu.org/licenses/>.
+# along with orix. If not, see <http://www.gnu.org/licenses/>.
+#
+
 
 import os
 from tempfile import TemporaryDirectory
@@ -48,6 +51,27 @@ skipif_numpy_quaternion_missing = pytest.mark.skipif(
 # ---------------------------- IO fixtures --------------------------- #
 
 # ----------------------------- .ang file ---------------------------- #
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    else:  # pragma: no cover
+        skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+        for item in items:
+            if "slow" in item.keywords:
+                item.add_marker(skip_slow)
 
 
 @pytest.fixture()

--- a/orix/tests/plot/test_direction_color_keys.py
+++ b/orix/tests/plot/test_direction_color_keys.py
@@ -47,6 +47,7 @@ class TestDirectionColorKeyTSL:
             [symmetry.Th, (415, 415, 4)],
         ],
     )
+    @pytest.mark.slow
     def test_rgba_grid_shape(self, symmetry, expected_shape):
         ckey = IPFColorKeyTSL(symmetry)
         ckey_direction = ckey.direction_color_key
@@ -64,6 +65,7 @@ class TestDirectionColorKeyTSL:
             [symmetry.Th, (0.0, 0.414), (0.0, 0.414)],
         ],
     )
+    @pytest.mark.slow
     def test_rgba_grid_limits(self, symmetry, expected_xlim, expected_ylim):
         ckey = IPFColorKeyTSL(symmetry)
         ckey_direction = ckey.direction_color_key
@@ -81,6 +83,7 @@ class TestDirectionColorKeyTSL:
         "symmetry",
         [symmetry.C2, symmetry.D6, symmetry.Oh],
     )
+    @pytest.mark.slow
     def test_rgba_grid_alpha(self, symmetry):
         ckey = IPFColorKeyTSL(symmetry)
         ckey_direction = ckey.direction_color_key

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -333,6 +333,7 @@ class TestMisorientation:
         distance2 = m2.get_distance_matrix()
         assert distance2.shape == 2 * shape
 
+    @pytest.mark.slow
     def test_get_distance_matrix_progressbar_chunksize(self):
         m = Misorientation.random((5, 15, 4))
         angle1 = m.get_distance_matrix(chunk_size=5)
@@ -590,6 +591,7 @@ class TestOrientation:
         angles3 = o.get_distance_matrix(degrees=True)
         assert np.allclose(np.rad2deg(angles_numpy), angles3)
 
+    @pytest.mark.slow
     def test_get_distance_matrix_lazy_parameters(self):
         shape = (5, 15, 4)
         rng = np.random.default_rng()

--- a/orix/tests/quaternion/test_quaternion.py
+++ b/orix/tests/quaternion/test_quaternion.py
@@ -223,6 +223,7 @@ class TestQuaternion:
         assert qo_dask2.shape == 2 * shape
         assert np.allclose(qo_numpy.data, qo_dask2.data)
 
+    @pytest.mark.slow
     def test_outer_lazy_chunk_size(self):
         shape = (5, 15, 4)
         rng = np.random.default_rng()


### PR DESCRIPTION
#### Description of the change

Add --run-slow and @pytest.mark.slow options for testing

#### Progress of the PR
- [ ] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [ ] Unit tests with pytest for all lines
- [ ] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### Minimal example of the bug fix or new feature
```python
>>> from orix import vector
>>> v = vector.Vector3d([1, 1, 1])
>>> # Your new feature...
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.