### PR TITLE
Making `matplotlib_scalebar` optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,9 @@ Changed
 - For speed and space reasons, vectors and quaternions are now randomly
   generated using a gaussian method as opposed to rejection-based sampling.
 
+- Due to dependency issues, matplotlib_scalebar as been moved from a
+  required dependency to an optional one.
+
 Removed
 -------
 

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -107,7 +107,6 @@ Package                                          Purpose
 :doc:`diffpy.structure <diffpy.structure:index>` Handling of crystal structures
 :doc:`h5py <h5py:index>`                         Read/write of HDF5 files
 :doc:`matplotlib <matplotlib:index>`             Visualization
-`matplotlib-scalebar`_                           Scale bar for crystal map plots
 :doc:`numba <numba:index>`                       CPU acceleration
 :doc:`numpy <numpy:index>`                       Handling of N-dimensional arrays
 :doc:`pooch <pooch:api/index>`                   Downloading and caching of datasets
@@ -119,11 +118,12 @@ Package                                          Purpose
 
 Some functionality requires optional dependencies:
 
-=================== ===========================================
-Package             Purpose                                    
-=================== ===========================================
-`numpy-quaternion`_ Faster quaternion and vector multiplication
-=================== ===========================================
+======================== ===========================================
+Package                  Purpose                                    
+======================== ===========================================
+`numpy-quaternion`_      Faster quaternion and vector multiplication
+`matplotlib-scalebar`_   Scale bar for crystal map plots
+======================== ===========================================
 
 .. _numpy-quaternion: https://quaternion.readthedocs.io/en/stable/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "diffpy.structure       >= 3.0.2",
     "h5py",
     "matplotlib             >= 3.6.1",
-    "matplotlib-scalebar",
     "numba",
     "numpy",
     "pooch                  >= 0.13",
@@ -42,6 +41,7 @@ dependencies = [
 
 [project.optional-dependencies]
 all = [  # NB! Update constants.py if this list is updated!
+    "matplotlib-scalebar",
     "numpy-quaternion",
 ]
 doc = [


### PR DESCRIPTION
#### Description of the change
As discussed in #540, `matplotlib_scalebar` has caused install problems on certain systems. This PR would make the package an optional dependency.

This PR is currently a draft, contributions welcome. It still needs unit tests written and Jupyter notebooks updated (crystal_map.ipynb for sure, possibly others).

#### Progress of the PR
- [x] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [ ] Unit tests with pytest for all lines
- [ ] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)


#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.