### PR TITLE
Add copy constructors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Added
   and Misorientations, albiet with a loss of symmetry information.
 - ``ignore_zero`` option for ``Vector3d.unique`` to allow all-zero elements, which were
   previously discarded. Discarding is still enabled by default.
+- Added copy constructors to ``Phase``, ``PhaseList`` and ``CrystalMap``.
 
 Changed
 -------

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -204,7 +204,7 @@ class CrystalMap:
 
     def __init__(
         self,
-        rotations: Rotation,
+        rotations: "Rotation | CrystalMap",
         phase_id: Optional[np.ndarray] = None,
         x: Optional[np.ndarray] = None,
         y: Optional[np.ndarray] = None,
@@ -213,6 +213,18 @@ class CrystalMap:
         scan_unit: Optional[str] = "px",
         is_in_data: Optional[np.ndarray] = None,
     ):
+        if isinstance(rotations, CrystalMap):
+            return CrystalMap.__init__(
+                self,
+                rotations.rotations,
+                rotations.phase_id,
+                rotations.x,
+                rotations.y,
+                rotations.phases,
+                rotations.prop,
+                rotations.scan_unit,
+                rotations.is_in_data,
+            )
         # Set rotations
         if not isinstance(rotations, Rotation):
             raise ValueError(

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -54,6 +54,7 @@ class Phase:
     ----------
     name
         Phase name. Overwrites the name in the ``structure`` object.
+        If this parameter is a :code:`Phase`, a copy is made.
     space_group
         Space group describing the symmetry operations resulting from
         associating the point group with a Bravais lattice, according
@@ -369,11 +370,14 @@ class PhaseList:
 
     Each phase in the list must have a unique phase id and name.
 
+    If the first parameter is a :code:`PhaseList`, a copy is made
+
     Parameters
     ----------
     phases
         A list or dict of phases or a single phase. The other
         arguments are ignored if this is passed.
+        If a :code:`PhaseList` is given, a copy is made.
     names
         Phase names. Overwrites the names in the ``structure`` objects.
     space_groups
@@ -447,7 +451,7 @@ class PhaseList:
 
     def __init__(
         self,
-        phases: Phase | list[Phase] | dict[int, Phase] | None = None,
+        phases: Phase | list[Phase] | dict[int, Phase] | "PhaseList" | None = None,
         names: str | list[str] | None = None,
         space_groups: int | SpaceGroup | list[int | SpaceGroup] | None = None,
         point_groups: str | int | Symmetry | list[str | int | Symmetry] | None = None,
@@ -456,6 +460,16 @@ class PhaseList:
         structures: Structure | list[Structure] | None = None,
     ) -> None:
         """Create a new phase list."""
+        if isinstance(phases, PhaseList):
+            return PhaseList.__init__(
+                self,
+                names=phases.names,
+                space_groups=phases.space_groups,
+                point_groups=phases.point_groups,
+                colors=phases.colors,
+                ids=phases.ids,
+                structures=phases.structures,
+            )
         d = {}
         if isinstance(phases, list):
             try:

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -48,6 +48,8 @@ ALL_COLORS.update(mcolors.XKCD_COLORS)
 class Phase:
     """Name, symmetry, and color of a phase in a crystallographic map.
 
+    If the first parameter is a :code:`Phase` instance, a copy is made
+
     Parameters
     ----------
     name
@@ -95,12 +97,21 @@ class Phase:
 
     def __init__(
         self,
-        name: str | None = None,
+        name: str | "Phase" | None = None,
         space_group: int | SpaceGroup | None = None,
         point_group: int | str | Symmetry | None = None,
         structure: Structure | None = None,
         color: str | None = None,
     ) -> None:
+        if isinstance(name, Phase):
+            return Phase.__init__(
+                self,
+                name.name,
+                name.space_group,
+                name.point_group,
+                name.structure.copy(),
+                name.color,
+            )
         self.structure = structure if structure is not None else Structure()
         if name is not None:
             self.name = name

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -25,7 +25,7 @@ from scipy.spatial.transform import Rotation as SciPyRotation
 # isort: off
 from orix.crystal_map import Phase
 from orix.plot import AxAnglePlot, InversePoleFigurePlot, RodriguesPlot
-from orix.quaternion import Misorientation, Orientation, Rotation
+from orix.quaternion import Misorientation, Orientation, Quaternion, Rotation
 from orix.quaternion.symmetry import (
     C1,
     C2,
@@ -53,6 +53,29 @@ def vector(request):
 @pytest.fixture(params=[(0.5, 0.5, 0.5, 0.5), (0.5**0.5, 0, 0, 0.5**0.5)])
 def orientation(request):
     return Orientation(request.param)
+
+
+def test_quaternion_subclasses_copy_constructor_casting():
+    """Test casting to parent classes with copy constructor"""
+    data = [0.5, 0.5, 0.5, 0.5]
+    q1 = Quaternion(data)
+    r1 = Rotation(data)
+    m1 = Misorientation(data)
+    o1 = Orientation(data)
+
+    assert Quaternion(r1) == q1
+    assert Quaternion(m1) == q1
+    assert Quaternion(o1) == q1
+
+    assert Rotation(m1) == r1
+    assert Rotation(o1) == r1
+
+    assert Misorientation(o1) == m1
+
+    assert Quaternion(q1) is not q1
+    assert Rotation(r1) is not r1
+    assert Misorientation(m1) is not m1
+    assert Orientation(o1) is not o1
 
 
 @pytest.mark.parametrize(

--- a/orix/tests/test_crystal_map.py
+++ b/orix/tests/test_crystal_map.py
@@ -46,6 +46,12 @@ class TestCrystalMap:
         assert isinstance(xmap.rotations, Rotation)
         assert np.allclose(xmap.rotations.data, rotations.data)
 
+    def test_init_with_instance(self, rotations):
+        xmap1 = CrystalMap(rotations)
+        xmap2 = CrystalMap(xmap1)
+        assert xmap1.rotations == xmap2.rotations
+        assert xmap1 is not xmap2
+
     def test_init_with_invalid_rotations(self, rotations):
         with pytest.raises(ValueError):
             _ = CrystalMap(rotations=rotations.data)

--- a/orix/tests/test_phase_list/test_phase.py
+++ b/orix/tests/test_phase_list/test_phase.py
@@ -93,6 +93,27 @@ class TestPhase:
         else:
             assert p.structure == Structure()
 
+    def test_copy_constructor_phase(self):
+        p1 = Phase(
+            "test", 
+            225, 
+            "m-3m", 
+            Structure(
+                [Atom("Al", (0, 0, 0))], 
+                Lattice(10, 10, 10, 90, 90, 90),
+            ),
+        )
+        p2 = Phase(p1)
+
+        assert p1 is not p2
+        assert repr(p1) == repr(p2)
+        assert p1.structure is not p2.structure
+        assert p1.structure[0].element == p2.structure[0].element
+        assert tuple(p1.structure[0].xyz) == tuple(p2.structure[0].xyz)
+        assert p1.structure[0] is not p2.structure[0]
+        assert p1.structure.lattice.abcABG() == p2.structure.lattice.abcABG()
+        assert p1.structure.lattice is not p2.structure.lattice
+
     @pytest.mark.parametrize("name", [None, "al", 1, np.arange(2)])
     def test_set_phase_name(self, name):
         p = Phase(name=name)

--- a/orix/tests/test_phase_list/test_phase.py
+++ b/orix/tests/test_phase_list/test_phase.py
@@ -95,11 +95,11 @@ class TestPhase:
 
     def test_copy_constructor_phase(self):
         p1 = Phase(
-            "test", 
-            225, 
-            "m-3m", 
+            "test",
+            225,
+            "m-3m",
             Structure(
-                [Atom("Al", (0, 0, 0))], 
+                [Atom("Al", (0, 0, 0))],
                 Lattice(10, 10, 10, 90, 90, 90),
             ),
         )

--- a/orix/tests/test_phase_list/test_phase_list.py
+++ b/orix/tests/test_phase_list/test_phase_list.py
@@ -72,6 +72,21 @@ class TestPhaseList:
         assert pl.colors == [p.color]
         assert pl.colors_rgb == [p.color_rgb]
 
+    def test_init_phaselist_from_phaselist(self):
+        p1 = Phase(name="austenite", point_group="432", color="C2")
+        pl1 = PhaseList(p1)
+        pl2 = PhaseList(pl1)
+
+        assert pl1 is not pl2
+        assert pl1[pl1.ids[0]] is not pl2[pl2.ids[0]]
+        assert pl1.names == pl2.names
+        assert pl1.point_groups == pl2.point_groups
+        assert pl1.space_groups == pl2.space_groups
+        assert pl1.colors == pl2.colors
+        assert pl1.colors_rgb == pl2.colors_rgb
+        assert pl1.structures == pl2.structures
+        assert pl1.structures[0] is not pl2.structures[0]
+
     @pytest.mark.parametrize(
         (
             "names, space_groups, point_groups, colors, phase_ids, desired_names, "


### PR DESCRIPTION
#### Description of the change
Partially addresses #535, input very much welcome!
Adds a copy constructor to some classes, i.e. if the first parameter to the constructor is an existing instance, make a copy of it.
This pattern exists in e.g. diffpy.structure already.

As described in the linked issue, we can also then add a copy method like this:
```python
def copy(self) -> Self:
    return self.__class__(self)
```
The control of how deep the copy becomes lies then in the constructor. I left this out for the most part, but e.g. arrays should probably be copied in the constructor call:
```python
class Phase:
    def __init__(self, arg1, ...):
       if isinstance(arg1, Phase):
            return Phase.__init__(
                self,
                arg1.arg1.copy(), # Explicitly copy here, if this behaviour is desired
                ...
            )
```

Currently implemented for:
- Phase
- PhaseList
- CrystalMap
- Quaternion, Rotation, Misorientation, Orientation (already worked by inheriting from Object3d, I just added a test. It might already be tested and I missed it)

#### Progress of the PR
- [x] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### Minimal example of the bug fix or new feature
```python
>>> from orix.crystal_map import Phase
>>> p1 = Phase(...)
>>> p2 = Phase(p1) # p2 is a new copy of p1
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.