### PR TITLE
fix  IPF colormaps for hex/trig and add tests

### DIFF
--- a/orix/plot/inverse_pole_figure_plot.py
+++ b/orix/plot/inverse_pole_figure_plot.py
@@ -223,6 +223,9 @@ class InversePoleFigurePlot(StereographicPlot):
         """Add appropriately placed and nicely formatted crystal
         direction labels [uvw] or [UVTW] to the sector corners.
         """
+        # use symmetry.fundamental_sector to get consistent fundamental
+        # sector definitions that align with section 2.4 of this paper:
+        # https://onlinelibrary.wiley.com/doi/abs/10.1107/S1600576716012942
         fs = self._symmetry.fundamental_sector
         vertices = fs.vertices
         if vertices.size > 0:
@@ -230,6 +233,15 @@ class InversePoleFigurePlot(StereographicPlot):
 
             # Nicely formatted labels for crystal directions
             labels = _get_ipf_axes_labels(vertices, self._symmetry)
+            if self._symmetry.system in ["trigonal", "hexagonal"]:
+                # trigonal and hexagonal are given in xyz here, and need
+                # to be converted to uvw, then UVTW to make the labels
+                # show up correctly.
+                sq2hex = np.array(
+                    [[1, 0, 0], [1 / np.sqrt(3), np.sqrt(4 / 3), 0], [0, 0, 1]]
+                )
+                label_v = vertices.data.dot(sq2hex)
+                labels = _get_ipf_axes_labels(label_v, self._symmetry)
             x, y = self._projection.vector2xy(vertices)
 
             x_edge, y_edge = self._edge_patch.get_path().vertices.T

--- a/orix/tests/plot/test_direction_color_keys.py
+++ b/orix/tests/plot/test_direction_color_keys.py
@@ -38,46 +38,58 @@ class TestDirectionColorKeyTSL:
         assert rgb2[0].size == rgb2[1].size == 0
 
     @pytest.mark.parametrize(
-        "symmetry, expected_shape",
+        "symmetry, expected_shape, expected_xy_lims, expected_labels",
         [
-            [symmetry.C1, (2000, 2000, 4)],
-            [symmetry.C2, (1000, 2000, 4)],
-            [symmetry.D6, (500, 1000, 4)],
-            [symmetry.Oh, (367, 415, 4)],
-            [symmetry.Th, (415, 415, 4)],
+            [symmetry.C1, (2000, 2000, 4), [(-1.0, 1.0), (-1.0, 1.0)], ""],
+            [
+                symmetry.C2,
+                (1000, 2000, 4),
+                [(-1.0, 1.0), (0.0, 1.0)],
+                "[$1 0 0$][$\\bar{1} 0 0$]",
+            ],
+            [
+                symmetry.S6,
+                (1000, 1500, 4),
+                [(-0.5, 1.0), (0, 1.0)],
+                "[$2 \\bar{1} \\bar{1} 0$][$0 0 0 1$][$\\bar{1} 2 \\bar{1} 0$]",
+            ],
+            [
+                symmetry.D6,
+                (500, 1000, 4),
+                [(0.0, 1.0), (0.0, 0.5)],
+                "[$2 \\bar{1} \\bar{1} 0$][$0 0 0 1$][$1 0 \\bar{1} 0$]",
+            ],
+            [
+                symmetry.Oh,
+                (367, 415, 4),
+                [(0.0, 0.414), (0.0, 0.366)],
+                "[$1 1 1$][$1 0 1$][$0 0 1$]",
+            ],
+            [
+                symmetry.Th,
+                (415, 415, 4),
+                [(0.0, 0.414), (0.0, 0.414)],
+                "[$0 1 1$][$1 1 1$][$1 0 1$][$0 0 1$]",
+            ],
         ],
     )
     @pytest.mark.slow
-    def test_rgba_grid_shape(self, symmetry, expected_shape):
+    def test_rgba_grid(
+        self, symmetry, expected_shape, expected_xy_lims, expected_labels
+    ):
         ckey = IPFColorKeyTSL(symmetry)
-        ckey_direction = ckey.direction_color_key
-        rgb_grid = ckey_direction._create_rgba_grid()
+        ckey_dcc = ckey.direction_color_key
+        rgb_grid, (xlim, ylim) = ckey_dcc._create_rgba_grid(return_extent=True)
+        (x_min, x_max), (y_min, y_max) = xlim, ylim
+        ax = ckey_dcc.plot(True).get_axes()[0]
+        labels = "".join([x.get_text() for x in ax.texts])
         assert isinstance(rgb_grid, np.ndarray)
         assert rgb_grid.shape == expected_shape
-
-    @pytest.mark.parametrize(
-        "symmetry, expected_xlim, expected_ylim",
-        [
-            [symmetry.C1, (-1.0, 1.0), (-1.0, 1.0)],
-            [symmetry.C2, (-1.0, 1.0), (0.0, 1.0)],
-            [symmetry.D6, (0.0, 1.0), (0.0, 0.5)],
-            [symmetry.Oh, (0.0, 0.414), (0.0, 0.366)],
-            [symmetry.Th, (0.0, 0.414), (0.0, 0.414)],
-        ],
-    )
-    @pytest.mark.slow
-    def test_rgba_grid_limits(self, symmetry, expected_xlim, expected_ylim):
-        ckey = IPFColorKeyTSL(symmetry)
-        ckey_direction = ckey.direction_color_key
-        (
-            _,
-            (x_lim, y_lim),
-        ) = ckey_direction._create_rgba_grid(return_extent=True)
-        (x_min, x_max), (y_min, y_max) = x_lim, y_lim
-        assert round(x_min, 3) == round(expected_xlim[0], 3)
-        assert round(x_max, 3) == round(expected_xlim[1], 3)
-        assert round(y_min, 3) == round(expected_ylim[0], 3)
-        assert round(y_max, 3) == round(expected_ylim[1], 3)
+        assert round(x_min, 3) == round(expected_xy_lims[0][0], 3)
+        assert round(x_max, 3) == round(expected_xy_lims[0][1], 3)
+        assert round(y_min, 3) == round(expected_xy_lims[1][0], 3)
+        assert round(y_max, 3) == round(expected_xy_lims[1][1], 3)
+        assert labels == expected_labels
 
     @pytest.mark.parametrize(
         "symmetry",


### PR DESCRIPTION
#### Description of the change
Fixes the error in IPF plot labels discussed in #543 

#### Progress of the PR
- [x] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### Minimal example of the bug fix or new feature
Compare the images from the following code to those at https://orix.readthedocs.io/en/stable/tutorials/inverse_pole_figures.html

```
from orix import plot, sampling
from orix.quaternion import Orientation, symmetry
from orix.vector import Vector3d

pg_laue = [
    symmetry.S6,
    symmetry.Ci,
    symmetry.C2h,
    symmetry.D2h,
    symmetry.D3d,
    symmetry.C4h,
    symmetry.D4h,
    symmetry.C6h,
    symmetry.D6h,
    symmetry.Th,
    symmetry.Oh,
]

for pg in pg_laue:
    ipfkey = plot.IPFColorKeyTSL(pg)
    ipfkey.plot()
    
    
```




#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.