### PR TITLE
Adding vector comparisons

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Added
   previously discarded. Discarding is still enabled by default.
 - Added copy constructors to ``Phase``, ``PhaseList`` and ``CrystalMap``.
 - Added ``Phase.expand_asymmetric_unit()`` to add all symmetrically equivalent atoms to the structure.
+- Added element-wise to indexing to ``Vector3d`` class and subclasses
 
 Changed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,7 @@ Added
 Changed
 -------
 - .ang files now allow optional rewriting of phase names based on elements and
-point group, as opposed to automatically  overwriting names 
+  point group, as opposed to automatically  overwriting names 
 - For speed and space reasons, vectors and quaternions are now randomly
   generated using a gaussian method as opposed to rejection-based sampling.
 

--- a/doc/dev/running_writing_tests.rst
+++ b/doc/dev/running_writing_tests.rst
@@ -34,9 +34,10 @@ Coverage can then be inspected in the browser by opening ``htmlcov/index.html``.
 
 We strive for 100% test coverage of lines when all dependencies are installed.
 
-If you have a test that takes a long time to run, you can mark it to skip it from running by default:
+If you have a test that takes a long time to run, you can mark it to skip it from running by default
 
-.. code-block::
+.. code-block:: Python
+
     @pytest.mark.slow
     def test_slow_function():
         pass

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -144,9 +144,7 @@ class Phase:
         if isinstance(value, Structure):
             # Ensure correct alignment
             old_matrix = value.lattice.base
-            new_matrix = _new_structure_matrix_from_alignment(
-                old_matrix, x="a", z="c*"
-            )
+            new_matrix = _new_structure_matrix_from_alignment(old_matrix, x="a", z="c*")
             value = copy.deepcopy(value)
             # Ensure atom positions are expressed in the new basis
             value.placeInLattice(Lattice(base=new_matrix))
@@ -156,9 +154,7 @@ class Phase:
                 value.title = self.name
             self._structure = value
         else:
-            raise ValueError(
-                f"{value} must be a diffpy.structure.Structure object."
-            )
+            raise ValueError(f"{value} must be a diffpy.structure.Structure object.")
 
     @property
     def name(self) -> str:
@@ -407,9 +403,8 @@ class Phase:
                 new_atom.xyz = pos
                 # Only add new atom if not already present
                 for present_atom in diffpy_structure:
-                    if (
-                        present_atom.element == new_atom.element
-                        and np.allclose(present_atom.xyz, new_atom.xyz)
+                    if present_atom.element == new_atom.element and np.allclose(
+                        present_atom.xyz, new_atom.xyz
                     ):
                         break
                 else:
@@ -507,14 +502,10 @@ class PhaseList:
 
     def __init__(
         self,
-        phases: (
-            Phase | list[Phase] | dict[int, Phase] | "PhaseList" | None
-        ) = None,
+        phases: Phase | list[Phase] | dict[int, Phase] | "PhaseList" | None = None,
         names: str | list[str] | None = None,
         space_groups: int | SpaceGroup | list[int | SpaceGroup] | None = None,
-        point_groups: (
-            str | int | Symmetry | list[str | int | Symmetry] | None
-        ) = None,
+        point_groups: str | int | Symmetry | list[str | int | Symmetry] | None = None,
         colors: str | list[str] | None = None,
         ids: int | list[int] | np.ndarray | None = None,
         structures: Structure | list[Structure] | None = None,
@@ -751,9 +742,7 @@ class PhaseList:
                     matching_phase_id = phase_id
                     break
             if matching_phase_id is None:
-                raise KeyError(
-                    f"{key} is not among the phase names {self.names}."
-                )
+                raise KeyError(f"{key} is not among the phase names {self.names}.")
             else:
                 self._dict.pop(matching_phase_id)
         else:
@@ -770,13 +759,10 @@ class PhaseList:
 
         # Ensure attributes set to None are treated OK
         names = ["None" if not i else i for i in self.names]
-        sg_names = [
-            "None" if not i else i.short_name for i in self.space_groups
-        ]
+        sg_names = ["None" if not i else i.short_name for i in self.space_groups]
         pg_names = ["None" if not i else i.name for i in self.point_groups]
         ppg_names = [
-            "None" if not i else i.proper_subgroup.name
-            for i in self.point_groups
+            "None" if not i else i.proper_subgroup.name for i in self.point_groups
         ]
 
         # Determine column widths (allowing PhaseList to be empty)
@@ -794,12 +780,8 @@ class PhaseList:
         representation = (
             "{:{align}{width}}  ".format("Id", width=id_len, align=align)
             + "{:{align}{width}}  ".format("Name", width=name_len, align=align)
-            + "{:{align}{width}}  ".format(
-                "Space group", width=sg_len, align=align
-            )
-            + "{:{align}{width}}  ".format(
-                "Point group", width=pg_len, align=align
-            )
+            + "{:{align}{width}}  ".format("Space group", width=sg_len, align=align)
+            + "{:{align}{width}}  ".format("Point group", width=pg_len, align=align)
             + "{:{align}{width}}  ".format(
                 "Proper point group", width=ppg_len, align=align
             )

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -144,7 +144,9 @@ class Phase:
         if isinstance(value, Structure):
             # Ensure correct alignment
             old_matrix = value.lattice.base
-            new_matrix = _new_structure_matrix_from_alignment(old_matrix, x="a", z="c*")
+            new_matrix = _new_structure_matrix_from_alignment(
+                old_matrix, x="a", z="c*"
+            )
             value = copy.deepcopy(value)
             # Ensure atom positions are expressed in the new basis
             value.placeInLattice(Lattice(base=new_matrix))
@@ -154,7 +156,9 @@ class Phase:
                 value.title = self.name
             self._structure = value
         else:
-            raise ValueError(f"{value} must be a diffpy.structure.Structure object.")
+            raise ValueError(
+                f"{value} must be a diffpy.structure.Structure object."
+            )
 
     @property
     def name(self) -> str:
@@ -370,13 +374,10 @@ class Phase:
 
         Examples
         --------
-        >>> phase = Phase(
-            structure=Structure(
-                atoms = [Atom("Si", xyz=(0, 0, 1))],
-                lattice=Lattice(4.04, 4.04, 4.04, 90, 90, 90)
-            ),
-            space_group=227,
-        )
+        >>> atoms = [Atom("Si", xyz=(0, 0, 1))]
+        >>> lattice = Lattice(4.04, 4.04, 4.04, 90, 90, 90)
+        >>> structure = Structure(atoms = atoms,lattice=lattice)
+        >>> phase = Phase(structure=structure, space_group=227)
         >>> phase.structure
         [Si   0.000000 0.000000 1.000000 1.0000]
         >>> expanded = phase.expand_asymmetric_unit()
@@ -406,8 +407,9 @@ class Phase:
                 new_atom.xyz = pos
                 # Only add new atom if not already present
                 for present_atom in diffpy_structure:
-                    if present_atom.element == new_atom.element and np.allclose(
-                        present_atom.xyz, new_atom.xyz
+                    if (
+                        present_atom.element == new_atom.element
+                        and np.allclose(present_atom.xyz, new_atom.xyz)
                     ):
                         break
                 else:
@@ -505,10 +507,14 @@ class PhaseList:
 
     def __init__(
         self,
-        phases: Phase | list[Phase] | dict[int, Phase] | "PhaseList" | None = None,
+        phases: (
+            Phase | list[Phase] | dict[int, Phase] | "PhaseList" | None
+        ) = None,
         names: str | list[str] | None = None,
         space_groups: int | SpaceGroup | list[int | SpaceGroup] | None = None,
-        point_groups: str | int | Symmetry | list[str | int | Symmetry] | None = None,
+        point_groups: (
+            str | int | Symmetry | list[str | int | Symmetry] | None
+        ) = None,
         colors: str | list[str] | None = None,
         ids: int | list[int] | np.ndarray | None = None,
         structures: Structure | list[Structure] | None = None,
@@ -564,7 +570,13 @@ class PhaseList:
             max_entries = max(
                 [
                     len(i) if i is not None else 0
-                    for i in [names, space_groups, point_groups, ids, structures]
+                    for i in [
+                        names,
+                        space_groups,
+                        point_groups,
+                        ids,
+                        structures,
+                    ]
                 ]
             )
 
@@ -739,7 +751,9 @@ class PhaseList:
                     matching_phase_id = phase_id
                     break
             if matching_phase_id is None:
-                raise KeyError(f"{key} is not among the phase names {self.names}.")
+                raise KeyError(
+                    f"{key} is not among the phase names {self.names}."
+                )
             else:
                 self._dict.pop(matching_phase_id)
         else:
@@ -756,10 +770,13 @@ class PhaseList:
 
         # Ensure attributes set to None are treated OK
         names = ["None" if not i else i for i in self.names]
-        sg_names = ["None" if not i else i.short_name for i in self.space_groups]
+        sg_names = [
+            "None" if not i else i.short_name for i in self.space_groups
+        ]
         pg_names = ["None" if not i else i.name for i in self.point_groups]
         ppg_names = [
-            "None" if not i else i.proper_subgroup.name for i in self.point_groups
+            "None" if not i else i.proper_subgroup.name
+            for i in self.point_groups
         ]
 
         # Determine column widths (allowing PhaseList to be empty)
@@ -777,8 +794,12 @@ class PhaseList:
         representation = (
             "{:{align}{width}}  ".format("Id", width=id_len, align=align)
             + "{:{align}{width}}  ".format("Name", width=name_len, align=align)
-            + "{:{align}{width}}  ".format("Space group", width=sg_len, align=align)
-            + "{:{align}{width}}  ".format("Point group", width=pg_len, align=align)
+            + "{:{align}{width}}  ".format(
+                "Space group", width=sg_len, align=align
+            )
+            + "{:{align}{width}}  ".format(
+                "Point group", width=pg_len, align=align
+            )
             + "{:{align}{width}}  ".format(
                 "Proper point group", width=ppg_len, align=align
             )

--- a/orix/tests/test_vector3d.py
+++ b/orix/tests/test_vector3d.py
@@ -78,7 +78,11 @@ def test_neg(vector):
 @pytest.mark.parametrize(
     "vector, other, expected",
     [
-        ([1, 2, 3], Vector3d([[1, 2, 3], [-3, -2, -1]]), [[2, 4, 6], [-2, 0, 2]]),
+        (
+            [1, 2, 3],
+            Vector3d([[1, 2, 3], [-3, -2, -1]]),
+            [[2, 4, 6], [-2, 0, 2]],
+        ),
         ([1, 2, 3], [4], [5, 6, 7]),
         ([1, 2, 3], 0.5, [1.5, 2.5, 3.5]),
         ([1, 2, 3], [-1, 2], [[0, 1, 2], [3, 4, 5]]),
@@ -106,7 +110,11 @@ def test_add_raises(vector, other):
 @pytest.mark.parametrize(
     "vector, other, expected",
     [
-        ([1, 2, 3], Vector3d([[1, 2, 3], [-3, -2, -1]]), [[0, 0, 0], [4, 4, 4]]),
+        (
+            [1, 2, 3],
+            Vector3d([[1, 2, 3], [-3, -2, -1]]),
+            [[0, 0, 0], [4, 4, 4]],
+        ),
         ([1, 2, 3], [4], [-3, -2, -1]),
         ([1, 2, 3], 0.5, [0.5, 1.5, 2.5]),
         ([1, 2, 3], [-1, 2], [[2, 3, 4], [-1, 0, 1]]),
@@ -202,6 +210,23 @@ def test_div_raises(vector, other, error_type):
 def test_rdiv_raises():
     with pytest.raises(ValueError):
         _ = 1 / Vector3d.xvector()
+
+
+def test_eq():
+    v = Vector3d.zvector()
+    s1 = symmetry.D3
+    s2 = symmetry.C6
+    s3 = symmetry.O
+    # check element-wise comparison
+    assert np.all((v == s1.axis) == [True, True, False, False, False, False])
+    assert np.all((v == s2.axis) == [True, True, False, True, False, True])
+    # check that two lists compare per-row
+    assert np.all((s1.axis == s2.axis) == [1, 1, 1, 0, 0, 0])
+    # check incorrectly sized things compare as a flat falsse
+    assert not (s1 == s3)
+    # check that things that aren't vectors treat vector comparison as array
+    # comparison.
+    assert np.all((v == 1) == [0, 0, 1])
 
 
 def test_dot(vector, something):
@@ -608,7 +633,12 @@ class TestSphericalCoordinates:
         "v, polar_desired, azimuth_desired, radial_desired",
         [
             (Vector3d((0.5, 0.5, 0.707107)), np.pi / 4, np.pi / 4, 1),
-            (Vector3d((-0.75, -0.433013, -0.5)), 2 * np.pi / 3, 7 * np.pi / 6, 1),
+            (
+                Vector3d((-0.75, -0.433013, -0.5)),
+                2 * np.pi / 3,
+                7 * np.pi / 6,
+                1,
+            ),
         ],
     )
     def test_to_polar(self, v, polar_desired, azimuth_desired, radial_desired):
@@ -661,7 +691,14 @@ class TestGetCircle:
 
 class TestPlotting:
     v = Vector3d(
-        [[0, 0, 1], [1, 0, 1], [1, 1, 1], [0, 0, -1], [-1, 0, -1], [-1, -1, -1]]
+        [
+            [0, 0, 1],
+            [1, 0, 1],
+            [1, 1, 1],
+            [0, 0, -1],
+            [-1, 0, -1],
+            [-1, -1, -1],
+        ]
     )
 
     def test_scatter(self):
@@ -765,7 +802,10 @@ class TestPlotting:
 
         # Normal scatter: half of the vectors are shown
         fig1 = v.scatter(return_figure=True)
-        assert fig1.axes[0].collections[0].get_offsets().shape == (v.size // 2, 2)
+        assert fig1.axes[0].collections[0].get_offsets().shape == (
+            v.size // 2,
+            2,
+        )
 
         # Reproject: all of the vectors are shown
         fig2 = v.scatter(reproject=True, return_figure=True, c="r")

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -332,6 +332,15 @@ class Vector3d(Object3d):
     def __rtruediv__(self, other: Any):
         raise ValueError("Division by a vector is undefined")
 
+    def __eq__(self, other: Any):
+        if isinstance(other, Vector3d):
+            return np.all(self.data == other.data, axis=-1)
+        else:
+            return self.data == other
+
+    def __hash__(self):
+        return id(self)
+
     # ------------------------ Class methods ------------------------- #
 
     @classmethod
@@ -819,7 +828,9 @@ class Vector3d(Object3d):
         return v2
 
     def get_circle(
-        self, opening_angle: Union[float, np.ndarray] = np.pi / 2, steps: int = 100
+        self,
+        opening_angle: Union[float, np.ndarray] = np.pi / 2,
+        steps: int = 100,
     ) -> Vector3d:
         r"""Get vectors delineating great or small circle(s) with a
         given ``opening_angle`` about each vector.


### PR DESCRIPTION
#### Description of the change
Simple PR, allows vectors to be compared to each other element-wise.

#### Progress of the PR
- N/A  [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### Minimal example of the bug fix or new feature
```
from orix.quaternion import symmetry
from orix.vector import Vector3d

v = Vector3d.zvector()
s1 = symmetry.D3
s2 = symmetry.C6
s3 = symmetry.O
# check element-wise comparison
assert np.all((v == s1.axis) == [True, True, False, False, False, False])
assert np.all((v == s2.axis) == [True, True, False, True, False, True])
# check that two lists compare per-row
assert np.all((s1.axis == s2.axis) == [1, 1, 1, 0, 0, 0])
# check incorrectly sized things compare as a flat falsse
assert not (s1 == s3)
# check that things that aren't vectors treat vector comparison as array
# comparison.
assert np.all((v == 1) == [0, 0, 1])
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [x] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.