### PR TITLE
hotfix for matplotlib projections

### DIFF
--- a/orix/plot/__init__.py
+++ b/orix/plot/__init__.py
@@ -22,9 +22,19 @@
 :class:`~orix.quaternion.Orientation`,
 :class:`~orix.quaternion.Misorientation`, and
 :class:`~orix.crystal_map.CrystalMap`.
-"""
 
+NOTE: While lazy loading is preferred, the following six classes
+are explicitly imported in order to populate matplotlib.projections
+"""
 import lazy_loader
+
+from orix.plot.crystal_map_plot import CrystalMapPlot
+from orix.plot.rotation_plot import AxAnglePlot, RodriguesPlot, RotationPlot
+from orix.plot.stereographic_plot import StereographicPlot
+
+# Must be imported below StereographicPlot since it imports it
+from orix.plot.inverse_pole_figure_plot import InversePoleFigurePlot  # isort: skip
+
 
 # Imports from stub file (see contributor guide for details)
 __getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)

--- a/orix/plot/__init__.pyi
+++ b/orix/plot/__init__.pyi
@@ -30,15 +30,9 @@ from .inverse_pole_figure_plot import InversePoleFigurePlot  # isort: skip
 # Lazily imported in module init
 __all__ = [
     # Classes
-    "AxAnglePlot",
-    "CrystalMapPlot",
     "DirectionColorKeyTSL",
     "EulerColorKey",
-    "InversePoleFigurePlot",
     "IPFColorKeyTSL",
-    "RodriguesPlot",
-    "RotationPlot",
-    "StereographicPlot",
     # Functions
     "format_labels",
 ]


### PR DESCRIPTION
[This commit](https://github.com/pyxem/orix/commit/79350b0dd4526bbdf7891968e5d3bb600351e262) implemented lazy loading into the `orix.plotting` module, which had the unintended side effect that custom orix plotting projections are no longer registered in `matplotlib.projections`. This has broken a lot of workflows, but a concise example can be seen [in this example](https://github.com/pyxem/orix/blob/develop/examples/plotting/subplots.py)

This PR removes lazy loading for the 5 classes that define custom projections.

~~Personally, I think this is a good permanent fix. I'm down for using lazy loading where it makes sense, but having  `import orix.plot` register all the projections on loading is a great feature with minimal overhead. However, if there is disagreement (@hakonanes or @CSSFrancis, you've both had opinions on this in the past), I would ask we at least push this PR  as-is now to restore functionality, then discuss a better solution in the issues page.~~  As discussed in #585, I don't think this is the right long-term solution anymore. This is more just a short-term solution to restore functionality now while we decide how best to implement "lazy registration". 