### PR TITLE
Draw a Wulff net in the stereographic projection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Unreleased
 
 Added
 -----
+- Wulff nets can be added to stereographic plots and customized using
+  :meth:`~orix.plot.stereographic_plot.StereographicPlot.wulff_net()`.
 - Conversion of :class:`~orix.quaternion.Orientation`,
   :class:`~orix.quaternion.Misorientation`, :class:`~orix.quaternion.Rotation`, and
   :class:`~orix.quaternion.Quaternion` to :class:`scipy.spatial.transform.Rotation` via

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,22 +11,22 @@ Unreleased
 
 Added
 -----
-- Wulff nets can be added to stereographic plots and customized using
-  :meth:`~orix.plot.stereographic_plot.StereographicPlot.wulff_net()`.
+- A customizable Wulff net can be added to a stereographic plot using
+  :meth:`~orix.plot.StereographicPlot.wulff_net`.
 - Conversion of :class:`~orix.quaternion.Orientation`,
   :class:`~orix.quaternion.Misorientation`, :class:`~orix.quaternion.Rotation`, and
   :class:`~orix.quaternion.Quaternion` to :class:`scipy.spatial.transform.Rotation` via
-  :meth:`~orix.quaternion.Quaterion.to_scipy_rotation`.
+  :meth:`~orix.quaternion.Quaternion.to_scipy_rotation`.
 - Allow controlling whether to keep zero-vectors in
-  :meth:`orix.vector3d.Vector3d.unique` with a new ``ignore_zero`` parameter.
+  :meth:`~orix.vector.Vector3d.unique` with a new ``ignore_zero`` parameter.
   Previous behavior, to discard them, is still default.
 - If a :class:`~orix.crystal_map.Phase`, :class:`~orix.crystal_map.PhaseList`, or a
   :class:`~orix.crystal_map.CrystalMap` is passed to their own constructors, a copy is
   returned.
 - Added :meth:`~orix.crystal_map.Phase.expand_asymmetric_unit` to add all symmetrically
   equivalent atoms to the structure in a new phase.
-- Element-wise indexing into :class:`~orix.vector3d.Vector3d` and subclasses, such as
-  :class:`~orix.vector3d.Miller`.
+- Element-wise indexing into :class:`~orix.vector.Vector3d` and subclasses, such as
+  :class:`~orix.vector.Miller`.
 - Explicit support for Python 3.13.
 - Dependency on `lazy-loader`.
 
@@ -35,7 +35,7 @@ Changed
 - The \*.ang file reader accepts a boolean parameter ``autogen_names`` via
   :func:`~orix.io.load` that allows rewriting phase names in the returned crystal map
   based on elements and point groups, as opposed to automatically overwriting names.
-- Generation of random :class:`~orix.vector3d.Vector3d` and
+- Generation of random :class:`~orix.vector.Vector3d` and
   :class:`~orix.quaternion.Quaternion` (and its subclasses) via ``random()`` now uses a
   Gaussian method as opposed to rejection-based sampling.
   This is faster and uses less memory.

--- a/doc/dev/handling_deprecations.rst
+++ b/doc/dev/handling_deprecations.rst
@@ -8,13 +8,14 @@ Deprecation warnings are raised whenever possible and feasible for
 functions/methods/properties/arguments, so that users get a heads-up one (minor) release
 before something is removed or changes, with a possible alternative to be used.
 
-The decorator should be placed right above the object signature to be deprecated::
+The decorator should be placed right above the object signature to be deprecated:
 
 .. code-block:: python
 
     @deprecate(since=0.8, removal=0.9, alternative="bar")
     def foo(self, n):
         return n + 1
+
 
     @property
     @deprecate(since=0.9, removal=0.10, alternative="another", object_type="property")
@@ -26,7 +27,7 @@ Parameters can be deprecated as well:
 .. code-block:: python
 
     @deprecate_argument(name="n", since=0.8, removal=0.9, alternative="m")
-    def foo(self, n: int | None = None, m: int: int | None = None) -> int:
+    def foo(self, n: int | None = None, m: int | None = None) -> int:
         if m is None:
             m = n
         return m + 1

--- a/examples/stereographic_projection/wulff_net.py
+++ b/examples/stereographic_projection/wulff_net.py
@@ -21,50 +21,48 @@
 Wulff net
 =========
 
-Some examples for how a Wulff net can be added to any stereographic plot in
-ORIX.
+This example shows how to draw a customized Wulff net in stereographic plots using
+:meth:`~orix.plot.StereographicPlot.wulff_net`
 """
 
-import matplotlib.collections as mcollctions
 import matplotlib.pyplot as plt
-import numpy as np
 
-from orix.plot import StereographicPlot
-from orix.quaternion.symmetry import C6
-from orix.vector.vector3d import Vector3d
+from orix.plot import InversePoleFigurePlot, StereographicPlot
+from orix.quaternion.symmetry import C6h
 
-fig, ax = plt.subplots(
-    figsize=[6, 4], nrows=1, ncols=2, subplot_kw=dict(projection="stereographic")
-)
+########################################################################################
+# Plot two stereographic projections, one with the standard Wulff net, another with a
+# customized net
 
-# display a standard Wulff net with 2 degree minor markers and 10 degree
+fig = plt.figure(figsize=(6, 4), layout="tight")
+ax0 = fig.add_subplot(121, projection="stereographic")
+ax1 = fig.add_subplot(122, projection="stereographic")
+
+# Display a standard Wulff net with 2 degree minor markers and 10 degree
 # major markers, with 10 degree caps at the tops and bottoms.
-ax[0].wulff_net()
+ax0.set_title("Standard Wulff net")
+ax0.wulff_net()
 
-# The grid spacing can also be changed or turned on and off, similar to ax.grid
-# in matplotlib. Here, the latitudinal grid is set to 3 degrees (15 degrees for
-# major grid lines), and the longitudinal to 9 degrees (45 degrees for major grid
-# lines)
+# The grid spacing can also be changed or turned on and off, similar to
+# matplotlib.axes.Axes.grid(). Here, the latitudinal grid is set to 3
+# degrees (15 degrees for major grid lines), and the longitudinal to 9
+# degrees (45 degrees for major grid lines).
+ax1.set_title("Custom Wulff net")
+ax1.wulff_net(True, 3, 9, 15, 45, 15)
 
-ax[1].wulff_net(True, 3, 9, 15, 45, 15)
 # Turn it off
-ax[0].wulff_net()
-# Then turn it back on, with the previously defined grid spacing saved.
-ax[0].wulff_net()
-ax[0].set_title("Standard")
-ax[1].set_title("Custom")
-plt.tight_layout()
+ax1.wulff_net()
 
-# This also works for subsections, such as fundamental sectors.
-fig = plt.figure()
-ax = fig.add_subplot(projection="stereographic")
-ax.restrict_to_sector(C6.fundamental_sector)
+# Then turn it back on, with the previously defined grid spacing saved.
+ax1.wulff_net()
+
+########################################################################################
+# The net also displays nicely for inverse pole figures (stereographic projections
+# restricted to a fundamental sector)
+fig = plt.figure(layout="tight")
+ax = fig.add_subplot(projection="ipf", symmetry=C6h)
+
 ax.wulff_net()
-# Add some manual labels. the XY coordinates can be set by using either a single
-# vector, or a polar-azimuth pair. Both methods are showb below for a 6-fold
-# crystal.
-ax.text(Vector3d([0, 0, 1]), s="[001]", offset=[0, -0.04], c="r")
-ax.text(Vector3d([1, 0, 0]).unit, s="[100]", offset=[0, -0.04], c="g")
-ax.text(np.pi / 3, np.pi / 2, s="[010]", offset=[-0, 0], c="b")
-ax.set_title("C6 symmetry\n\n")
-plt.tight_layout()
+ax.set_title(f"{C6h.name} inverse pole figure", pad=30)
+
+plt.show()

--- a/examples/stereographic_projection/wulff_net.py
+++ b/examples/stereographic_projection/wulff_net.py
@@ -21,40 +21,50 @@
 Wulff net
 =========
 
-This example shows how to draw a Wulff net in the stereographic projection with great
-and small circles.
+Some examples for how a Wulff net can be added to any stereographic plot in
+ORIX.
 """
 
+import matplotlib.collections as mcollctions
 import matplotlib.pyplot as plt
 import numpy as np
 
-from orix import plot
-from orix.vector import Vector3d
-
-n = int(90 / 2)  # Degree / net resolution
-steps = 500
-kwargs = dict(linewidth=0.25, color="k")
-
-polar = np.linspace(0, 0.5 * np.pi, num=n)
-v_right = Vector3d.from_polar(azimuth=np.zeros(n), polar=polar)
-v_left = Vector3d.from_polar(azimuth=np.ones(n) * np.pi, polar=polar)
-v010 = Vector3d.zero(shape=(n,))
-v010.y = 1
-v010_opposite = -v010
+from orix.plot import StereographicPlot
+from orix.quaternion.symmetry import C6
+from orix.vector.vector3d import Vector3d
 
 fig, ax = plt.subplots(
-    figsize=(5, 5), subplot_kw=dict(projection="stereographic"), layout="tight"
+    figsize=[6, 4], nrows=1, ncols=2, subplot_kw=dict(projection="stereographic")
 )
-ax.stereographic_grid(False)
-ax.draw_circle(v_right, steps=steps, **kwargs)
-ax.draw_circle(v_left, steps=steps, **kwargs)
-ax.draw_circle(v010, opening_angle=polar, steps=steps, **kwargs)
-ax.draw_circle(v010_opposite, opening_angle=polar, steps=steps, **kwargs)
-for label, azimuth, va, ha, offset in zip(
-    ["B", "M''", "A", "M'"],
-    np.array([0, 0.5, 1, 1.5]) * np.pi,
-    ["center", "bottom", "center", "top"],
-    ["left", "center", "right", "center"],
-    [(0.02, 0), (0, 0.02), (-0.02, 0), (0, -0.02)],
-):
-    ax.text(azimuth, 0.5 * np.pi, s=label, offset=offset, c="r", va=va, ha=ha)
+
+# display a standard Wulff net with 2 degree minor markers and 10 degree
+# major markers, with 10 degree caps at the tops and bottoms.
+ax[0].wulff_net()
+
+# The grid spacing can also be changed or turned on and off, similar to ax.grid
+# in matplotlib. Here, the latitudinal grid is set to 3 degrees (15 degrees for
+# major grid lines), and the longitudinal to 9 degrees (45 degrees for major grid
+# lines)
+
+ax[1].wulff_net(True, 3, 9, 15, 45, 15)
+# Turn it off
+ax[0].wulff_net()
+# Then turn it back on, with the previously defined grid spacing saved.
+ax[0].wulff_net()
+ax[0].set_title("Standard")
+ax[1].set_title("Custom")
+plt.tight_layout()
+
+# This also works for subsections, such as fundamental sectors.
+fig = plt.figure()
+ax = fig.add_subplot(projection="stereographic")
+ax.restrict_to_sector(C6.fundamental_sector)
+ax.wulff_net()
+# Add some manual labels. the XY coordinates can be set by using either a single
+# vector, or a polar-azimuth pair. Both methods are showb below for a 6-fold
+# crystal.
+ax.text(Vector3d([0, 0, 1]), s="[001]", offset=[0, -0.04], c="r")
+ax.text(Vector3d([1, 0, 0]).unit, s="[100]", offset=[0, -0.04], c="g")
+ax.text(np.pi / 3, np.pi / 2, s="[010]", offset=[-0, 0], c="b")
+ax.set_title("C6 symmetry\n\n")
+plt.tight_layout()

--- a/orix/plot/inverse_pole_figure_plot.py
+++ b/orix/plot/inverse_pole_figure_plot.py
@@ -27,7 +27,7 @@ from typing import Any
 
 import matplotlib.axes as maxes
 from matplotlib.figure import Figure
-from matplotlib.patches import PathPatch
+import matplotlib.patches as mpatches
 import matplotlib.projections as mprojections
 import matplotlib.pyplot as plt
 import numpy as np
@@ -97,10 +97,14 @@ class InversePoleFigurePlot(StereographicPlot):
         self._add_crystal_direction_labels()
 
     @property
-    def _edge_patch(self) -> PathPatch:
+    def _edge_patch(self) -> mpatches.Patch:
         """Easy access to the fundamental sector border patch."""
         patches = self.patches
-        return patches[self._has_collection(label="sa_sector", collections=patches)[1]]
+        return patches[
+            self._has_collection(label=self._get_label("sector"), collections=patches)[
+                1
+            ]
+        ]
 
     def pole_density_function(
         self,

--- a/orix/plot/stereographic_plot.py
+++ b/orix/plot/stereographic_plot.py
@@ -624,7 +624,7 @@ class StereographicPlot(maxes.Axes):
             or show_grid is None
             and (azimuth_resolution is not None or polar_resolution is not None)
             or show_grid is True
-        ) and hasattr(self, "patch"):
+        ):
             self._azimuth_grid(azimuth_resolution)
             self._polar_grid(polar_resolution)
             self._stereographic_grid = True
@@ -702,7 +702,7 @@ class StereographicPlot(maxes.Axes):
             or show_grid is None
             and (lat_resolution is not None or long_resolution is not None)
             or show_grid is True
-        ) and hasattr(self, "patch"):
+        ):
             # if so, plot them
             self._lat_grid(lat_resolution, lat_resolution_major, linewidth_ratio)
             self._long_grid(

--- a/orix/plot/stereographic_plot.py
+++ b/orix/plot/stereographic_plot.py
@@ -898,18 +898,20 @@ class StereographicPlot(maxes.Axes):
             self._wulff_net_linewidth_ratio
         )
 
-        def res2latlines(res):
+        def res2latlines(res, rotation_pole):
             bottom = np.arange(-res, -90, -res)[::-1]
             top = np.arange(0, 90, res)
             ticks = np.hstack([bottom, top])
             v_lats = Vector3d.xvector().rotate(angle=np.radians(ticks))
             lat_deltas = np.linspace(0, np.pi, 100, True)
-            v_lines = [v.rotate([0, -1, 0], lat_deltas) for v in v_lats]
+            v_lines = [v.rotate(rotation_pole, lat_deltas) for v in v_lats]
             xy_lines = [np.stack(self._projection.vector2xy(x)).T for x in v_lines]
             return xy_lines
 
+        rotation_pole = [0, self.pole, 0]
+
         lc_minor = mcollections.LineCollection(
-            res2latlines(self._lat_resolution),
+            res2latlines(self._lat_resolution, rotation_pole),
             label=self._get_label("latitudinal_grid"),
             **kwargs_minor,
         )
@@ -917,7 +919,7 @@ class StereographicPlot(maxes.Axes):
         lc_major: None | mcollections.LineCollection = None
         if self._lat_resolution_major > 0:
             lc_major = mcollections.LineCollection(
-                res2latlines(self._lat_resolution_major),
+                res2latlines(self._lat_resolution_major, rotation_pole),
                 label=self._get_label("latitudinal_grid_major"),
                 **kwargs_major,
             )
@@ -982,11 +984,11 @@ class StereographicPlot(maxes.Axes):
             self._wulff_net_linewidth_ratio
         )
 
-        def res2llonglines(res, cap):
+        def res2llonglines(res, cap, rotation_pole):
             left = np.arange(90, 0 - res, -res)[::-1]
             right = np.arange(90 + res, 180 + res, res)
             ticks = np.hstack([left, right])
-            v_longs = Vector3d.xvector().rotate([0, 1, 0], np.radians(-ticks))
+            v_longs = Vector3d.xvector().rotate(rotation_pole, np.radians(-ticks))
             long_deltas = np.radians(np.linspace(90 - cap, -90 + cap, 100, True))
             v_lines = [
                 v.rotate(v.rotate([0, 1, 0], np.pi / 2), long_deltas) for v in v_longs
@@ -994,8 +996,9 @@ class StereographicPlot(maxes.Axes):
             xy_lines = [np.stack(self._projection.vector2xy(x)).T for x in v_lines]
             return xy_lines
 
+        rotation_pole = [0, -self.pole, 0]
         lc_minor = mcollections.LineCollection(
-            res2llonglines(self._long_resolution, self._wulff_net_cap),
+            res2llonglines(self._long_resolution, self._wulff_net_cap, rotation_pole),
             label=self._get_label("longitudinal_grid"),
             **kwargs_minor,
         )
@@ -1003,7 +1006,9 @@ class StereographicPlot(maxes.Axes):
         lc_major: None | mcollections.LineCollection = None
         if self._long_resolution_major > 0:
             lc_major = mcollections.LineCollection(
-                res2llonglines(self._long_resolution_major, self._wulff_net_cap),
+                res2llonglines(
+                    self._long_resolution_major, self._wulff_net_cap, rotation_pole
+                ),
                 label=self._get_label("longitudinal_grid_major"),
                 **kwargs_major,
             )

--- a/orix/plot/stereographic_plot.py
+++ b/orix/plot/stereographic_plot.py
@@ -654,48 +654,47 @@ class StereographicPlot(maxes.Axes):
         wulff_net_cap: float | int | None = None,
         linewidth_ratio: float | int = 2,
     ) -> None:
-        """Turn a wulff net grid on or off, and set spacing in degrees
-        for the major and minor axes.
+        """Turn a wulff net grid on or off, and set the grid resolution
+        in degrees.
 
         Parameters
         ----------
         show_grid
             Whether to show grid lines. If any keyword arguments are
-            passed, this is set to ``True``. If not given and there are
-            no keyword arguments, the grid lines are toggled.
+            passed, this is set to True. If not given and there are no
+            keyword arguments, the grid lines are toggled.
         lat_resolution
-            latitudinal (up and down) grid spacing in degrees.
-            This can also be set upon initialization of the axes by
-            passing ``lat_resolution`` to ``subplot_kw``. If none is given,
-            it will use the most recently stored value (2 degrees by default)
+            Latitudinal (up and down) grid spacing in degrees. This can
+            also be set upon initialization of the axes by passing
+            *lat_resolution* to *subplot_kw*. If not given, the
+            current resolution is used (2 degrees by default).
         long_resolution
-            longitudinal (left and right) grid spacing in degrees.
-            This can also be set upon initialization of the axes by
-            passing ``long_resolution`` to ``subplot_kw``. If none is given,
-            it will use the most recently stored value (2 degrees by default)
+            Longitudinal (left and right) grid spacing in degrees. This
+            can also be set upon initialization of the axes by passing
+            *long_resolution* to *subplot_kw*. If not given, the
+            current resolution is used (2 degrees by default).
         lat_resolution_major
-            Identical to lat_resolution, but for the major grid lines
-            (10 degree increments by default).
+            Identical to *lat_resolution*, but for the major grid lines
+            (10 degrees resolution by default).
         long_resolution_major
-            Identical to long_resolution, but for the major grid lines
-            (10 degree increments by default).
+            Identical to *long_resolution*, but for the major grid lines
+            (10 degrees resolution by default).
         wulff_net_cap
-            The angular spread of the cap around the north and south poles
-            of the plot in degrees, within which longitudinal lines are
-            not drawn. If None, the most recently stored value will be used
-            (10 degrees by default)
+            The angular spread of the cap around the north and south
+            poles of the plot in degrees, within which longitudinal
+            lines are not drawn. If not given, the current resolution is
+            used (10 degrees by default).
         linewidth_ratio
-            ratio between the thickness of the major and minor grid lines.
-            Minor grid line properties are determined by the
-            ``grid.linewidth`` parameter in matplotlib.rcParams, the same
-            way ``matplotlib.axes.Axes.grid`` objects are.
+            Ratio between the thickness of the major and minor grid
+            lines. Minor grid line properties are determined by the
+            "grid.linewidth" parameter in Matplotlib's rcParams, the
+            same way :meth:`matplotlib.axes.Axes.grid` objects are.
             Major grid lines are then set relative to the minor values.
 
         See Also
         --------
         matplotlib.axes.Axes.grid
         """
-        # check for three cases where a new grid should be plotted
         if (
             show_grid is None
             and self._wulff_net_grid in [None, False]
@@ -703,7 +702,6 @@ class StereographicPlot(maxes.Axes):
             and (lat_resolution is not None or long_resolution is not None)
             or show_grid is True
         ):
-            # if so, plot them
             self._latitudinal_grid(
                 lat_resolution, lat_resolution_major, linewidth_ratio
             )
@@ -712,7 +710,6 @@ class StereographicPlot(maxes.Axes):
             )
             self._wulff_net_grid = True
         elif show_grid in [None, False] and self._wulff_net_grid is True:
-            # Remove grid
             for query in [
                 "sa_lat_grid",
                 "sa_lat_grid_major",

--- a/orix/plot/stereographic_plot.py
+++ b/orix/plot/stereographic_plot.py
@@ -89,27 +89,23 @@ class StereographicPlot(maxes.Axes):
         hemisphere: str = "upper",
         azimuth_resolution: int | float = 10,
         polar_resolution: int | float = 10,
-        lat_resolution: int | float = 2,
-        long_resolution: int | float = 2,
-        lat_resolution_major: int | float = 10,
-        long_resolution_major: int | float = 10,
-        wulff_net_cap: int | float = 10,
         **kwargs,
     ) -> None:
         """Create an axis for plotting :class:`~orix.vector.Vector3d`."""
         self.hemisphere = hemisphere
-        self._azimuth_resolution = azimuth_resolution
-        self._polar_resolution = polar_resolution
-        self._lat_resolution = lat_resolution
-        self._long_resolution = long_resolution
-        self._lat_resolution_major = lat_resolution_major
-        self._long_resolution_major = long_resolution_major
-        self._wulff_net_cap = wulff_net_cap
-        self._wulff_net_linewidth_ratio = 2
 
-        # Custom attribute to keep track of whether grids are on or off
+        # Custom attributes to keep track of whether grids are on or off,
+        # as well as the spacings to use when drawing them.
         self._stereographic_grid = None
         self._wulff_net_grid = None
+        self._azimuth_resolution = azimuth_resolution
+        self._polar_resolution = polar_resolution
+        self._lat_resolution = 2
+        self._long_resolution = 2
+        self._lat_resolution_major = 10
+        self._long_resolution_major = 10
+        self._wulff_net_cap = 10
+        self._wulff_net_linewidth_ratio = 2
 
         super().__init__(*args, **kwargs)
 
@@ -664,15 +660,12 @@ class StereographicPlot(maxes.Axes):
             passed, this is set to True. If not given and there are no
             keyword arguments, the grid lines are toggled.
         lat_resolution
-            Latitudinal (up and down) grid spacing in degrees. This can
-            also be set upon initialization of the axes by passing
-            *lat_resolution* to *subplot_kw*. If not given, the
-            current resolution is used (2 degrees by default).
+            Latitudinal (up and down) grid spacing in degrees.If not
+            given, the current resolution is used (2 degrees by default).
         long_resolution
-            Longitudinal (left and right) grid spacing in degrees. This
-            can also be set upon initialization of the axes by passing
-            *long_resolution* to *subplot_kw*. If not given, the
-            current resolution is used (2 degrees by default).
+            Longitudinal (left and right) grid spacing in degrees. If
+            not given, the current resolution is used (2 degrees by
+            default).
         lat_resolution_major
             Identical to *lat_resolution*, but for the major grid lines
             (10 degrees resolution by default).
@@ -875,14 +868,10 @@ class StereographicPlot(maxes.Axes):
         Parameters
         ----------
         lat_resolution
-            Minor latitudinal grid resolution in degrees. This can also
-            be set upon initialization of the axes by passing
-            *lat_resolution* to *subplot_kw*.
+            Minor latitudinal grid resolution in degrees.
         lat_resolution_major
-            Major latitudinal grid resolution in degrees. This can also
-            be set upon initialization of the axes by passing
-            *lat_resolution_major* to *subplot_kw*. If 0, no major grid
-            lines will be added.
+            Major latitudinal grid resolution in degrees. If 0, no
+            major grid lines will be added.
         linewidth_ratio
             Ratio between the thickness of the major and minor grid
             lines.
@@ -961,13 +950,10 @@ class StereographicPlot(maxes.Axes):
         Parameters
         ----------
         long_resolution
-            Minor longitudinal grid resolution in degrees. This can also
-            be set upon initialization of the axes by passing
-            *long_resolution* to *subplot_kw*.
+            Minor longitudinal grid resolution in degrees.
         long_resolution_major
-            Major longitudinal grid resolution in degrees. This can also
-            be set upon initialization of the axes by passing
-            *long_resolution_major* to *subplot_kw*.
+            Major longitudinal grid resolution in degrees. If 0, no
+            major grid lines will be added.
         linewidth_ratio
             Ratio between the thickness of the major and minor grid
             lines.

--- a/orix/plot/stereographic_plot.py
+++ b/orix/plot/stereographic_plot.py
@@ -105,6 +105,7 @@ class StereographicPlot(maxes.Axes):
         self._lat_resolution_major = lat_resolution_major
         self._long_resolution_major = long_resolution_major
         self._wulff_net_cap = wulff_net_cap
+        self._wulff_net_linewidth_ratio = 2
 
         # Custom attribute to keep track of whether grids are on or off
         self._stereographic_grid = None
@@ -651,7 +652,7 @@ class StereographicPlot(maxes.Axes):
         lat_resolution_major: float | None = None,
         long_resolution_major: float | None = None,
         wulff_net_cap: float | None = None,
-        linewidth_ratio: bool = True,
+        linewidth_ratio: float | int = 2,
     ):
         """Turn a wulff net grid on or off, and set spacing in degrees
         for the major and minor axes.
@@ -863,7 +864,7 @@ class StereographicPlot(maxes.Axes):
         self,
         lat_resolution: float | int | None = None,
         lat_resolution_major: float | int | None = None,
-        lat_major_minor_ratio: float | int = 2,
+        linewidth_ratio: float | int = 2,
     ):
         """Set the major and minor latitudinal grids. Intended to be called
         as part of ``StereographicPlot.wulff_net()``
@@ -874,14 +875,12 @@ class StereographicPlot(maxes.Axes):
             minor latitudinal grid resolution in degrees.
             This can also be set upon initialization of the axes by
             passing ``lat_resolution`` to ``subplot_kw``.
-
         lat_resolution_major
             major latitudinal grid resolution in degrees.
             This can also be set upon initialization of the axes by
             passing ``lat_resolution_major`` to ``subplot_kw``.
             If 0, no major grid lines will be added.
-
-        lat_major_minor_ratio
+        linewidth_ratio
             ratio between the thickness of the major and minor grid lines.
 
         """
@@ -892,6 +891,8 @@ class StereographicPlot(maxes.Axes):
             self._lat_resolution = lat_resolution
         if lat_resolution_major is not None:
             self._lat_resolution_major = lat_resolution_major
+        if linewidth_ratio is not None:
+            self._wulff_net_linewidth_ratio = linewidth_ratio
 
         # remove previous lat grids if they exist
         exists, index = self._has_collection("sa_lat_grid_major", self.collections)
@@ -913,7 +914,9 @@ class StereographicPlot(maxes.Axes):
         )
         kwargs_major = dict()
         kwargs_major.update(kwargs)
-        kwargs_major["linewidth"] = kwargs["linewidth"] * 2
+        kwargs_major["linewidth"] = (
+            kwargs["linewidth"] * self._wulff_net_linewidth_ratio
+        )
 
         def res2latlines(res):
             bottom = np.arange(-res, -90, -res)[::-1]
@@ -951,7 +954,7 @@ class StereographicPlot(maxes.Axes):
         self,
         long_resolution: float | int | None = None,
         long_resolution_major: float | int | None = None,
-        long_major_minor_ratio: float | int = 2,
+        linewidth_ratio: float | int = 2,
         wulff_net_cap: float | None = None,
     ):
         """Set the major and minor longitudinal grids. Intended to be called
@@ -963,13 +966,11 @@ class StereographicPlot(maxes.Axes):
             minor longitudinal grid resolution in degrees.
             This can also be set upon initialization of the axes by
             passing ``laong_resolution`` to ``subplot_kw``.
-
         long_resolution_major
             major longitudinal grid resolution in degrees.
             This can also be set upon initialization of the axes by
             passing ``long_resolution_major`` to ``subplot_kw``.
-
-        long_major_minor_ratio
+        linewidth_ratio
             ratio between the thickness of the major and minor grid lines.
 
         """
@@ -980,6 +981,8 @@ class StereographicPlot(maxes.Axes):
             self._long_resolution = long_resolution
         if long_resolution_major is not None:
             self._long_resolution_major = long_resolution_major
+        if linewidth_ratio is not None:
+            self._wulff_net_linewidth_ratio = linewidth_ratio
         if wulff_net_cap is not None:
             self._wulff_net_cap = wulff_net_cap
 
@@ -1003,7 +1006,9 @@ class StereographicPlot(maxes.Axes):
         )
         kwargs_major = dict()
         kwargs_major.update(kwargs)
-        kwargs_major["linewidth"] = kwargs["linewidth"] * 2
+        kwargs_major["linewidth"] = (
+            kwargs["linewidth"] * self._wulff_net_linewidth_ratio
+        )
 
         def res2llonglines(res, cap):
             left = np.arange(90, 0 - res, -res)[::-1]

--- a/orix/plot/stereographic_plot.py
+++ b/orix/plot/stereographic_plot.py
@@ -91,8 +91,8 @@ class StereographicPlot(maxes.Axes):
         polar_resolution: int | float = 10,
         lat_resolution: int | float = 2,
         long_resolution: int | float = 2,
-        lat_resolution_major: int | float | None = 10,
-        long_resolution_major: int | float | None = 10,
+        lat_resolution_major: int | float = 10,
+        long_resolution_major: int | float = 10,
         wulff_net_cap: int | float = 10,
         **kwargs,
     ) -> None:
@@ -647,13 +647,13 @@ class StereographicPlot(maxes.Axes):
     def wulff_net(
         self,
         show_grid: bool | None = None,
-        lat_resolution: float = None,
-        long_resolution: float = None,
-        lat_resolution_major: float | None = None,
-        long_resolution_major: float | None = None,
-        wulff_net_cap: float | None = None,
+        lat_resolution: float | int | None = None,
+        long_resolution: float | int | None = None,
+        lat_resolution_major: float | int | None = None,
+        long_resolution_major: float | int | None = None,
+        wulff_net_cap: float | int | None = None,
         linewidth_ratio: float | int = 2,
-    ):
+    ) -> None:
         """Turn a wulff net grid on or off, and set spacing in degrees
         for the major and minor axes.
 
@@ -865,24 +865,25 @@ class StereographicPlot(maxes.Axes):
         lat_resolution: float | int | None = None,
         lat_resolution_major: float | int | None = None,
         linewidth_ratio: float | int = 2,
-    ):
-        """Set the major and minor latitudinal grids. Intended to be called
-        as part of ``StereographicPlot.wulff_net()``
+    ) -> None:
+        """Set the major and minor latitudinal grids.
+
+        Intended to be called by :meth:`wulff_net`.
 
         Parameters
         ----------
         lat_resolution
-            minor latitudinal grid resolution in degrees.
-            This can also be set upon initialization of the axes by
-            passing ``lat_resolution`` to ``subplot_kw``.
+            Minor latitudinal grid resolution in degrees. This can also
+            be set upon initialization of the axes by passing
+            *lat_resolution* to *subplot_kw*.
         lat_resolution_major
-            major latitudinal grid resolution in degrees.
-            This can also be set upon initialization of the axes by
-            passing ``lat_resolution_major`` to ``subplot_kw``.
-            If 0, no major grid lines will be added.
+            Major latitudinal grid resolution in degrees. This can also
+            be set upon initialization of the axes by passing
+            *lat_resolution_major* to *subplot_kw*. If 0, no major grid
+            lines will be added.
         linewidth_ratio
-            ratio between the thickness of the major and minor grid lines.
-
+            Ratio between the thickness of the major and minor grid
+            lines.
         """
         # overwrite defaults, which essentially saves the values so future calls
         # of "self.wulff_net() turn the newly defined grid on and off, instead of
@@ -956,23 +957,24 @@ class StereographicPlot(maxes.Axes):
         long_resolution_major: float | int | None = None,
         linewidth_ratio: float | int = 2,
         wulff_net_cap: float | None = None,
-    ):
-        """Set the major and minor longitudinal grids. Intended to be called
-        as part of ``StereographicPlot.wulff_net()``
+    ) -> None:
+        """Set the major and minor longitudinal grids.
+
+        Intended to be called by :meth:`wulff_net`.
 
         Parameters
         ----------
         long_resolution
-            minor longitudinal grid resolution in degrees.
-            This can also be set upon initialization of the axes by
-            passing ``laong_resolution`` to ``subplot_kw``.
+            Minor longitudinal grid resolution in degrees. This can also
+            be set upon initialization of the axes by passing
+            *long_resolution* to *subplot_kw*.
         long_resolution_major
-            major longitudinal grid resolution in degrees.
-            This can also be set upon initialization of the axes by
-            passing ``long_resolution_major`` to ``subplot_kw``.
+            Major longitudinal grid resolution in degrees. This can also
+            be set upon initialization of the axes by passing
+            *long_resolution_major* to *subplot_kw*.
         linewidth_ratio
-            ratio between the thickness of the major and minor grid lines.
-
+            Ratio between the thickness of the major and minor grid
+            lines.
         """
         # overwrite defaults, which essentially saves the values so future calls
         # of "self.wolf_net() turn the newly defined grid on and off, instead of

--- a/orix/plot/stereographic_plot.py
+++ b/orix/plot/stereographic_plot.py
@@ -704,8 +704,10 @@ class StereographicPlot(maxes.Axes):
             or show_grid is True
         ):
             # if so, plot them
-            self._lat_grid(lat_resolution, lat_resolution_major, linewidth_ratio)
-            self._long_grid(
+            self._latitudinal_grid(
+                lat_resolution, lat_resolution_major, linewidth_ratio
+            )
+            self._longitudinal_grid(
                 long_resolution, long_resolution_major, linewidth_ratio, wulff_net_cap
             )
             self._wulff_net_grid = True
@@ -755,9 +757,8 @@ class StereographicPlot(maxes.Axes):
         # TODO: Find a way to control padding, so that markers aren't
         #  clipped
 
-    # =============================================== #
-    #      Internal functions for creating grids      #
-    # =============================================== #
+    # ----------- Internal functions for controlling grids ----------- #
+
     def _azimuth_grid(self, resolution: float | None = None) -> None:
         """Set the azimuth grid resolution in degrees.
 
@@ -860,7 +861,7 @@ class StereographicPlot(maxes.Axes):
             circles_collection.set_clip_path(self.patches[sector_index])
         self.add_collection(circles_collection)
 
-    def _lat_grid(
+    def _latitudinal_grid(
         self,
         lat_resolution: float | int | None = None,
         lat_resolution_major: float | int | None = None,
@@ -951,7 +952,7 @@ class StereographicPlot(maxes.Axes):
         if self._lat_resolution_major > 0:
             self.add_collection(lc_major)
 
-    def _long_grid(
+    def _longitudinal_grid(
         self,
         long_resolution: float | int | None = None,
         long_resolution_major: float | int | None = None,
@@ -1048,9 +1049,7 @@ class StereographicPlot(maxes.Axes):
         if self._long_resolution_major > 0:
             self.add_collection(lc_major)
 
-    # =============================================== #
-    #            Other Internal functions             #
-    # =============================================== #
+    # -------------------- Other internal methods -------------------- #
 
     @staticmethod
     def _has_collection(label, collections):

--- a/orix/tests/test_plot/test_stereographic_plot.py
+++ b/orix/tests/test_plot/test_stereographic_plot.py
@@ -107,7 +107,7 @@ class TestStereographicPlot:
 
         plt.close("all")
 
-    def test_grids(self):
+    def test_stereo_grids(self):
         azimuth_res = 10
         polar_res = 15
         _, ax = plt.subplots(
@@ -133,6 +133,42 @@ class TestStereographicPlot:
         assert len(ax.collections) == 2
         assert all([coll.get_alpha() for coll in ax.collections])
 
+        plt.close("all")
+
+    def test_wulff_grids(self):
+        lat_res = 11
+        long_res = 3.431
+        _, ax = plt.subplots(
+            subplot_kw=dict(
+                projection=PROJ_NAME,
+                lat_resolution=lat_res,
+                long_resolution=long_res,
+            )
+        )
+        assert ax._lat_resolution == lat_res
+        assert ax._long_resolution == long_res
+
+        ax.wulff_net()
+        assert ax._lat_resolution == lat_res
+        assert ax._long_resolution == long_res
+
+        alpha = 0.5
+        with plt.rc_context({"grid.alpha": alpha}):
+            ax.wulff_net(lat_resolution=1, long_resolution=3, wulff_net_cap=11)
+        assert ax._azimuth_resolution == 10
+        assert ax._polar_resolution == 10
+        assert ax._lat_resolution == 1
+        assert ax._long_resolution == 3
+        assert ax._wulff_net_cap == 11
+
+        assert len(ax.collections) == 6
+        ax.stereographic_grid()
+        assert all([coll.get_alpha() for coll in ax.collections])
+        assert len(ax.collections) == 4
+        ax.wulff_net()
+        assert len(ax.collections) == 0
+        ax.wulff_net(long_resolution_major=0, lat_resolution_major=0)
+        assert len(ax.collections) == 2
         plt.close("all")
 
     def test_set_labels(self):
@@ -513,6 +549,8 @@ class TestRestrictToFundamentalSector:
         assert ax3[0].patches[1].get_label() == "sa_sector"
 
         # Ensure grid lines are clipped by sector
+        ax3[0].wulff_net(True)
+        ax3[0].wulff_net(False)
         ax3[0].stereographic_grid(False)
         ax3[0].stereographic_grid(True)
 

--- a/orix/tests/test_plot/test_stereographic_plot.py
+++ b/orix/tests/test_plot/test_stereographic_plot.py
@@ -546,7 +546,7 @@ class TestRestrictToFundamentalSector:
         _, ax3 = plt.subplots(ncols=2, subplot_kw=dict(projection=PROJ_NAME))
         ax3[0].restrict_to_sector(symmetry.C6.fundamental_sector)
         assert not np.allclose(vertices[:10], ax3[0].patches[0].get_verts()[:10])
-        assert ax3[0].patches[1].get_label() == "sa_sector"
+        assert ax3[0].patches[1].get_label() == "_stereographic_sector"
 
         # Ensure grid lines are clipped by sector
         ax3[0].wulff_net(True)
@@ -561,14 +561,14 @@ class TestRestrictToFundamentalSector:
         ax4.restrict_to_sector(fs)
         upper_patches4 = ax4.patches
         assert len(upper_patches4) == 2
-        assert upper_patches4[1].get_label() == "sa_sector"
+        assert upper_patches4[1].get_label() == "_stereographic_sector"
 
         _, ax5 = plt.subplots(subplot_kw=dict(projection=PROJ_NAME))
         ax5.hemisphere = "lower"
         ax5.restrict_to_sector(fs)
         lower_patches4 = ax5.patches
         assert len(lower_patches4) == 1
-        assert lower_patches4[0].get_label() == "sa_circle"
+        assert lower_patches4[0].get_label() == "_stereographic_border"
         assert np.allclose(vertices, lower_patches4[0].get_verts())
 
         # No lines are added to lower hemisphere, only the upper
@@ -611,7 +611,7 @@ class TestRestrictToFundamentalSector:
 
         ax.restrict_to_sector(symmetry.Oh.fundamental_sector, show_edges=False)
         assert len(ax.patches) == 1
-        assert ax.patches[0].get_label() == "sa_circle"
+        assert ax.patches[0].get_label() == "_stereographic_border"
 
         plt.close("all")
 

--- a/orix/tests/test_plot/test_stereographic_plot.py
+++ b/orix/tests/test_plot/test_stereographic_plot.py
@@ -141,14 +141,10 @@ class TestStereographicPlot:
         _, ax = plt.subplots(
             subplot_kw=dict(
                 projection=PROJ_NAME,
-                lat_resolution=lat_res,
-                long_resolution=long_res,
             )
         )
-        assert ax._lat_resolution == lat_res
-        assert ax._long_resolution == long_res
 
-        ax.wulff_net()
+        ax.wulff_net(True, lat_res, long_res)
         assert ax._lat_resolution == lat_res
         assert ax._long_resolution == long_res
 
@@ -170,6 +166,22 @@ class TestStereographicPlot:
         ax.wulff_net(long_resolution_major=0, lat_resolution_major=0)
         assert len(ax.collections) == 2
         plt.close("all")
+
+        # Check the grids plot appropriately for both hemispheres.
+        fig, ax = fig, ax = plt.subplots(
+            1, 2, subplot_kw=dict(projection="stereographic")
+        )
+        ax[0].hemisphere = "upper"
+        ax[1].hemisphere = "lower"
+        ax[0].wulff_net()
+        ax[1].wulff_net()
+        for axis in ax:
+            for c in axis.collections:
+                if "lat" in c.get_label() and "major" in c.get_label():
+                    equator = c.get_paths()[8].vertices
+                    max_delta = np.abs(np.max(equator[1:, 0] - equator[:-1, 0]))
+                    # if the maximum spacing is too big, the projection is wrong
+                    assert max_delta < 0.1
 
     def test_set_labels(self):
         _, ax = plt.subplots(subplot_kw=dict(projection=PROJ_NAME))


### PR DESCRIPTION
<!--
Copyright 2018-2025 the orix developers

This file is part of orix.

orix is free software: you can redistribute it and/or modify
it under the terms of the GNU General Public License as published by
the Free Software Foundation, either version 3 of the License, or
(at your option) any later version.

orix is distributed in the hope that it will be useful,
but WITHOUT ANY WARRANTY; without even the implied warranty of
MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
GNU General Public License for more details.

You should have received a copy of the GNU General Public License
along with orix. If not, see <http://www.gnu.org/licenses/>.
-->
#### Description of the change
I saw #163 while looking for something unrelated, remembered I had previously done a Wulff plot as well, and added `StereographicPlot.wulff_net()` as a feature. 

This is mostly a copy/paste of the `StereographicPlot.stereographic_grid` methodology, but adjusted as needed. I believe i also added all the features mentioned in #163 :
- major/minor grid lines
- end caps
- on/off, adjustable, etc.


#### Progress of the PR
- [x] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### Minimal example of the bug fix or new feature
UPDATE: New example, which is copied from the `examples` folder
```
"""
=========
Wulff net
=========

Some examples for how a Wulff net can be added to any stereographic plot in
ORIX.
"""

import matplotlib.collections as mcollctions
import matplotlib.pyplot as plt
import numpy as np

from orix.plot import StereographicPlot
from orix.quaternion.symmetry import C6
from orix.vector.vector3d import Vector3d

fig, ax = plt.subplots(
    figsize=[6, 4], nrows=1, ncols=2, subplot_kw=dict(projection="stereographic")
)

# display a standard Wulff net with 2 degree minor markers and 10 degree
# major markers, with 10 degree caps at the tops and bottoms.
ax[0].wulff_net()

# The grid spacing can also be changed or turned on and off, similar to ax.grid
# in matplotlib. Here, the latitudinal grid is set to 3 degrees (15 degrees for
# major grid lines), and the longitudinal to 9 degrees (45 degrees for major grid
# lines)

ax[1].wulff_net(True, 3, 9, 15, 45, 15)
# Turn it off
ax[0].wulff_net()
# Then turn it back on, with the previously defined grid spacing saved.
ax[0].wulff_net()
ax[0].set_title("Standard")
ax[1].set_title("Custom")
plt.tight_layout()

# This also works for subsections, such as fundamental sectors.
fig = plt.figure()
ax = fig.add_subplot(projection="stereographic")
ax.restrict_to_sector(C6.fundamental_sector)
ax.wulff_net()
# Add some manual labels. the XY coordinates can be set by using either a single
# vector, or a polar-azimuth pair. Both methods are showb below for a 6-fold
# crystal.
ax.text(Vector3d([0, 0, 1]), s="[001]", offset=[0, -0.04], c="r")
ax.text(Vector3d([1, 0, 0]).unit, s="[100]", offset=[0, -0.04], c="g")
ax.text(np.pi / 3, np.pi / 2, s="[010]", offset=[-0, 0], c="b")
ax.set_title("C6 symmetry\n\n")
plt.tight_layout()

```
<img width="572" height="345" alt="image" src="https://github.com/user-attachments/assets/960d1ca2-899e-4344-a775-8676dd356038" />

<img width="489" height="461" alt="image" src="https://github.com/user-attachments/assets/c7003076-5b72-45e1-a313-4f9f199602b7" />

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [n/a] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [x] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.