### PR TITLE
New function to register custom Matplotlib projections

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,11 @@ Added
   :class:`~orix.vector3d.Miller`.
 - Explicit support for Python 3.13.
 - Dependency on `lazy-loader`.
+- Function :func:`~orix.plot.register_projections` to register all our custom
+  projections for use in Matplotlib.
+  An example of a custom projection is the :class:`~orix.plot.StereographicPlot`.
+  This function replaces the previous behavior of relying on a side-effect of importing
+  the :mod:`orix.plot` module, which also registered the projections.
 
 Changed
 -------

--- a/doc/tutorials/clustering_across_fundamental_region_boundaries.ipynb
+++ b/doc/tutorials/clustering_across_fundamental_region_boundaries.ipynb
@@ -270,7 +270,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "ox",
    "language": "python",
    "name": "python3"
   },
@@ -284,7 +284,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/clustering_misorientations.ipynb
+++ b/doc/tutorials/clustering_misorientations.ipynb
@@ -37,13 +37,16 @@
     "from skimage.color import label2rgb\n",
     "from sklearn.cluster import DBSCAN\n",
     "\n",
-    "from orix import data, plot\n",
-    "from orix.quaternion import Orientation, Misorientation, Rotation\n",
+    "from orix.plot import register_projections, IPFColorKeyTSL\n",
+    "from orix import data\n",
+    "from orix.quaternion import Misorientation, Rotation\n",
     "from orix.quaternion.symmetry import D6\n",
     "from orix.vector import Vector3d\n",
     "\n",
     "\n",
-    "plt.rcParams.update({\"font.size\": 20, \"figure.figsize\": (10, 10)})"
+    "plt.rcParams.update({\"font.size\": 20, \"figure.figsize\": (10, 10)})\n",
+    "\n",
+    "register_projections()"
    ]
   },
   {
@@ -126,7 +129,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ckey = plot.IPFColorKeyTSL(D6)\n",
+    "ckey = IPFColorKeyTSL(D6)\n",
     "\n",
     "directions = [(1, 0, 0), (0, 1, 0)]\n",
     "titles = [\"X\", \"Y\"]\n",
@@ -571,7 +574,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "ox",
    "language": "python",
    "name": "python3"
   },
@@ -585,7 +588,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,

--- a/orix/plot/__init__.py
+++ b/orix/plot/__init__.py
@@ -22,9 +22,19 @@
 :class:`~orix.quaternion.Orientation`,
 :class:`~orix.quaternion.Misorientation`, and
 :class:`~orix.crystal_map.CrystalMap`.
-"""
 
+NOTE: While lazy loading is preferred, the following six classes
+are explicitly imported in order to populate matplotlib.projections
+"""
 import lazy_loader
+
+from orix.plot.crystal_map_plot import CrystalMapPlot
+from orix.plot.rotation_plot import AxAnglePlot, RodriguesPlot, RotationPlot
+from orix.plot.stereographic_plot import StereographicPlot
+
+# Must be imported below StereographicPlot since it imports it
+from orix.plot.inverse_pole_figure_plot import InversePoleFigurePlot  # isort: skip
+
 
 # Imports from stub file (see contributor guide for details)
 __getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)

--- a/orix/plot/__init__.py
+++ b/orix/plot/__init__.py
@@ -16,25 +16,21 @@
 # You should have received a copy of the GNU General Public License
 # along with orix. If not, see <http://www.gnu.org/licenses/>.
 #
-
 """Extensions of Matplotlib's projections framework for plotting
 :class:`~orix.vector.Vector3d`, :class:`~orix.quaternion.Rotation`,
 :class:`~orix.quaternion.Orientation`,
 :class:`~orix.quaternion.Misorientation`, and
 :class:`~orix.crystal_map.CrystalMap`.
-
-NOTE: While lazy loading is preferred, the following six classes
-are explicitly imported in order to populate matplotlib.projections
 """
+
 import lazy_loader
 
-from orix.plot.crystal_map_plot import CrystalMapPlot
-from orix.plot.rotation_plot import AxAnglePlot, RodriguesPlot, RotationPlot
-from orix.plot.stereographic_plot import StereographicPlot
+from orix.plot._plot import register_projections
 
-# Must be imported below StereographicPlot since it imports it
-from orix.plot.inverse_pole_figure_plot import InversePoleFigurePlot  # isort: skip
-
+# TODO: Remove this call once relying on the old side-effect of
+# importing orix.plot to register these projections has little-to-no
+# consequence
+register_projections()
 
 # Imports from stub file (see contributor guide for details)
 __getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)

--- a/orix/plot/__init__.pyi
+++ b/orix/plot/__init__.pyi
@@ -31,15 +31,9 @@ from .inverse_pole_figure_plot import InversePoleFigurePlot  # isort: skip
 # Lazily imported in module init
 __all__ = [
     # Classes
-    "AxAnglePlot",
-    "CrystalMapPlot",
     "DirectionColorKeyTSL",
     "EulerColorKey",
-    "InversePoleFigurePlot",
     "IPFColorKeyTSL",
-    "RodriguesPlot",
-    "RotationPlot",
-    "StereographicPlot",
     # Functions
     "format_labels",
     "register_projections",

--- a/orix/plot/__init__.pyi
+++ b/orix/plot/__init__.pyi
@@ -17,6 +17,7 @@
 # along with orix. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from ._plot import register_projections
 from ._util import format_labels
 from .crystal_map_plot import CrystalMapPlot
 from .direction_color_keys import DirectionColorKeyTSL
@@ -41,4 +42,5 @@ __all__ = [
     "StereographicPlot",
     # Functions
     "format_labels",
+    "register_projections",
 ]

--- a/orix/plot/_plot.py
+++ b/orix/plot/_plot.py
@@ -20,9 +20,15 @@
 import matplotlib.projections as mprojections
 
 from .crystal_map_plot import CrystalMapPlot
-from .inverse_pole_figure_plot import InversePoleFigurePlot
 from .rotation_plot import AxAnglePlot, RodriguesPlot
 from .stereographic_plot import StereographicPlot
+
+# Inverse pole figure plot class must be imported below stereographic
+# plot class, since the former imports the latter
+# isort: off
+from .inverse_pole_figure_plot import InversePoleFigurePlot
+
+# isort: on
 
 
 def register_projections() -> None:

--- a/orix/plot/_plot.py
+++ b/orix/plot/_plot.py
@@ -1,0 +1,65 @@
+#
+# Copyright 2018-2025 the orix developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix. If not, see <http://www.gnu.org/licenses/>.
+#
+
+import matplotlib.projections as mprojections
+
+from .crystal_map_plot import CrystalMapPlot
+from .inverse_pole_figure_plot import InversePoleFigurePlot
+from .rotation_plot import AxAnglePlot, RodriguesPlot
+from .stereographic_plot import StereographicPlot
+
+
+def register_projections() -> None:
+    """Register custom Matplotlib projections.
+
+    This must be called when using one of our custom projections in
+    Matplotlib.
+
+    See Also
+    --------
+    :class:`~orix.plot.CrystalMapPlot`
+    :class:`~orix.plot.InversePoleFigurePlot`
+    :class:`~orix.plot.AxAnglePlot`
+    :class:`~orix.plot.RodriguesPlot`
+    :class:`~orix.plot.StereographicPlot`
+
+    Examples
+    --------
+    >>> import matplotlib.pyplot as plt
+    >>> from orix.plot import register_projections
+    >>> fig = plt.figure()
+
+    May fail
+
+    >>> ax = fig.add_subplot(projection="stereographic")  # doctest: +SKIP
+
+    Works
+
+    >>> register_projections()
+    >>> ax = fig.add_subplot(projection="stereographic")
+    """
+    projections = [
+        AxAnglePlot,
+        CrystalMapPlot,
+        InversePoleFigurePlot,
+        RodriguesPlot,
+        StereographicPlot,
+    ]
+    for proj in projections:
+        mprojections.register_projection(proj)

--- a/orix/tests/test_plot/test_plotting_utilities.py
+++ b/orix/tests/test_plot/test_plotting_utilities.py
@@ -17,10 +17,11 @@
 # along with orix. If not, see <http://www.gnu.org/licenses/>.
 #
 
+import matplotlib.projections as mprojections
 import numpy as np
 import pytest
 
-from orix import plot
+from orix.plot import format_labels, register_projections
 from orix.vector import Vector3d
 
 
@@ -60,12 +61,34 @@ class TestFormatVectorLabels:
     def test_format_vector_labels(self, kwargs, desired):
         v = Vector3d([[1, 1, 1], [-2, 0, 1], [4, 0, 0], [-4, 0, 0]])
         v = v.reshape(2, 2)
-        labels = plot.format_labels(v.data, **kwargs)
+        labels = format_labels(v.data, **kwargs)
         assert labels.shape == (2, 2)
         assert labels.flatten().tolist() == desired
 
     def test_format_vector_labels_4(self):
-        assert all(
-            plot.format_labels([[1, 2, 3, 4], [1.1, 2.2, 3.3, 4.51]])
-            == np.array(["$1234$", "$1235$"], dtype="U6")
-        )
+        labels = [[1, 2, 3, 4], [1.1, 2.2, 3.3, 4.51]]
+        formatted = format_labels(labels)
+        expected_formatted = np.array(["$1234$", "$1235$"], dtype="U6")
+        assert all(formatted == expected_formatted)
+
+
+class TestRegisterProjections:
+    def test_register_projections(self):
+        # This check only passes if our custom projections are not
+        # already registered via a side-effect by importing orix.plot:
+        #
+        # known_projections1 = mprojections.get_projection_names()
+        # assert "stereographic" not in known_projections1
+
+        register_projections()
+        known_projections2 = mprojections.get_projection_names()
+
+        custom_projections = [
+            "axangle",
+            "ipf",
+            "plot_map",
+            "rodrigues",
+            "stereographic",
+        ]
+        for proj in custom_projections:
+            assert proj in known_projections2


### PR DESCRIPTION
#### Description of the change
I've adde a new function to register all our Matplotlib projections. This replaces registration of the projections via the side-effect of importing the `orix.plot` module.

This is required, as @argerlt points out in #583, because lazy loading of the plot module means importing the module does not cause the projections to be registered. This PR replaces #583.

This fixes #585.

#### Progress of the PR
- [x] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### Minimal example of the bug fix or new feature
Previously:
```python
>>> import matplotlib.pyplot as plt
>>> from orix import plot  # Register projections
>>> fig = plt.figure()
>>> ax = fig.add_subplot(projection="stereographic")
```

Now:
```python
>>> import matplotlib.pyplot as plt
>>> import orix.plot as opl
>>> opl.register_projections()
>>> fig = plt.figure()
>>> ax = fig.add_subplot(projection="stereographic")
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [x] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [x] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.