### PR TITLE
Set Phase structure based on point group

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,7 +55,10 @@ Deprecated
 
 Fixed
 -----
+-  :class:`~orix.plot.IPFColorKey` automatic labels and shapes have been corrected.
 
+
+``IPFCOlorKeyTSL.plot`` now produces properly labeled plot axes.
 
 2025-01-01 - version 0.13.3
 ===========================

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -117,12 +117,19 @@ class Phase:
                 name.structure.copy(),
                 name.color,
             )
-        self.structure = structure if structure is not None else Structure()
-        if name is not None:
-            self.name = name
         self.space_group = space_group  # Needs to be set before point group
         self.point_group = point_group
         self.color = color if color is not None else "tab:blue"
+        if structure is not None:
+            self.structure = structure
+        elif self.point_group is None:
+            self.structure = Structure()
+        elif np.isin(self.point_group.system, ["trigonal", "hexagonal"]):
+            self.structure = Structure(lattice=Lattice(1, 1, 1, 90, 90, 120))
+        else:
+            self.structure = Structure(lattice=Lattice(1, 1, 1, 90, 90, 90))
+        if name is not None:
+            self.name = name
 
     @property
     def structure(self) -> Structure:

--- a/orix/plot/inverse_pole_figure_plot.py
+++ b/orix/plot/inverse_pole_figure_plot.py
@@ -476,9 +476,11 @@ def _get_ipf_axes_labels(vertices: Vector3d, symmetry: Symmetry) -> list[str]:
         List of strings, with -1 formatted like $\bar{1}$.
     """
     phase = Phase(point_group=symmetry)
-    m = Miller(uvw=vertices.data, phase=phase)
     if symmetry.system in ["trigonal", "hexagonal"]:
+        m = Miller(xyz=vertices.data, phase=phase)
         m.coordinate_format = "UVTW"
+    else:
+        m = Miller(uvw=vertices.data, phase=phase)
     axes = m.round(max_index=2).coordinates.astype(int)
 
     labels = []

--- a/orix/tests/test_plot/test_direction_color_keys.py
+++ b/orix/tests/test_plot/test_direction_color_keys.py
@@ -40,46 +40,59 @@ class TestDirectionColorKeyTSL:
         assert rgb2[0].size == rgb2[1].size == 0
 
     @pytest.mark.parametrize(
-        "symmetry, expected_shape",
+        "symmetry, expected_shape, expected_xy_lims, expected_labels",
         [
-            [symmetry.C1, (2000, 2000, 4)],
-            [symmetry.C2, (1000, 2000, 4)],
-            [symmetry.D6, (500, 1000, 4)],
-            [symmetry.Oh, (367, 415, 4)],
-            [symmetry.Th, (415, 415, 4)],
+            [symmetry.C1, (2000, 2000, 4), [(-1.0, 1.0), (-1.0, 1.0)], ""],
+            [symmetry.Ci, (2000, 2000, 4), [(-1.0, 1.0), (-1.0, 1.0)], ""],
+            [
+                symmetry.C2,
+                (1000, 2000, 4),
+                [(-1.0, 1.0), (0.0, 1.0)],
+                "[$1 0 0$][$\\bar{1} 0 0$]",
+            ],
+            [
+                symmetry.S6,
+                (1000, 1500, 4),
+                [(-0.5, 1.0), (0, 1.0)],
+                "[$2 \\bar{1} \\bar{1} 0$][$0 0 0 1$][$\\bar{1} 2 \\bar{1} 0$]",
+            ],
+            [
+                symmetry.D6,
+                (500, 1000, 4),
+                [(0.0, 1.0), (0.0, 0.5)],
+                "[$2 \\bar{1} \\bar{1} 0$][$0 0 0 1$][$1 0 \\bar{1} 0$]",
+            ],
+            [
+                symmetry.Oh,
+                (367, 415, 4),
+                [(0.0, 0.414), (0.0, 0.366)],
+                "[$1 1 1$][$1 0 1$][$0 0 1$]",
+            ],
+            [
+                symmetry.Th,
+                (415, 415, 4),
+                [(0.0, 0.414), (0.0, 0.414)],
+                "[$0 1 1$][$1 1 1$][$1 0 1$][$0 0 1$]",
+            ],
         ],
     )
     @pytest.mark.slow
-    def test_rgba_grid_shape(self, symmetry, expected_shape):
+    def test_rgba_grid(
+        self, symmetry, expected_shape, expected_xy_lims, expected_labels
+    ):
         ckey = IPFColorKeyTSL(symmetry)
-        ckey_direction = ckey.direction_color_key
-        rgb_grid = ckey_direction._create_rgba_grid()
+        ckey_dcc = ckey.direction_color_key
+        rgb_grid, (xlim, ylim) = ckey_dcc._create_rgba_grid(return_extent=True)
+        (x_min, x_max), (y_min, y_max) = xlim, ylim
+        ax = ckey_dcc.plot(True).get_axes()[0]
+        labels = "".join([x.get_text() for x in ax.texts])
         assert isinstance(rgb_grid, np.ndarray)
         assert rgb_grid.shape == expected_shape
-
-    @pytest.mark.parametrize(
-        "symmetry, expected_xlim, expected_ylim",
-        [
-            [symmetry.C1, (-1.0, 1.0), (-1.0, 1.0)],
-            [symmetry.C2, (-1.0, 1.0), (0.0, 1.0)],
-            [symmetry.D6, (0.0, 1.0), (0.0, 0.5)],
-            [symmetry.Oh, (0.0, 0.414), (0.0, 0.366)],
-            [symmetry.Th, (0.0, 0.414), (0.0, 0.414)],
-        ],
-    )
-    @pytest.mark.slow
-    def test_rgba_grid_limits(self, symmetry, expected_xlim, expected_ylim):
-        ckey = IPFColorKeyTSL(symmetry)
-        ckey_direction = ckey.direction_color_key
-        (
-            _,
-            (x_lim, y_lim),
-        ) = ckey_direction._create_rgba_grid(return_extent=True)
-        (x_min, x_max), (y_min, y_max) = x_lim, y_lim
-        assert round(x_min, 3) == round(expected_xlim[0], 3)
-        assert round(x_max, 3) == round(expected_xlim[1], 3)
-        assert round(y_min, 3) == round(expected_ylim[0], 3)
-        assert round(y_max, 3) == round(expected_ylim[1], 3)
+        assert round(x_min, 3) == round(expected_xy_lims[0][0], 3)
+        assert round(x_max, 3) == round(expected_xy_lims[0][1], 3)
+        assert round(y_min, 3) == round(expected_xy_lims[1][0], 3)
+        assert round(y_max, 3) == round(expected_xy_lims[1][1], 3)
+        assert labels == expected_labels
 
     @pytest.mark.parametrize(
         "symmetry",

--- a/orix/vector/fundamental_sector.py
+++ b/orix/vector/fundamental_sector.py
@@ -147,9 +147,9 @@ def _closed_edges_in_hemisphere(
     edges: Vector3d, sector: FundamentalSector, pole: int = -1
 ) -> Vector3d:
     if pole == -1:
-        is_outside = edges.polar >= np.pi / 2
+        is_outside = edges.polar >= np.pi / 2 + 1e-6
     else:  # pole == 1
-        is_outside = edges.polar <= np.pi / 2
+        is_outside = edges.polar <= np.pi / 2 + 1e-6
 
     if not np.any(is_outside):
         return edges


### PR DESCRIPTION
#### Description of the change

This does 3 things:
1) Ensures the lattice associated with a `Phase` matches it's Laue class, as discussed in #579 
2) Updates how labels are make for IPF plots which, in combination with point 1, solves #543 
3) Fixes a rounding error in `orix.vector.fundamental_sector._closed_edges_in_hemisphere` that caused the Ci symmetry group to plot it's boundary weirdly.

This does NOT solve #566 (making some attributes of `Phase` immutable) as that issue is more complicated, but it does make the issue easier to tackle in a future PR.

#### Progress of the PR
- [x] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### Minimal example of the bug fix or new feature
Run the following code on both the development branch and this PR branch to see the updates. m3m is unchanged and is just added as a sanity check, but the other 6 all had errors that are now resolved

```python

from orix import plot
from orix.quaternion import symmetry
from orix.crystal_map import Phase
import matplotlib.pyplot as plt

plt.close('all')
pg_laue = [
    symmetry.Oh,
    symmetry.Ci,
    symmetry.D3d,
    symmetry.S6,
    symmetry.D4h,
    symmetry.C6h,
    symmetry.D6h,
]

for pg in pg_laue:
    ipfkey = plot.IPFColorKeyTSL(pg)
    ipfkey.plot()

```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.