### PR TITLE
Correct phase structure based on crystal system

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,21 +1,3 @@
-<!--
-Copyright 2018-2025 the orix developers
-
-This file is part of orix.
-
-orix is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-orix is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with orix. If not, see <http://www.gnu.org/licenses/>.
--->
 #### Description of the change
 
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,7 @@ repos:
             "-cy",
             "-n", "orix",
             "--additional-extensions", "python=.pyi",
+            "--exclude", "*/pull_request_template.md",
             "-f",
           ]
 # https://pre-commit.ci/#configuration

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,7 +55,10 @@ Deprecated
 
 Fixed
 -----
+-  :class:`~orix.plot.IPFColorKey` automatic labels and shapes have been corrected.
 
+
+``IPFCOlorKeyTSL.plot`` now produces properly labeled plot axes.
 
 2025-01-01 - version 0.13.3
 ===========================

--- a/orix/crystal_map/__init__.pyi
+++ b/orix/crystal_map/__init__.pyi
@@ -17,9 +17,10 @@
 # along with orix. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from ._phase import Phase
+from ._phase_list import PhaseList
 from .crystal_map import CrystalMap, create_coordinate_arrays
 from .crystal_map_properties import CrystalMapProperties
-from .phase_list import Phase, PhaseList
 
 # Lazily imported in module init
 __all__ = [

--- a/orix/crystal_map/_phase.py
+++ b/orix/crystal_map/_phase.py
@@ -1,0 +1,493 @@
+#
+# Copyright 2018-2025 the orix developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""Phase class and private utilities used by it."""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+import warnings
+
+from diffpy.structure import Lattice, Structure
+from diffpy.structure.parsers import p_cif
+from diffpy.structure.spacegroups import GetSpaceGroup, SpaceGroup
+from diffpy.structure.symmetryutilities import ExpandAsymmetricUnit
+import matplotlib.colors as mcolors
+import numpy as np
+
+from orix.plot._util.color import get_matplotlib_color
+from orix.quaternion.symmetry import (
+    _EDAX_POINT_GROUP_ALIASES,
+    Symmetry,
+    _groups,
+    get_point_group,
+)
+from orix.vector.miller import Miller
+from orix.vector.vector3d import Vector3d
+
+
+class Phase:
+    """Symmetry and unit cell of a phase in a crystallographic map.
+
+    The phase can be crystallographic or non-crystallographic, with the
+    latter not having a crystal structure or symmetry set.
+
+    Parameters
+    ----------
+    name
+        Phase name. Overwrites the name in the *structure*. A phase can
+        also be given, in which case a copy is returned and all other
+        parameters are ignored.
+    space_group
+        Space group describing the symmetry operations resulting from
+        associating the point group with a Bravais lattice, according
+        to the International Tables of Crystallography. If not given, it
+        is set to None.
+    point_group
+        Point group describing the symmetry operations of the phase's
+        crystal structure, according to the International Tables of
+        Crystallography. If neither this or *space_group* is given, it
+        is set to None. If not given but *space_group* is, it is derived
+        from the space group. If both this and *space_group* is given,
+        the space group must to be derived from the point group.
+    structure
+        Unit cell with atoms and a lattice. If not given, a default
+        :class:`~diffpy.structure.structure.Structure` compatible with
+        the symmetry is used.
+    color
+        Phase color. If not given, it is set to the first default
+        Matplotlib color "tab:blue".
+    """
+
+    def __init__(
+        self,
+        name: str | Phase | None = None,
+        space_group: int | SpaceGroup | None = None,
+        point_group: int | str | Symmetry | None = None,
+        structure: Structure | None = None,
+        color: str | None = None,
+    ) -> None:
+        if isinstance(name, Phase):
+            return Phase.__init__(
+                self,
+                name.name,
+                name.space_group,
+                name.point_group,
+                name.structure.copy(),
+                name.color,
+            )
+
+        self.space_group = space_group  # Needs to be set before point group
+        self.point_group = point_group
+
+        self.color = color if color is not None else "tab:blue"
+
+        if structure is None:
+            pg = self.point_group
+            if pg is not None and pg.system is not None:
+                lat = default_lattice(pg.system)
+            else:
+                lat = Lattice()
+            structure = Structure(lattice=lat)
+        self.structure = structure
+
+        if name is not None:
+            self.name = name
+
+    @property
+    def structure(self) -> Structure:
+        r"""Return or set the crystal structure containing a lattice
+        (:class:`~diffpy.structure.lattice.Lattice`) and possibly many
+        atoms (:class:`~diffpy.structure.atom.Atom`).
+
+        Parameters
+        ----------
+        value : ~diffpy.structure.Structure
+            Crystal structure. The cartesian reference frame of the
+            crystal lattice is assumed to align :math:`a` with
+            :math:`e_1` and :math:`c*` with :math:`e_3`. This alignment
+            is assumed when transforming direct, reciprocal and
+            cartesian vectors between these spaces.
+        """
+        return self._structure
+
+    @structure.setter
+    def structure(self, value: Structure) -> None:
+        """Set the crystal structure."""
+        if not isinstance(value, Structure):
+            raise ValueError(f"{value} must be a diffpy.structure.Structure")
+
+        # Ensure correct alignment
+        old_matrix = value.lattice.base
+        new_matrix = new_structure_matrix_from_alignment(old_matrix, x="a", z="c*")
+        new_value = value.copy()
+
+        # Ensure atom positions are expressed in the new basis
+        new_value.placeInLattice(Lattice(base=new_matrix))
+
+        # Store old lattice for expand_asymmetric_unit
+        self._diffpy_lattice = old_matrix
+        if new_value.title == "" and hasattr(self, "_structure"):
+            new_value.title = self.name
+
+        self._structure = new_value
+
+    @property
+    def name(self) -> str:
+        """Return or set the phase name.
+
+        Parameters
+        ----------
+        value : str
+            Phase name.
+        """
+        return self.structure.title
+
+    @name.setter
+    def name(self, value: str) -> None:
+        """Set the phase name."""
+        self.structure.title = str(value)
+
+    @property
+    def color(self) -> str:
+        """Return or set the phase color name.
+
+        Parameters
+        ----------
+        value : str
+            A valid color string identifier recognized by
+            :func:`matplotlib.colors.is_color_like`. If a valid alias is
+            given, e.g. "g", the default name is used, e.g. "green".
+        """
+        return self._color
+
+    @color.setter
+    def color(self, value: str) -> None:
+        """Set the phase color."""
+        name, _ = get_matplotlib_color(value)
+        self._color = name
+
+    @property
+    def color_rgb(self) -> tuple:
+        """Return the phase color as RGB tuple."""
+        return mcolors.to_rgb(self._color)
+
+    @property
+    def space_group(self) -> SpaceGroup | None:
+        """Return or set the space group.
+
+        Parameters
+        ----------
+        value : int, SpaceGroup or None
+            Space group. If an integer is passed, it must be between
+            1-230.
+        """
+        return self._space_group
+
+    @space_group.setter
+    def space_group(self, value: int | SpaceGroup | None) -> None:
+        """Set the space group."""
+        if isinstance(value, int):
+            value = GetSpaceGroup(value)
+        if not isinstance(value, SpaceGroup) and value is not None:
+            raise ValueError(
+                f"{value!r} must be of type {SpaceGroup}, an integer 1-230, or None"
+            )
+        # Overwrites any point group set before
+        self._space_group: SpaceGroup | None = value
+
+    @property
+    def point_group(self) -> Symmetry | None:
+        """Return or set the point group.
+
+        Parameters
+        ----------
+        value : int, str, Symmetry or None
+            Point group.
+        """
+        if self.space_group is not None:
+            return get_point_group(self.space_group.number)
+        else:
+            return self._point_group
+
+    @point_group.setter
+    def point_group(self, value: int | str | Symmetry | None) -> None:
+        """Set the point group."""
+        if isinstance(value, int):
+            value = str(value)
+        if isinstance(value, str):
+            for key, aliases in _EDAX_POINT_GROUP_ALIASES.items():
+                if value in aliases:
+                    value = key
+                    break
+            for point_group in _groups:
+                if value == point_group.name:
+                    value = point_group
+                    break
+        if not isinstance(value, Symmetry) and value is not None:
+            raise ValueError(
+                f"{value!r} must be of type {Symmetry}, the name of a valid point group"
+                " as a string, or None"
+            )
+        else:
+            if self.space_group is not None and value is not None:
+                old_point_group_name = self.point_group.name
+                if old_point_group_name != value.name:
+                    warnings.warn(
+                        "Setting space group to 'None', as current space group "
+                        f"{self.space_group.short_name!r} is derived from current point"
+                        f" group {old_point_group_name!r}"
+                    )
+                    self.space_group = None
+            self._point_group = value
+
+    @property
+    def is_hexagonal(self) -> bool:
+        """Return whether the crystal structure is hexagonal/trigonal or
+        not.
+        """
+        return np.allclose(self.structure.lattice.abcABG()[3:], [90, 90, 120])
+
+    @property
+    def a_axis(self) -> Miller:
+        """Return the direct lattice vector :math:`a` in the cartesian
+        reference frame of the crystal lattice :math:`e_i`.
+        """
+        return Miller(uvw=(1, 0, 0), phase=self)
+
+    @property
+    def b_axis(self) -> Miller:
+        """Return the direct lattice vector :math:`b` in the cartesian
+        reference frame of the crystal lattice :math:`e_i`.
+        """
+        return Miller(uvw=(0, 1, 0), phase=self)
+
+    @property
+    def c_axis(self) -> Miller:
+        """Return the direct lattice vector :math:`c` in the cartesian
+        reference frame of the crystal lattice :math:`e_i`.
+        """
+        return Miller(uvw=(0, 0, 1), phase=self)
+
+    @property
+    def ar_axis(self) -> Miller:
+        """Return the reciprocal lattice vector :math:`a^{*}` in the
+        cartesian reference frame of the crystal lattice :math:`e_i`.
+        """
+        return Miller(hkl=(1, 0, 0), phase=self)
+
+    @property
+    def br_axis(self) -> Miller:
+        """Return the reciprocal lattice vector :math:`b^{*}` in the
+        cartesian reference frame of the crystal lattice :math:`e_i`.
+        """
+        return Miller(hkl=(0, 1, 0), phase=self)
+
+    @property
+    def cr_axis(self) -> Miller:
+        """Return the reciprocal lattice vector :math:`c^{*}` in the
+        cartesian reference frame of the crystal lattice :math:`e_i`.
+        """
+        return Miller(hkl=(0, 0, 1), phase=self)
+
+    def __repr__(self) -> str:
+        if self.point_group is not None:
+            pg_name = self.point_group.name
+            ppg_name = self.point_group.proper_subgroup.name
+        else:
+            pg_name = self.point_group  # Should be None
+            ppg_name = None
+        if self.space_group is not None:
+            sg_name = self.space_group.short_name
+        else:
+            sg_name = self.space_group  # Should be None
+        return (
+            f"<name: {self.name}. space group: {sg_name}. point group: {pg_name}. "
+            f"proper point group: {ppg_name}. color: {self.color}>"
+        )
+
+    @classmethod
+    def from_cif(cls, filename: str | Path) -> Phase:
+        r"""Return a new phase from a Crystallographic Information File
+        (CIF).
+
+        Parameters
+        ----------
+        filename
+            Path to the \*.cif. The phase name is obtained from the file
+            name.
+
+        Returns
+        -------
+        phase
+            New phase.
+
+        Notes
+        -----
+        The file is read using :mod:`diffpy.structure` 's CIF file
+        parser.
+
+        See https://www.iucr.org/resources/cif for details on the CIF
+        file format.
+        """
+        path = Path(filename)
+        parser = p_cif.P_cif()
+        name = path.stem
+        structure = parser.parseFile(str(path))
+        try:
+            space_group = parser.spacegroup.number
+        except AttributeError:  # pragma: no cover
+            space_group = None
+            warnings.warn(f"Could not read space group from CIF file {path!r}")
+        return cls(name, space_group, structure=structure)
+
+    def deepcopy(self) -> Phase:
+        """Return a deep copy using :py:func:`~copy.deepcopy`
+        function.
+        """
+        return copy.deepcopy(self)
+
+    def expand_asymmetric_unit(self) -> Phase:
+        """Return a new phase with all symmetrically equivalent atoms.
+
+        Returns
+        -------
+        expanded_phase
+            New phase with the a :attr:`structure` with the unit cell
+            filled with symmetrically equivalent atoms.
+
+        Examples
+        --------
+        >>> from diffpy.structure import Atom, Lattice, Structure
+        >>> import orix.crystal_map as ocm
+        >>> atoms = [Atom("Si", xyz=(0, 0, 1))]
+        >>> lattice = Lattice(4.04, 4.04, 4.04, 90, 90, 90)
+        >>> structure = Structure(atoms = atoms,lattice=lattice)
+        >>> phase = ocm.Phase(structure=structure, space_group=227)
+        >>> phase.structure
+        [Si   0.000000 0.000000 1.000000 1.0000]
+        >>> expanded_phase = phase.expand_asymmetric_unit()
+        >>> expanded_phase.structure
+        [Si   0.000000 0.000000 0.000000 1.0000,
+         Si   0.000000 0.500000 0.500000 1.0000,
+         Si   0.500000 0.500000 0.000000 1.0000,
+         Si   0.500000 0.000000 0.500000 1.0000,
+         Si   0.750000 0.250000 0.750000 1.0000,
+         Si   0.250000 0.250000 0.250000 1.0000,
+         Si   0.250000 0.750000 0.750000 1.0000,
+         Si   0.750000 0.750000 0.250000 1.0000]
+        """
+        if self.space_group is None:
+            raise ValueError("Space group must be set")
+
+        # Ensure atom positions are expressed in diffpy's convention
+        diffpy_structure = self.structure.copy()
+        diffpy_structure.placeInLattice(Lattice(base=self._diffpy_lattice))
+        xyz = diffpy_structure.xyz
+        diffpy_structure.clear()
+
+        eau = ExpandAsymmetricUnit(self.space_group, xyz)
+        for atom, new_positions in zip(self.structure, eau.expandedpos):
+            for pos in new_positions:
+                new_atom = copy.deepcopy(atom)
+                new_atom.xyz = pos
+                # Only add new atom if not already present
+                for present_atom in diffpy_structure:
+                    if present_atom.element == new_atom.element and np.allclose(
+                        present_atom.xyz, new_atom.xyz
+                    ):
+                        break
+                else:
+                    diffpy_structure.append(new_atom)
+
+        # This handles conversion back to correct alignment
+        expanded_phase = self.__class__(self)
+        expanded_phase.structure = diffpy_structure
+
+        return expanded_phase
+
+
+def new_structure_matrix_from_alignment(
+    old_matrix: np.ndarray,
+    x: str | None = None,
+    y: str | None = None,
+    z: str | None = None,
+) -> np.ndarray:
+    """Return a new structure matrix given the old structure matrix and
+    at least two aligned axes x, y, or z.
+
+    The structure matrix defines the alignment of direct and reciprocal
+    lattice base vectors with the cartesian reference frame of the
+    crystal lattice defined by x, y, and z. x, y, and z are often termed
+    :math:`e_i`.
+
+    Parameters
+    ----------
+    old_matrix
+        Old structure matrix, i.e. the 3x3 matrix of row base vectors
+        expressed in Cartesian coordinates.
+    x, y, z
+        Which of the six axes "a", "b", "c", "a*", "b*", or "z*" are
+        aligned with the base vectors of the cartesian crystal reference
+        frame. At least two must be specified.
+
+    Returns
+    -------
+    new_matrix
+        New structure matrix according to the alignment.
+    """
+    if sum([i is None for i in [x, y, z]]) > 1:
+        raise ValueError("At least two of x, y, z must be set.")
+
+    # Old direct lattice base (row) vectors in Cartesian coordinates
+    old_matrix = Vector3d(old_matrix)
+    ad, bd, cd = old_matrix.unit
+
+    # Old reciprocal lattice base vectors in cartesian coordinates
+    ar = bd.cross(cd).unit
+    br = cd.cross(ad).unit
+    cr = ad.cross(bd).unit
+
+    # New unit crystal base
+    new_vectors = Vector3d.zero((3,))
+    axes_mapping = {"a": ad, "b": bd, "c": cd, "a*": ar, "b*": br, "c*": cr}
+    for i, al in enumerate([x, y, z]):
+        if al in axes_mapping.keys():
+            new_vectors[i] = axes_mapping[al]
+    other_idx = {0: (1, 2), 1: (2, 0), 2: (0, 1)}
+    for i in range(3):
+        if np.isclose(new_vectors[i].norm, 0):
+            other0, other1 = other_idx[i]
+            new_vectors[i] = new_vectors[other0].cross(new_vectors[other1])
+
+    # New crystal base
+    new_matrix = new_vectors.dot(old_matrix.reshape(3, 1)).round(12)
+
+    return new_matrix
+
+
+def default_lattice(system: str) -> Lattice:
+    if system in ["triclinic", "monoclinic", "orthorhombic", "tetragonal", "cubic"]:
+        lat = Lattice()
+    elif system in ["trigonal", "hexagonal"]:
+        lat = Lattice(1, 1, 1, 90, 90, 120)
+    else:
+        raise ValueError(f"Unknown crystal system {system!r}")
+    return lat

--- a/orix/crystal_map/_phase_list.py
+++ b/orix/crystal_map/_phase_list.py
@@ -17,422 +17,22 @@
 # along with orix. If not, see <http://www.gnu.org/licenses/>.
 #
 
+"""Phase list class."""
+
 from __future__ import annotations
 
 from collections import OrderedDict
 import copy
 from itertools import islice
-from pathlib import Path
 from typing import Generator
-import warnings
 
-from diffpy.structure import Lattice, Structure
-from diffpy.structure.parsers import p_cif
-from diffpy.structure.spacegroups import GetSpaceGroup, SpaceGroup
-from diffpy.structure.symmetryutilities import ExpandAsymmetricUnit
-import matplotlib.colors as mcolors
+from diffpy.structure import Structure
+from diffpy.structure.spacegroups import SpaceGroup
 import numpy as np
 
-from orix.quaternion.symmetry import (
-    _EDAX_POINT_GROUP_ALIASES,
-    Symmetry,
-    _groups,
-    get_point_group,
-)
-from orix.vector.miller import Miller
-from orix.vector.vector3d import Vector3d
-
-# All named Matplotlib colors (tableau and xkcd already lower case hex)
-ALL_COLORS = mcolors.TABLEAU_COLORS
-for k, v in {**mcolors.BASE_COLORS, **mcolors.CSS4_COLORS}.items():
-    ALL_COLORS[k] = mcolors.to_hex(v)
-ALL_COLORS.update(mcolors.XKCD_COLORS)
-
-
-class Phase:
-    """Name, symmetry, and color of a phase in a crystallographic map.
-
-    If the first parameter is a :code:`Phase` instance, a copy is made
-
-    Parameters
-    ----------
-    name
-        Phase name. Overwrites the name in the ``structure`` object.
-        If this parameter is a :code:`Phase`, a copy is made.
-    space_group
-        Space group describing the symmetry operations resulting from
-        associating the point group with a Bravais lattice, according
-        to the International Tables of Crystallography. If not given, it
-        is set to ``None``.
-    point_group
-        Point group describing the symmetry operations of the phase's
-        crystal structure, according to the International Tables of
-        Crystallography. If not given and ``space_group`` is not given,
-        it set to ``None``. If ``None`` is passed but ``space_group``
-        is not ``None``, it is derived from the space group. If both
-        ``point_group`` and ``space_group`` is not ``None``, the space
-        group needs to be derived from the point group.
-    structure
-        Unit cell with atoms and a lattice. If not given, a default
-        :class:`~diffpy.structure.structure.Structure` object is
-        created.
-    color
-        Phase color. If not given, it is set to ``"tab:blue"`` (first
-        among the default Matplotlib colors).
-
-    Examples
-    --------
-    >>> from diffpy.structure import Atom, Lattice, Structure
-    >>> from orix.crystal_map import Phase
-    >>> p = Phase(
-    ...     name="al",
-    ...     space_group=225,
-    ...     structure=Structure(
-    ...         atoms=[Atom("al", [0, 0, 0])],
-    ...         lattice=Lattice(0.405, 0.405, 0.405, 90, 90, 90)
-    ...     )
-    ... )
-    >>> p
-    <name: al. space group: Fm-3m. point group: m-3m. proper point group: 432. color: tab:blue>
-    >>> p.structure
-    [al   0.000000 0.000000 0.000000 1.0000]
-    >>> p.structure.lattice
-    Lattice(a=0.405, b=0.405, c=0.405, alpha=90, beta=90, gamma=90)
-    """
-
-    def __init__(
-        self,
-        name: str | "Phase" | None = None,
-        space_group: int | SpaceGroup | None = None,
-        point_group: int | str | Symmetry | None = None,
-        structure: Structure | None = None,
-        color: str | None = None,
-    ) -> None:
-        if isinstance(name, Phase):
-            return Phase.__init__(
-                self,
-                name.name,
-                name.space_group,
-                name.point_group,
-                name.structure.copy(),
-                name.color,
-            )
-        self.space_group = space_group  # Needs to be set before point group
-        self.point_group = point_group
-        self.color = color if color is not None else "tab:blue"
-        if structure is not None:
-            self.structure = structure
-        elif self.point_group is None:
-            self.structure = Structure()
-        elif np.isin(self.point_group.system, ["trigonal", "hexagonal"]):
-            self.structure = Structure(lattice=Lattice(1, 1, 1, 90, 90, 120))
-        else:
-            self.structure = Structure(lattice=Lattice(1, 1, 1, 90, 90, 90))
-        if name is not None:
-            self.name = name
-
-    @property
-    def structure(self) -> Structure:
-        r"""Return or set the crystal structure containing a lattice
-        (:class:`~diffpy.structure.lattice.Lattice`) and possibly many
-        atoms (:class:`~diffpy.structure.atom.Atom`).
-
-        Parameters
-        ----------
-        value : ~diffpy.structure.Structure
-            Crystal structure. The cartesian reference frame of the
-            crystal lattice is assumed to align :math:`a` with
-            :math:`e_1` and :math:`c*` with :math:`e_3`. This alignment
-            is assumed when transforming direct, reciprocal and
-            cartesian vectors between these spaces.
-        """
-        return self._structure
-
-    @structure.setter
-    def structure(self, value: Structure) -> None:
-        """Set the crystal structure."""
-        if isinstance(value, Structure):
-            # Ensure correct alignment
-            old_matrix = value.lattice.base
-            new_matrix = _new_structure_matrix_from_alignment(old_matrix, x="a", z="c*")
-            value = copy.deepcopy(value)
-            # Ensure atom positions are expressed in the new basis
-            value.placeInLattice(Lattice(base=new_matrix))
-            # Store old lattice for expand_asymmetric_unit
-            self._diffpy_lattice = old_matrix
-            if value.title == "" and hasattr(self, "_structure"):
-                value.title = self.name
-            self._structure = value
-        else:
-            raise ValueError(f"{value} must be a diffpy.structure.Structure object.")
-
-    @property
-    def name(self) -> str:
-        """Return or set the phase name.
-
-        Parameters
-        ----------
-        value : str
-            Phase name.
-        """
-        return self.structure.title
-
-    @name.setter
-    def name(self, value: str) -> None:
-        """Set the phase name."""
-        self.structure.title = str(value)
-
-    @property
-    def color(self) -> str:
-        """Return or set the name of phase color.
-
-        Parameters
-        ----------
-        value : str
-            A valid color identifier. See
-            :func:`matplotlib.colors.is_color_like`.
-        """
-        return self._color
-
-    @color.setter
-    def color(self, value: str) -> None:
-        """Set the phase color."""
-        value_hex = mcolors.to_hex(value)
-        for name, color_hex in ALL_COLORS.items():
-            if color_hex == value_hex:
-                self._color = name
-                break
-
-    @property
-    def color_rgb(self) -> tuple:
-        """Return the phase color as RGB tuple."""
-        return mcolors.to_rgb(self.color)
-
-    @property
-    def space_group(self) -> SpaceGroup | None:
-        """Return or set the space group.
-
-        Parameters
-        ----------
-        value : int, SpaceGroup or None
-            Space group. If an integer is passed, it must be between
-            1-230.
-        """
-        return self._space_group
-
-    @space_group.setter
-    def space_group(self, value: int | SpaceGroup | None) -> None:
-        """Set the space group."""
-        if isinstance(value, int):
-            value = GetSpaceGroup(value)
-        if not isinstance(value, SpaceGroup) and value is not None:
-            raise ValueError(
-                f"'{value}' must be of type {SpaceGroup}, an integer 1-230, or None."
-            )
-        # Overwrites any point group set before
-        self._space_group: SpaceGroup | None = value
-
-    @property
-    def point_group(self) -> Symmetry | None:
-        """Return or set the point group.
-
-        Parameters
-        ----------
-        value : int, str, Symmetry or None
-            Point group.
-        """
-        if self.space_group is not None:
-            return get_point_group(self.space_group.number)
-        else:
-            return self._point_group
-
-    @point_group.setter
-    def point_group(self, value: int | str | Symmetry | None) -> None:
-        """Set the point group."""
-        if isinstance(value, int):
-            value = str(value)
-        if isinstance(value, str):
-            for key, aliases in _EDAX_POINT_GROUP_ALIASES.items():
-                if value in aliases:
-                    value = key
-                    break
-            for point_group in _groups:
-                if value == point_group.name:
-                    value = point_group
-                    break
-        if not isinstance(value, Symmetry) and value is not None:
-            raise ValueError(
-                f"'{value}' must be of type {Symmetry}, the name of a valid point"
-                " group as a string, or None."
-            )
-        else:
-            if self.space_group is not None and value is not None:
-                old_point_group_name = self.point_group.name
-                if old_point_group_name != value.name:
-                    warnings.warn(
-                        "Setting space group to 'None', as current space group "
-                        f"'{self.space_group.short_name}' is derived from current point"
-                        f" group '{old_point_group_name}'."
-                    )
-                    self.space_group = None
-            self._point_group = value
-
-    @property
-    def is_hexagonal(self) -> bool:
-        """Return whether the crystal structure is hexagonal/trigonal or
-        not.
-        """
-        return np.allclose(self.structure.lattice.abcABG()[3:], [90, 90, 120])
-
-    @property
-    def a_axis(self) -> Miller:
-        """Return the direct lattice vector :math:`a` in the cartesian
-        reference frame of the crystal lattice :math:`e_i`.
-        """
-        return Miller(uvw=(1, 0, 0), phase=self)
-
-    @property
-    def b_axis(self) -> Miller:
-        """Return the direct lattice vector :math:`b` in the cartesian
-        reference frame of the crystal lattice :math:`e_i`.
-        """
-        return Miller(uvw=(0, 1, 0), phase=self)
-
-    @property
-    def c_axis(self) -> Miller:
-        """Return the direct lattice vector :math:`c` in the cartesian
-        reference frame of the crystal lattice :math:`e_i`.
-        """
-        return Miller(uvw=(0, 0, 1), phase=self)
-
-    @property
-    def ar_axis(self) -> Miller:
-        """Return the reciprocal lattice vector :math:`a^{*}` in the
-        cartesian reference frame of the crystal lattice :math:`e_i`.
-        """
-        return Miller(hkl=(1, 0, 0), phase=self)
-
-    @property
-    def br_axis(self) -> Miller:
-        """Return the reciprocal lattice vector :math:`b^{*}` in the
-        cartesian reference frame of the crystal lattice :math:`e_i`.
-        """
-        return Miller(hkl=(0, 1, 0), phase=self)
-
-    @property
-    def cr_axis(self) -> Miller:
-        """Return the reciprocal lattice vector :math:`c^{*}` in the
-        cartesian reference frame of the crystal lattice :math:`e_i`.
-        """
-        return Miller(hkl=(0, 0, 1), phase=self)
-
-    def __repr__(self) -> str:
-        if self.point_group is not None:
-            pg_name = self.point_group.name
-            ppg_name = self.point_group.proper_subgroup.name
-        else:
-            pg_name = self.point_group  # Should be None
-            ppg_name = None
-        if self.space_group is not None:
-            sg_name = self.space_group.short_name
-        else:
-            sg_name = self.space_group  # Should be None
-        return (
-            f"<name: {self.name}. space group: {sg_name}. point group: {pg_name}. "
-            f"proper point group: {ppg_name}. color: {self.color}>"
-        )
-
-    @classmethod
-    def from_cif(cls, filename: str | Path) -> Phase:
-        """Return a new phase from a CIF file using
-        :mod:`diffpy.structure`'s CIF file parser.
-
-        Parameters
-        ----------
-        filename
-            Complete path to CIF file with ".cif" file ending. The phase
-            name is obtained from the file name.
-
-        Returns
-        -------
-        phase
-            New phase.
-        """
-        path = Path(filename)
-        parser = p_cif.P_cif()
-        name = path.stem
-        structure = parser.parseFile(str(path))
-        try:
-            space_group = parser.spacegroup.number
-        except AttributeError:  # pragma: no cover
-            space_group = None
-            warnings.warn(f"Could not read space group from CIF file {path!r}")
-        return cls(name, space_group, structure=structure)
-
-    def deepcopy(self) -> Phase:
-        """Return a deep copy using :py:func:`~copy.deepcopy`
-        function.
-        """
-        return copy.deepcopy(self)
-
-    def expand_asymmetric_unit(self) -> Phase:
-        """Return a new phase with all symmetrically equivalent atoms.
-
-        Returns
-        -------
-        expanded_phase
-            New phase with the a :attr:`structure` with the unit cell
-            filled with symmetrically equivalent atoms.
-
-        Examples
-        --------
-        >>> from diffpy.structure import Atom, Lattice, Structure
-        >>> import orix.crystal_map as ocm
-        >>> atoms = [Atom("Si", xyz=(0, 0, 1))]
-        >>> lattice = Lattice(4.04, 4.04, 4.04, 90, 90, 90)
-        >>> structure = Structure(atoms = atoms,lattice=lattice)
-        >>> phase = ocm.Phase(structure=structure, space_group=227)
-        >>> phase.structure
-        [Si   0.000000 0.000000 1.000000 1.0000]
-        >>> expanded_phase = phase.expand_asymmetric_unit()
-        >>> expanded_phase.structure
-        [Si   0.000000 0.000000 0.000000 1.0000,
-         Si   0.000000 0.500000 0.500000 1.0000,
-         Si   0.500000 0.500000 0.000000 1.0000,
-         Si   0.500000 0.000000 0.500000 1.0000,
-         Si   0.750000 0.250000 0.750000 1.0000,
-         Si   0.250000 0.250000 0.250000 1.0000,
-         Si   0.250000 0.750000 0.750000 1.0000,
-         Si   0.750000 0.750000 0.250000 1.0000]
-        """
-        if self.space_group is None:
-            raise ValueError("Space group must be set")
-
-        # Ensure atom positions are expressed in diffpy's convention
-        diffpy_structure = self.structure.copy()
-        diffpy_structure.placeInLattice(Lattice(base=self._diffpy_lattice))
-        xyz = diffpy_structure.xyz
-        diffpy_structure.clear()
-
-        eau = ExpandAsymmetricUnit(self.space_group, xyz)
-        for atom, new_positions in zip(self.structure, eau.expandedpos):
-            for pos in new_positions:
-                new_atom = copy.deepcopy(atom)
-                new_atom.xyz = pos
-                # Only add new atom if not already present
-                for present_atom in diffpy_structure:
-                    if present_atom.element == new_atom.element and np.allclose(
-                        present_atom.xyz, new_atom.xyz
-                    ):
-                        break
-                else:
-                    diffpy_structure.append(new_atom)
-
-        # This handles conversion back to correct alignment
-        expanded_phase = self.__class__(self)
-        expanded_phase.structure = diffpy_structure
-
-        return expanded_phase
+from orix.crystal_map._phase import Phase
+from orix.plot._util.color import get_named_matplotlib_colors
+from orix.quaternion.symmetry import Symmetry
 
 
 class PhaseList:
@@ -594,7 +194,8 @@ class PhaseList:
                 ids = list(np.arange(max_entries))
 
             # Get first 2 * n entries in color list (for good measure)
-            all_colors = list(islice(ALL_COLORS.keys(), 2 * max_entries))[::-1]
+            all_colors, _ = get_named_matplotlib_colors()
+            all_color_names = list(islice(all_colors.keys(), 2 * max_entries))[::-1]
 
             # Create phase dictionary
             d = {}
@@ -624,11 +225,11 @@ class PhaseList:
                     if colors[i] is not None:
                         color = colors[i]
                     else:
-                        color = all_colors.pop()
+                        color = all_color_names.pop()
                 except (IndexError, TypeError):
-                    color = all_colors.pop()
+                    color = all_color_names.pop()
                 while color in used_colors:
-                    color = all_colors.pop()
+                    color = all_color_names.pop()
 
                 # Get a phase_id (always)
                 try:
@@ -896,7 +497,8 @@ class PhaseList:
 
             # Ensure a new color
             if phase.color in self.colors:
-                for color_name in ALL_COLORS.keys():
+                all_colors, _ = get_named_matplotlib_colors()
+                for color_name in all_colors.keys():
                     if color_name not in self.colors:
                         phase.color = color_name
                         break
@@ -909,62 +511,3 @@ class PhaseList:
 
             # Finally, add the phase to the list
             self._dict[new_phase_id] = phase
-
-
-def _new_structure_matrix_from_alignment(
-    old_matrix: np.ndarray,
-    x: str | None = None,
-    y: str | None = None,
-    z: str | None = None,
-) -> np.ndarray:
-    """Return a new structure matrix given the old structure matrix and
-    at least two aligned axes x, y, or z.
-
-    The structure matrix defines the alignment of direct and reciprocal
-    lattice base vectors with the cartesian reference frame of the
-    crystal lattice defined by x, y, and z. x, y, and z are often termed
-    :math:`e_i`.
-
-    Parameters
-    ----------
-    old_matrix
-        Old structure matrix, i.e. the 3x3 matrix of row base vectors
-        expressed in Cartesian coordinates.
-    x, y, z
-        Which of the six axes "a", "b", "c", "a*", "b*", or "z*" are
-        aligned with the base vectors of the cartesian crystal reference
-        frame. At least two must be specified.
-
-    Returns
-    -------
-    new_matrix
-        New structure matrix according to the alignment.
-    """
-    if sum([i is None for i in [x, y, z]]) > 1:
-        raise ValueError("At least two of x, y, z must be set.")
-
-    # Old direct lattice base (row) vectors in Cartesian coordinates
-    old_matrix = Vector3d(old_matrix)
-    ad, bd, cd = old_matrix.unit
-
-    # Old reciprocal lattice base vectors in cartesian coordinates
-    ar = bd.cross(cd).unit
-    br = cd.cross(ad).unit
-    cr = ad.cross(bd).unit
-
-    # New unit crystal base
-    new_vectors = Vector3d.zero((3,))
-    axes_mapping = {"a": ad, "b": bd, "c": cd, "a*": ar, "b*": br, "c*": cr}
-    for i, al in enumerate([x, y, z]):
-        if al in axes_mapping.keys():
-            new_vectors[i] = axes_mapping[al]
-    other_idx = {0: (1, 2), 1: (2, 0), 2: (0, 1)}
-    for i in range(3):
-        if np.isclose(new_vectors[i].norm, 0):
-            other0, other1 = other_idx[i]
-            new_vectors[i] = new_vectors[other0].cross(new_vectors[other1])
-
-    # New crystal base
-    new_matrix = new_vectors.dot(old_matrix.reshape(3, 1)).round(12)
-
-    return new_matrix

--- a/orix/crystal_map/crystal_map.py
+++ b/orix/crystal_map/crystal_map.py
@@ -26,8 +26,10 @@ import matplotlib.figure as mfigure
 import matplotlib.pyplot as plt
 import numpy as np
 
+from orix.crystal_map._phase import Phase
+from orix.crystal_map._phase_list import PhaseList
 from orix.crystal_map.crystal_map_properties import CrystalMapProperties
-from orix.crystal_map.phase_list import ALL_COLORS, Phase, PhaseList
+from orix.plot._util.color import get_named_matplotlib_colors
 from orix.quaternion.orientation import Orientation
 from orix.quaternion.rotation import Rotation
 
@@ -284,7 +286,8 @@ class CrystalMap:
                 # Create new phase list adding the missing phases with
                 # default initial values (but unique colors)
                 phase_dict = {}
-                all_colors = list(ALL_COLORS.keys())
+                all_colors, _ = get_named_matplotlib_colors()
+                all_colors = list(all_colors.keys())
                 all_unique_colors = np.delete(
                     all_colors, np.isin(all_colors, phase_list.colors)
                 )

--- a/orix/crystal_map/phase_list.py
+++ b/orix/crystal_map/phase_list.py
@@ -117,12 +117,19 @@ class Phase:
                 name.structure.copy(),
                 name.color,
             )
-        self.structure = structure if structure is not None else Structure()
-        if name is not None:
-            self.name = name
         self.space_group = space_group  # Needs to be set before point group
         self.point_group = point_group
         self.color = color if color is not None else "tab:blue"
+        if structure is not None:
+            self.structure = structure
+        elif self.point_group is None:
+            self.structure = Structure()
+        elif np.isin(self.point_group.system, ["trigonal", "hexagonal"]):
+            self.structure = Structure(lattice=Lattice(1, 1, 1, 90, 90, 120))
+        else:
+            self.structure = Structure(lattice=Lattice(1, 1, 1, 90, 90, 90))
+        if name is not None:
+            self.name = name
 
     @property
     def structure(self) -> Structure:

--- a/orix/io/plugins/ang.py
+++ b/orix/io/plugins/ang.py
@@ -29,8 +29,8 @@ from diffpy.structure import Lattice, Structure
 import numpy as np
 
 from orix import __version__
+from orix.crystal_map._phase_list import PhaseList
 from orix.crystal_map.crystal_map import CrystalMap, create_coordinate_arrays
-from orix.crystal_map.phase_list import PhaseList
 from orix.quaternion.rotation import Rotation
 from orix.quaternion.symmetry import _EDAX_POINT_GROUP_ALIASES
 

--- a/orix/io/plugins/ctf.py
+++ b/orix/io/plugins/ctf.py
@@ -28,8 +28,8 @@ from typing import Any, Literal
 from diffpy.structure import Lattice, Structure
 import numpy as np
 
+from orix.crystal_map._phase_list import PhaseList
 from orix.crystal_map.crystal_map import CrystalMap, _data_slices_from_coordinates
-from orix.crystal_map.phase_list import PhaseList
 from orix.quaternion.rotation import Rotation
 
 __all__ = ["file_reader"]

--- a/orix/io/plugins/orix_hdf5.py
+++ b/orix/io/plugins/orix_hdf5.py
@@ -28,8 +28,9 @@ from diffpy.structure import Atom, Lattice, Structure
 from h5py import File, Group
 import numpy as np
 
+from orix.crystal_map._phase import Phase
+from orix.crystal_map._phase_list import PhaseList
 from orix.crystal_map.crystal_map import CrystalMap
-from orix.crystal_map.phase_list import Phase, PhaseList
 from orix.io.plugins._h5ebsd import hdf5group2dict
 from orix.quaternion.rotation import Rotation
 

--- a/orix/plot/__init__.pyi
+++ b/orix/plot/__init__.pyi
@@ -18,7 +18,7 @@
 #
 
 from ._plot import register_projections
-from ._util import format_labels
+from ._util.formatting import format_labels
 from .crystal_map_plot import CrystalMapPlot
 from .direction_color_keys import DirectionColorKeyTSL
 from .orientation_color_keys import EulerColorKey, IPFColorKeyTSL

--- a/orix/plot/_util/__init__.py
+++ b/orix/plot/_util/__init__.py
@@ -1,0 +1,20 @@
+#
+# Copyright 2018-2025 the orix developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""Private utilities used across the plotting module."""

--- a/orix/plot/_util/arrow_3d.py
+++ b/orix/plot/_util/arrow_3d.py
@@ -1,0 +1,39 @@
+#
+# Copyright 2018-2025 the orix developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix. If not, see <http://www.gnu.org/licenses/>.
+#
+from matplotlib.patches import FancyArrowPatch
+from mpl_toolkits.mplot3d import proj3d
+import numpy as np
+
+
+class Arrow3D(FancyArrowPatch):
+    """Matplotlib arrows in 3D with arrowheads.
+
+    Initially taken from this Stack Overflow answer by user CT Zhu
+    https://stackoverflow.com/a/22867877/12063126.
+    """
+
+    def __init__(self, xs, ys, zs, *args, **kwargs):
+        super().__init__((0, 0), (0, 0), *args, **kwargs)
+        self._verts3d = xs, ys, zs
+
+    def do_3d_projection(self, renderer=None):
+        xs3d, ys3d, zs3d = self._verts3d
+        xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)
+        self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
+        return np.min(zs)

--- a/orix/plot/_util/color.py
+++ b/orix/plot/_util/color.py
@@ -1,0 +1,66 @@
+#
+# Copyright 2018-2025 the orix developers
+#
+# This file is part of orix.
+#
+# orix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# orix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with orix. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""Private utilities for handling color in visualization."""
+
+from functools import cache
+
+import matplotlib.colors as mcolors
+
+
+def get_matplotlib_color(identifier: str) -> tuple[str, str]:
+    """Return a valid Matplotlib color by an identifier recognized by
+    :func:`~matplotlib.colors.is_color_like`.
+
+    Parameters
+    ----------
+    identifier
+        String identifying a color.
+
+    Returns
+    -------
+    name
+        Matplotlib color name.
+    hex_value
+        Hex color string.
+    """
+    hex_value = mcolors.to_hex(identifier)  # Raises if invalid
+    _, colors_reverse = get_named_matplotlib_colors()
+    name = colors_reverse[hex_value]
+    return name, hex_value
+
+
+@cache
+def get_named_matplotlib_colors() -> tuple[dict[str, str], dict[str, str]]:
+    """Return two dictionary mappings of most of Matplotlib's colors,
+    (name: hex) and its reverse, (hex: name).
+
+    The colors are gathered only once as the results are cached.
+    """
+    colors: dict[str, str] = mcolors.TABLEAU_COLORS
+    colors.update(mcolors.XKCD_COLORS)
+
+    # Tableau and xkcd already lower case hex
+    for d in [mcolors.BASE_COLORS, mcolors.CSS4_COLORS]:
+        for k, v in d.items():
+            colors[k] = mcolors.to_hex(v)
+
+    colors_reverse = {v: k for k, v in colors.items()}
+
+    return colors, colors_reverse

--- a/orix/plot/_util/formatting.py
+++ b/orix/plot/_util/formatting.py
@@ -17,32 +17,14 @@
 # along with orix. If not, see <http://www.gnu.org/licenses/>.
 #
 
-from matplotlib.patches import FancyArrowPatch
-from mpl_toolkits.mplot3d import proj3d
+"""Private utilities for formatting text and such in visualization."""
+
 import numpy as np
 
 
-class Arrow3D(FancyArrowPatch):
-    """Matplotlib arrows in 3D with arrowheads.
-
-    Initially taken from this Stack Overflow answer by user CT Zhu
-    https://stackoverflow.com/a/22867877/12063126.
-    """
-
-    def __init__(self, xs, ys, zs, *args, **kwargs) -> None:
-        super().__init__((0, 0), (0, 0), *args, **kwargs)
-        self._verts3d = xs, ys, zs
-
-    def do_3d_projection(self, renderer=None) -> np.ndarray:
-        xs3d, ys3d, zs3d = self._verts3d
-        xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)
-        self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
-        return np.min(zs)
-
-
 def format_labels(
-    v: list | tuple | np.ndarray,
-    brackets: tuple[str, str] = ("", ""),
+    v: np.ndarray | list | tuple,
+    brackets: tuple[str, str] | None = None,
     use_latex: bool = True,
 ) -> np.ndarray:
     r"""Return formatted vector integer labels.
@@ -55,15 +37,15 @@ def format_labels(
     Parameters
     ----------
     v
-        Vector labels in an array-like with the last dimension having a
-        size of 3 or 4. The labels are rounded to the closets integers
-        before being formatted.
+        Vector labels with the last dimension having a size of 3 or 4.
+        The labels are rounded to the closets integers before being
+        formatted.
     brackets
-        Left and right parentheses. These are typically () or [] when
-        labeling reciprocal (hkl) or direct [uvw] lattice vectors,
-        respectively. If not given, no parentheses are added. If
-        ``use_latex=True``, then the brackets {} and <> will be escaped
-        if given.
+        Left and right parentheses as a tuple of strings. Default is
+        ("(", ")"). These are typically () or [] when labeling
+        reciprocal (hkl) or direct [uvw] lattice vectors, respectively.
+        If not given, no parentheses are added. If *use_latex* is True,
+        the brackets {} and <> will be escaped if given.
     use_latex
         Whether to use LaTeX when formatting the labels. Default is
         True.
@@ -93,6 +75,9 @@ def format_labels(
      '$\\left<400\\right>$',
      '$\\left<\\bar{4}00\\right>$']
     """
+    if brackets is None:
+        brackets = ("", "")
+
     if use_latex:
         start = end = r"$"
         if brackets == ("<", ">"):
@@ -116,5 +101,6 @@ def format_labels(
                 new_label += str(i)
         new_label += brackets[1] + end
         new_labels.append(new_label)
+    new_labels = np.asarray(new_labels).reshape(shape[:-1])
 
-    return np.asarray(new_labels).reshape(shape[:-1])
+    return new_labels

--- a/orix/plot/_util/formatting.py
+++ b/orix/plot/_util/formatting.py
@@ -57,19 +57,19 @@ def format_labels(
 
     Examples
     --------
-    >>> from orix import plot
+    >>> from orix.plot import format_labels
     >>> from orix.vector import Vector3d
     >>> v = Vector3d([[1, 1, 1], [-2, 0, 1], [4, 0, 0], [-4, 0, 0]])
-    >>> plot.format_labels(v.reshape(2, 2).data)
+    >>> format_labels(v.reshape(2, 2).data)
     array([['$111$', '$\\bar{2}01$'],
            ['$400$', '$\\bar{4}00$']], dtype='<U11')
-    >>> plot.format_labels(v.data, ("[", "]"), use_latex=False).tolist()
+    >>> format_labels(v.data, ("[", "]"), use_latex=False).tolist()
     ['[111]', '[-201]', '[400]', '[-400]']
-    >>> plot.format_labels(v.data, ("{", "}")).tolist()
+    >>> format_labels(v.data, ("{", "}")).tolist()
     ['$\\{111\\}$', '$\\{\\bar{2}01\\}$', '$\\{400\\}$', '$\\{\\bar{4}00\\}$']
-    >>> plot.format_labels(v.data, ("{", "}"), use_latex=False).tolist()
+    >>> format_labels(v.data, ("{", "}"), use_latex=False).tolist()
     ['{111}', '{-201}', '{400}', '{-400}']
-    >>> plot.format_labels(v.data, ("<", ">")).tolist()
+    >>> format_labels(v.data, ("<", ">")).tolist()
     ['$\\left<111\\right>$',
      '$\\left<\\bar{2}01\\right>$',
      '$\\left<400\\right>$',

--- a/orix/plot/inverse_pole_figure_plot.py
+++ b/orix/plot/inverse_pole_figure_plot.py
@@ -476,9 +476,11 @@ def _get_ipf_axes_labels(vertices: Vector3d, symmetry: Symmetry) -> list[str]:
         List of strings, with -1 formatted like $\bar{1}$.
     """
     phase = Phase(point_group=symmetry)
-    m = Miller(uvw=vertices.data, phase=phase)
     if symmetry.system in ["trigonal", "hexagonal"]:
+        m = Miller(xyz=vertices.data, phase=phase)
         m.coordinate_format = "UVTW"
+    else:
+        m = Miller(uvw=vertices.data, phase=phase)
     axes = m.round(max_index=2).coordinates.astype(int)
 
     labels = []

--- a/orix/plot/inverse_pole_figure_plot.py
+++ b/orix/plot/inverse_pole_figure_plot.py
@@ -32,7 +32,6 @@ import matplotlib.projections as mprojections
 import matplotlib.pyplot as plt
 import numpy as np
 
-from orix.crystal_map.phase_list import Phase
 from orix.measure.pole_density_function import pole_density_function
 from orix.plot.direction_color_keys.direction_color_key_tsl import DirectionColorKeyTSL
 from orix.plot.stereographic_plot import ZORDER, StereographicPlot
@@ -475,6 +474,9 @@ def _get_ipf_axes_labels(vertices: Vector3d, symmetry: Symmetry) -> list[str]:
     list of str
         List of strings, with -1 formatted like $\bar{1}$.
     """
+    # Import here to avoid circular import
+    from orix.crystal_map._phase import Phase
+
     phase = Phase(point_group=symmetry)
     if symmetry.system in ["trigonal", "hexagonal"]:
         m = Miller(xyz=vertices.data, phase=phase)

--- a/orix/plot/inverse_pole_figure_plot.py
+++ b/orix/plot/inverse_pole_figure_plot.py
@@ -478,11 +478,9 @@ def _get_ipf_axes_labels(vertices: Vector3d, symmetry: Symmetry) -> list[str]:
     from orix.crystal_map._phase import Phase
 
     phase = Phase(point_group=symmetry)
+    m = Miller(xyz=vertices.data, phase=phase)
     if symmetry.system in ["trigonal", "hexagonal"]:
-        m = Miller(xyz=vertices.data, phase=phase)
         m.coordinate_format = "UVTW"
-    else:
-        m = Miller(uvw=vertices.data, phase=phase)
     axes = m.round(max_index=2).coordinates.astype(int)
 
     labels = []

--- a/orix/plot/unit_cell_plot.py
+++ b/orix/plot/unit_cell_plot.py
@@ -29,7 +29,7 @@ import matplotlib.figure as mfigure
 import matplotlib.pyplot as plt
 import numpy as np
 
-from orix.plot._util import Arrow3D
+from orix.plot._util.arrow_3d import Arrow3D
 from orix.vector.vector3d import Vector3d
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -27,8 +27,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
+from orix.crystal_map._phase import Phase
+from orix.crystal_map._phase_list import PhaseList
 from orix.crystal_map.crystal_map import CrystalMap, create_coordinate_arrays
-from orix.crystal_map.phase_list import Phase, PhaseList
 from orix.quaternion.rotation import Rotation
 
 # --------------------------- pytest hooks --------------------------- #

--- a/orix/tests/test_crystal_map/test_crystal_map.py
+++ b/orix/tests/test_crystal_map/test_crystal_map.py
@@ -970,9 +970,9 @@ class TestCrystalMapRepresentation:
         # fmt: off
         assert repr(xmap) == (
             "Phase  Orientations  Name  Space group  Point group  Proper point group  Color\n"
-            "    0    10 (83.3%)     a        Im-3m         m-3m                 432      r\n"
-            "    1      1 (8.3%)     b         P432          432                 432      g\n"
-            "    2      1 (8.3%)     c           P3            3                   3      b\n"
+            "    0    10 (83.3%)     a        Im-3m         m-3m                 432    red\n"
+            "    1      1 (8.3%)     b         P432          432                 432  green\n"
+            "    2      1 (8.3%)     c           P3            3                   3   blue\n"
             "Properties: iq\n"
             "Scan unit: nm"
         )

--- a/orix/tests/test_crystal_map/test_phase_list.py
+++ b/orix/tests/test_crystal_map/test_phase_list.py
@@ -117,7 +117,7 @@ class TestPhaseList:
                 ["al", ""],
                 ["F4132", "Fm-3m"],
                 ["432", "m-3m"],
-                ["r", "tab:blue"],
+                ["red", "tab:blue"],
                 [100, 101],
             ),
             (
@@ -129,7 +129,7 @@ class TestPhaseList:
                 ["", ""],
                 [None, None],
                 [None, None],
-                ["g", "k"],
+                ["green", "black"],
                 [1, 2],
             ),
             (
@@ -197,8 +197,10 @@ class TestPhaseList:
     def test_get_phaselist_colors_rgb(self):
         pl = PhaseList(names=["a", "b", "c"], colors=["r", "g", (0, 0, 1)])
 
-        assert pl.colors == ["r", "g", "b"]
-        assert np.allclose(pl.colors_rgb, [(1.0, 0.0, 0.0), [0, 0.5, 0], (0, 0, 1)])
+        assert pl.colors == ["red", "green", "blue"]
+        assert np.allclose(
+            pl.colors_rgb, [(1.0, 0.0, 0.0), [0, 0.5020, 0], (0, 0, 1)], atol=1e-4
+        )
 
     @pytest.mark.parametrize("n_names", [1, 3])
     def test_get_phaselist_size(self, n_names):
@@ -234,9 +236,9 @@ class TestPhaseList:
             "desired_proper_point_group, desired_color"
         ),
         [
-            (0, "a", "Im-3m", "m-3m", "432", "r"),
-            ("b", "b", "P432", "432", "432", "g"),
-            (slice(2, None, None), "c", "P3", "3", "3", "b"),  # equivalent to pl[2:]
+            (0, "a", "Im-3m", "m-3m", "432", "red"),
+            ("b", "b", "P432", "432", "432", "green"),
+            (slice(2, None, None), "c", "P3", "3", "3", "blue"),  # equivalent to pl[2:]
         ],
     )
     def test_get_phase_from_phaselist(
@@ -264,12 +266,12 @@ class TestPhaseList:
                 slice(0, None, None),
                 ["a", "b", "c"],
                 ["m-3m", "432", "3"],
-                ["r", "g", "b"],
+                ["red", "green", "blue"],
             ),
-            (("a", "b"), ["a", "b"], ["m-3m", "432"], ["r", "g"]),
-            (["a", "b"], ["a", "b"], ["m-3m", "432"], ["r", "g"]),
-            ((0, 2), ["a", "c"], ["m-3m", "3"], ["r", "b"]),
-            ([0, 2], ["a", "c"], ["m-3m", "3"], ["r", "b"]),
+            (("a", "b"), ["a", "b"], ["m-3m", "432"], ["red", "green"]),
+            (["a", "b"], ["a", "b"], ["m-3m", "432"], ["red", "green"]),
+            ((0, 2), ["a", "c"], ["m-3m", "3"], ["red", "blue"]),
+            ([0, 2], ["a", "c"], ["m-3m", "3"], ["red", "blue"]),
         ],
     )
     def test_get_phases_from_phaselist(
@@ -391,7 +393,7 @@ class TestPhaseList:
     def test_iterate_phaselist(self):
         names = ["al", "ni", "sigma"]
         point_groups = [3, 432, "m-3m"]
-        colors = ["g", "b", "r"]
+        colors = ["green", "blue", "red"]
         structures = [
             Structure(),
             Structure(lattice=Lattice(1, 2, 3, 90, 90, 90)),
@@ -420,11 +422,11 @@ class TestPhaseList:
         assert pl2.names == names
 
         phase_list.add(Phase("d", point_group="m-3m"))
-        phase_list["d"].color = "g"
+        phase_list["d"].color = "green"
 
         assert phase_list.names == names + ["d"]
         assert [s.name for s in phase_list.point_groups] == point_groups + ["m-3m"]
-        assert phase_list.colors == colors + ["g"]
+        assert phase_list.colors == colors + ["green"]
 
         assert pl2.names == names
         assert [s.name for s in pl2.point_groups] == point_groups
@@ -443,7 +445,7 @@ class TestPhaseList:
 
     def test_make_not_indexed(self):
         phase_names = ["a", "b", "c"]
-        phase_colors = ["r", "g", "b"]
+        phase_colors = ["red", "green", "blue"]
         pl = PhaseList(names=phase_names, colors=phase_colors, ids=[-1, 0, 1])
 
         assert pl.names == phase_names
@@ -452,7 +454,7 @@ class TestPhaseList:
         pl.add_not_indexed()
 
         phase_names[0] = "not_indexed"
-        phase_colors[0] = "w"
+        phase_colors[0] = "white"
         assert pl.names == phase_names
         assert pl.colors == phase_colors
 

--- a/orix/tests/test_plot/test_direction_color_keys.py
+++ b/orix/tests/test_plot/test_direction_color_keys.py
@@ -40,46 +40,59 @@ class TestDirectionColorKeyTSL:
         assert rgb2[0].size == rgb2[1].size == 0
 
     @pytest.mark.parametrize(
-        "symmetry, expected_shape",
+        "symmetry, expected_shape, expected_xy_lims, expected_labels",
         [
-            [symmetry.C1, (2000, 2000, 4)],
-            [symmetry.C2, (1000, 2000, 4)],
-            [symmetry.D6, (500, 1000, 4)],
-            [symmetry.Oh, (367, 415, 4)],
-            [symmetry.Th, (415, 415, 4)],
+            [symmetry.C1, (2000, 2000, 4), [(-1.0, 1.0), (-1.0, 1.0)], ""],
+            [symmetry.Ci, (2000, 2000, 4), [(-1.0, 1.0), (-1.0, 1.0)], ""],
+            [
+                symmetry.C2,
+                (1000, 2000, 4),
+                [(-1.0, 1.0), (0.0, 1.0)],
+                "[$1 0 0$][$\\bar{1} 0 0$]",
+            ],
+            [
+                symmetry.S6,
+                (1000, 1500, 4),
+                [(-0.5, 1.0), (0, 1.0)],
+                "[$2 \\bar{1} \\bar{1} 0$][$0 0 0 1$][$\\bar{1} 2 \\bar{1} 0$]",
+            ],
+            [
+                symmetry.D6,
+                (500, 1000, 4),
+                [(0.0, 1.0), (0.0, 0.5)],
+                "[$2 \\bar{1} \\bar{1} 0$][$0 0 0 1$][$1 0 \\bar{1} 0$]",
+            ],
+            [
+                symmetry.Oh,
+                (367, 415, 4),
+                [(0.0, 0.414), (0.0, 0.366)],
+                "[$1 1 1$][$1 0 1$][$0 0 1$]",
+            ],
+            [
+                symmetry.Th,
+                (415, 415, 4),
+                [(0.0, 0.414), (0.0, 0.414)],
+                "[$0 1 1$][$1 1 1$][$1 0 1$][$0 0 1$]",
+            ],
         ],
     )
     @pytest.mark.slow
-    def test_rgba_grid_shape(self, symmetry, expected_shape):
+    def test_rgba_grid(
+        self, symmetry, expected_shape, expected_xy_lims, expected_labels
+    ):
         ckey = IPFColorKeyTSL(symmetry)
-        ckey_direction = ckey.direction_color_key
-        rgb_grid = ckey_direction._create_rgba_grid()
+        ckey_dcc = ckey.direction_color_key
+        rgb_grid, (xlim, ylim) = ckey_dcc._create_rgba_grid(return_extent=True)
+        (x_min, x_max), (y_min, y_max) = xlim, ylim
+        ax = ckey_dcc.plot(True).get_axes()[0]
+        labels = "".join([x.get_text() for x in ax.texts])
         assert isinstance(rgb_grid, np.ndarray)
         assert rgb_grid.shape == expected_shape
-
-    @pytest.mark.parametrize(
-        "symmetry, expected_xlim, expected_ylim",
-        [
-            [symmetry.C1, (-1.0, 1.0), (-1.0, 1.0)],
-            [symmetry.C2, (-1.0, 1.0), (0.0, 1.0)],
-            [symmetry.D6, (0.0, 1.0), (0.0, 0.5)],
-            [symmetry.Oh, (0.0, 0.414), (0.0, 0.366)],
-            [symmetry.Th, (0.0, 0.414), (0.0, 0.414)],
-        ],
-    )
-    @pytest.mark.slow
-    def test_rgba_grid_limits(self, symmetry, expected_xlim, expected_ylim):
-        ckey = IPFColorKeyTSL(symmetry)
-        ckey_direction = ckey.direction_color_key
-        (
-            _,
-            (x_lim, y_lim),
-        ) = ckey_direction._create_rgba_grid(return_extent=True)
-        (x_min, x_max), (y_min, y_max) = x_lim, y_lim
-        assert round(x_min, 3) == round(expected_xlim[0], 3)
-        assert round(x_max, 3) == round(expected_xlim[1], 3)
-        assert round(y_min, 3) == round(expected_ylim[0], 3)
-        assert round(y_max, 3) == round(expected_ylim[1], 3)
+        assert round(x_min, 3) == round(expected_xy_lims[0][0], 3)
+        assert round(x_max, 3) == round(expected_xy_lims[0][1], 3)
+        assert round(y_min, 3) == round(expected_xy_lims[1][0], 3)
+        assert round(y_max, 3) == round(expected_xy_lims[1][1], 3)
+        assert labels == expected_labels
 
     @pytest.mark.parametrize(
         "symmetry",

--- a/orix/tests/test_plot/test_unit_cell_plot.py
+++ b/orix/tests/test_plot/test_unit_cell_plot.py
@@ -22,7 +22,7 @@ from matplotlib import pyplot as plt
 import numpy as np
 import pytest
 
-from orix.plot._util import Arrow3D
+from orix.plot._util.arrow_3d import Arrow3D
 from orix.plot.unit_cell_plot import (
     _calculate_basic_unit_cell_edges,
     _calculate_basic_unit_cell_vertices,

--- a/orix/vector/fundamental_sector.py
+++ b/orix/vector/fundamental_sector.py
@@ -147,9 +147,9 @@ def _closed_edges_in_hemisphere(
     edges: Vector3d, sector: FundamentalSector, pole: int = -1
 ) -> Vector3d:
     if pole == -1:
-        is_outside = edges.polar >= np.pi / 2
+        is_outside = edges.polar >= np.pi / 2 + 1e-6
     else:  # pole == 1
-        is_outside = edges.polar <= np.pi / 2
+        is_outside = edges.polar <= np.pi / 2 + 1e-6
 
     if not np.any(is_outside):
         return edges

--- a/orix/vector/miller.py
+++ b/orix/vector/miller.py
@@ -29,7 +29,7 @@ import numpy as np
 from orix.vector.vector3d import Vector3d
 
 if TYPE_CHECKING:  # pragma: no cover
-    from orix.crystal_map.phase_list import Phase
+    from orix.crystal_map._phase import Phase
     from orix.quaternion.symmetry import Symmetry
 
 


### PR DESCRIPTION
#### Description of the change
This PR includes the fix in #591 but has additional commits. It's meant to replace #591.

See below for API changes.

Further internal improvements:
- Separate phase and phase list files for clearer separation of concerns
- Improves structure of plot utilities
- Changing from color dictionary constants to a cached function with a clearer description

@argerlt, I already had these changes and a few more in a branch, https://github.com/hakonanes/orix/tree/566-phase-symmetry-immutable, in my fork that I didn't get to push... That's why I took the liberty to build upon your PR.

#### Progress of the PR
- [ ] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [ ] Unit tests with pytest for all lines
- [ ] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### Minimal example of the bug fix or new feature
The fixes made by @argerlt in #591:

```python
>>> import orix.crystal_map as ocm
>>> import orix.plot as opl
>>> phase3 = ocm.Phase(point_group="-3")
>>> ckey3 = opl.IPFColorKeyTSL(phase3.point_group)
>>> ckey3.plot()
```

<img width="609" height="416" alt="ckey3" src="https://github.com/user-attachments/assets/8463454f-f76e-45be-b4f2-77bd6eace6ab" />

```python
>>> phase6m = ocm.Phase(point_group="6/m")
>>> ckey6m = opl.IPFColorKeyTSL(phase6m.point_group)
>>> ckey6m.plot()
```

<img width="520" height="449" alt="ckey6m" src="https://github.com/user-attachments/assets/eda2d673-382f-41ea-83ad-e71de00b913f" />

And not giving brackets is now allowed:

```python
>>> import orix.plot as opl
>>> opl.format_labels([1, 1, 1])
array('$111$', dtype='<U5')
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.