### PR TITLE
readthedocs_hotfix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ All user facing changes to this project are documented in this file. The format 
 on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`__, and this project tries
 its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`__.
 
+2025-12-10 - version 0.14.1
+===========================
+
+Fixed
+-----
+- Documentation build now passes again.
+
+
 2025-12-09 - version 0.14.0
 ===========================
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -31,7 +31,7 @@ Preparation
   work as expected, a release candidate with version e.g. "0.9.1rc1" can be made. Update
   ``CHANGELOG.rst`` accordingly.
 
-- For minor releases, remove deprecated functionality. For details on how depreciations
+- For minor releases, remove deprecated functionality. For details on how deprecations
   are handled, see ``orix/doc/dev/handling_deprecations.rst``.
 
 - Make a PR of the release branch to ``main``. Discuss the release and changelog with

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -31,8 +31,8 @@ Preparation
   work as expected, a release candidate with version e.g. "0.9.1rc1" can be made. Update
   ``CHANGELOG.rst`` accordingly.
 
-- For minor releases, remove any deprecated functionality as described in
-  ``orix/doc/dev/handling_deprecations.rst``.
+- For minor releases, remove deprecated functionality. For details on how depreciations
+  are handled, see ``orix/doc/dev/handling_deprecations.rst``.
 
 - Make a PR of the release branch to ``main``. Discuss the release and changelog with
   others. Merge.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -29,7 +29,9 @@ Preparation
   patch release. If downstream packages should test their use of the next version of
   orix in CI before it is released, or we want to ensure that the below release steps
   work as expected, a release candidate with version e.g. "0.9.1rc1" can be made. Update
-  ``CHANGELOG.rst`` accordingly. Remove any deprecated functionality as described in 
+  ``CHANGELOG.rst`` accordingly.
+
+- For minor releases, remove any deprecated functionality as described in
   ``orix/doc/dev/handling_deprecations.rst``.
 
 - Make a PR of the release branch to ``main``. Discuss the release and changelog with

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -85,7 +85,7 @@ intersphinx_mapping = {
     "pytest": ("https://docs.pytest.org/en/stable", None),
     "pytest-xdist": ("https://pytest-xdist.readthedocs.io/en/stable", None),
     "python": ("https://docs.python.org/3", None),
-    "pyxem": ("https://pyxem.org/en/latest", None),
+    "pyxem": ("https://www.pyxem.org/en/latest", None),
     "readthedocs": ("https://docs.readthedocs.com/platform/stable", None),
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
     "sklearn": ("https://scikit-learn.org/stable", None),

--- a/doc/tutorials/point_groups.ipynb
+++ b/doc/tutorials/point_groups.ipynb
@@ -68,7 +68,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "$(\\mathbf{e_1}, \\mathbf{e_2}, \\mathbf{e_3})$ are the unit vectors of the standard Cartesian (orthonormal) reference frame (see the [crystal reference frame tutorial](../tutorials/crystal_reference_frame.ipynb) for more details).\n",
+    "$(\\mathbf{e_1}, \\mathbf{e_2}, \\mathbf{e_3})$ are the unit vectors of the standard Cartesian (orthonormal) reference frame (see the [crystal reference frame example](../examples/crystal_phase/crystal_reference_frame.py) for more details).\n",
     "\n",
     "The stereographic projection of all point groups is shown below:"
    ]
@@ -142,8 +142,8 @@
    "hash": "4396f389b93e7269692bd3bea4c62813bbe379469bde939b058805f538feec11"
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
+   "display_name": "Python 3 (Spyder)",
+   "language": "python3",
    "name": "python3"
   },
   "language_info": {
@@ -156,7 +156,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.13.10"
   }
  },
  "nbformat": 4,

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -17,7 +17,7 @@
 # along with orix. If not, see <http://www.gnu.org/licenses/>.
 #
 
-__version__ = "0.14.0"
+__version__ = "0.14.1"
 
 # Sorted by line contributions (ideally excluding lines in notebook
 # files)

--- a/orix/io/__init__.pyi
+++ b/orix/io/__init__.pyi
@@ -17,12 +17,10 @@
 # along with orix. If not, see <http://www.gnu.org/licenses/>.
 #
 
-from ._io import load, loadang, loadctf, save
+from ._io import load, save
 
 # Lazily imported in module init
 __all__ = [
-    "loadang",
-    "loadctf",
     "load",
     "save",
 ]


### PR DESCRIPTION
copied from #609:

- remove lazy_loader references to depreciated functions.
 - update pyxem web address to avoid stalling when fetching object.inv.
-   Remove defunct links in point_groups.ipynb.


#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.