### PR TITLE
v0.14.2 patch release, removing RTD PDF build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,15 +34,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: psf/black@stable
-
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-
-      - uses: isort/isort-action@master
-        with:
-          configuration: --profile black --filter-files --force-sort-within-sections --check-only --diff
 
       - name: Install Black with Jupyter extension
         run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ All user facing changes to this project are documented in this file. The format 
 on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`__, and this project tries
 its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`__.
 
-2025-12-10 - version 0.14.1
+2025-12-10 - version 0.14.2
 ===========================
 
 Changed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ All user facing changes to this project are documented in this file. The format 
 on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`__, and this project tries
 its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`__.
 
-2025-12-10 - version 0.14.2
+2026-01-12 - version 0.14.2
 ===========================
 
 Changed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,17 @@ its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>
 2025-12-10 - version 0.14.1
 ===========================
 
+Changed
+-----
+- The PDF version of the ORIX documentation is no longer automatically built by
+  ReadtheDocs.
+- :class: Arrow3D class is no longer a private class, and is accessible as 
+  ``orix.plot.Arrow3d``.
+
+
+2025-12-10 - version 0.14.1
+===========================
+
 Fixed
 -----
 - Documentation build now passes again.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ All user facing changes to this project are documented in this file. The format 
 on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`__, and this project tries
 its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`__.
 
-2026-01-12 - version 0.14.2
+2026-02-03 - version 0.14.2
 ===========================
 
 Changed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,8 +13,6 @@ Changed
 -----
 - The PDF version of the ORIX documentation is no longer automatically built by
   ReadtheDocs.
-- :class: Arrow3D class is no longer a private class, and is accessible as 
-  ``orix.plot.Arrow3d``.
 
 
 2025-12-10 - version 0.14.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,8 +11,7 @@ its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>
 
 Changed
 -----
-- The PDF version of the ORIX documentation is no longer automatically built by
-  ReadtheDocs.
+- The PDF version of the documentation is no longer available from ReadTheDocs.
 
 
 2025-12-10 - version 0.14.1

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -177,12 +177,6 @@ nbsphinx_prolog = (
         }
       </script>
     </div>
-
-.. raw:: latex
-
-    \nbsphinxstartnotebook{\scriptsize\noindent\strut
-    \textcolor{gray}{The following section was generated from
-    \sphinxcode{\sphinxupquote{\strut {{ docname | escape_latex }}}} \dotfill}}
 """
 )
 # https://nbsphinx.readthedocs.io/en/0.8.0/never-execute.html

--- a/orix/plot/__init__.pyi
+++ b/orix/plot/__init__.pyi
@@ -18,8 +18,8 @@
 #
 
 from ._plot import register_projections
-from ._util.formatting import format_labels
 from ._util.arrow_3d import Arrow3D
+from ._util.formatting import format_labels
 from .crystal_map_plot import CrystalMapPlot
 from .direction_color_keys import DirectionColorKeyTSL
 from .orientation_color_keys import EulerColorKey, IPFColorKeyTSL

--- a/orix/plot/__init__.pyi
+++ b/orix/plot/__init__.pyi
@@ -19,6 +19,7 @@
 
 from ._plot import register_projections
 from ._util.formatting import format_labels
+from ._util.arrow_3d import Arrow3D
 from .crystal_map_plot import CrystalMapPlot
 from .direction_color_keys import DirectionColorKeyTSL
 from .orientation_color_keys import EulerColorKey, IPFColorKeyTSL
@@ -48,5 +49,6 @@ __all__ = [
     "StereographicPlot",
     # Functions
     "format_labels",
+    "Arrow3D",
     "register_projections",
 ]

--- a/orix/plot/__init__.pyi
+++ b/orix/plot/__init__.pyi
@@ -18,7 +18,6 @@
 #
 
 from ._plot import register_projections
-from ._util.arrow_3d import Arrow3D
 from ._util.formatting import format_labels
 from .crystal_map_plot import CrystalMapPlot
 from .direction_color_keys import DirectionColorKeyTSL
@@ -49,6 +48,5 @@ __all__ = [
     "StereographicPlot",
     # Functions
     "format_labels",
-    "Arrow3D",
     "register_projections",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
     "numba",
     "numpy",
     "pooch                  >= 0.13",
+    # TODO: Remove once diffpy.structure >= 3.2.1
+    "pycifrw",
     "scipy",
     "tqdm",
 ]
@@ -62,7 +64,7 @@ doc = [
 tests = [
     "numpydoc",
     "pytest                         >= 5.4",
-    "pytest-rerunfailures",
+    "pytest-rerunfailures           != 16.0",
     "pytest-xdist",
 ]
 coverage = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,6 @@ dependencies = [
     "numba",
     "numpy",
     "pooch                  >= 0.13",
-    # TODO: Remove once diffpy.structure >= 3.2.1
-    "pycifrw",
     "scipy",
     "tqdm",
 ]
@@ -64,9 +62,7 @@ doc = [
 tests = [
     "numpydoc",
     "pytest                         >= 5.4",
-    # TODO: Remove restriction once a new release fixing
-    # https://github.com/pytest-dev/pytest-rerunfailures/issues/302 is available.
-    "pytest-rerunfailures           < 16.0",
+    "pytest-rerunfailures",
     "pytest-xdist",
 ]
 coverage = [

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -39,7 +39,6 @@ build:
 # Doc formats
 formats:
   - htmlzip
-  - pdf
 
 conda:
   environment: doc/environment.yml


### PR DESCRIPTION
I plan on leaving this open for a bit as additional potential downstream pipeline problems are reported, but this includes optional solutions to address #611, #613, and #616

~~1) (optional) make Arrow3D a public facing class~~ (removed, based on discussion in [kikuchipy](https://github.com/pyxem/kikuchipy/pull/765))
2) Remove the pdf build in ReadtheDocs
~~3) remove dependency on pycifrw and version restriction from pytest-rerunfailures, as the bugs necessitating both have been patched.~~

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [x] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [x] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.