### PR TITLE
Numpy-like flattening

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Added
 
 Changed
 -------
+ - :func:`~orix/_base.py/Object3D.flatten()` supports column-major (current default)
+  and row-major (future default) flattening, similar to numpy.flatten().
 
 Removed
 -------

--- a/orix/_base.py
+++ b/orix/_base.py
@@ -21,7 +21,8 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
+import warnings
 
 import numpy as np
 
@@ -204,11 +205,37 @@ class Object3d:
 
     # --------------------- Other public methods --------------------- #
 
-    def flatten(self) -> Object3d:
-        """Return a new object with the same data in a single column."""
-        obj = self.__class__(self.data.T.reshape(self.dim, -1).T)
-        real_dim = self._data.shape[-1]
-        obj._data = self._data.T.reshape(real_dim, -1).T
+    # TODO: make "None" default to "C" in version 0.16.
+    def flatten(self, order: Literal["F", "C"] | None = None) -> Object3d:
+        """Return a new object with the same data in a single column.
+
+        Parameters
+        ----------
+        order: 'F' or 'C', optional
+            ‘C’ means to flatten in row-major (C-style) order. ‘F’
+            means to flatten in column-major (Fortran- style) order.
+            The default is ‘F’.
+
+        Notes
+        -----
+        For historical reasons, the current default is 'F'. This will
+        change to 'C' in orix 0.16, in order to match numpy.flatten().
+        """
+        if order == None:
+            warnings.warn(
+                DeprecationWarning(
+                    "The default flattening order for orix objects will "
+                    + "change from column-major (fortran style) to row-major "
+                    + "(numpy/C style) in orix 0.16. Setting 'order' to either "
+                    + "'C' for numpy or 'F' for fortran will silence this warning."
+                )
+            )
+        if order == "C":
+            obj = self.__class__(self.data.reshape(self.size, self.dim))
+        else:
+            obj = self.__class__(self.data.T.reshape(self.dim, -1).T)
+            real_dim = self._data.shape[-1]
+            obj._data = self._data.T.reshape(real_dim, -1).T
         return obj
 
     def unique(

--- a/orix/_utils/deprecation.py
+++ b/orix/_utils/deprecation.py
@@ -33,7 +33,7 @@ class deprecated:
 
     Adapted from
     `scikit-image
-    <https://github.com/scikit-image/scikit-image/blob/main/skimage/_shared/utils.py#L297>`_
+    <https://github.com/scikit-image/scikit-image/blob/b118e596933885c83fbe26145a74c3cc34a5d422/src/skimage/_shared/utils.py#L207>
     and `matplotlib
     <https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/_api/deprecation.py#L122>`_.
     """

--- a/orix/tests/test_base/test_object3d.py
+++ b/orix/tests/test_base/test_object3d.py
@@ -17,6 +17,8 @@
 # along with orix. If not, see <http://www.gnu.org/licenses/>.
 #
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -178,10 +180,20 @@ def test_stack(object3d, n):
 
 
 def test_flatten(object3d):
-    flat = object3d.flatten()
-    assert isinstance(flat, object3d.__class__)
-    assert flat.ndim == 1
-    assert flat.shape[0] == object3d.size
+    with warnings.catch_warnings(record=True) as w:
+        flat_C = object3d.flatten("C")
+        flat_F = object3d.flatten("F")
+        assert isinstance(flat_C, object3d.__class__)
+        assert flat_C.ndim == 1
+        assert flat_F.ndim == 1
+        assert flat_C.shape[0] == object3d.size
+        assert flat_F.shape[0] == object3d.size
+        assert len(w) == 0
+        flat_None = object3d.flatten()
+        assert flat_None.ndim == 1
+        assert flat_None.shape[0] == object3d.size
+        assert len(w) == 1
+        assert "0.16" in str(w[0].message)
 
 
 @pytest.mark.parametrize("test_object3d", [1], indirect=["test_object3d"])

--- a/orix/tests/test_quaternion/test_rotation.py
+++ b/orix/tests/test_quaternion/test_rotation.py
@@ -608,10 +608,10 @@ class TestToFromScipyRotation:
             warnings.simplefilter("always")
             rot.to_scipy_rotation()
             # check this threw a warning
-            assert len(w) == 1
+            assert len(w) >= 1
             # check the warning thrown included words from the custom warning
             # message for converting Nd orix arrays to 1d scipy rotations.
-            assert "greater than" in str(w[-1].message)
+            assert "greater than" in str(w[0].message)
 
 
 class TestFromAlignVectors:


### PR DESCRIPTION
**Note: force-pushed on April 9th to remove unnecessary reformatting.**

Working but unfinished answer to #595. Implementation is complete, docstrings still need fixing though, and this causes pytest to raise 191258 warnings. This is to be expected, but I want to slim that number down before merging.

#### Progress of the PR
- [] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [] Unit tests with pytest for all lines
- [] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### Minimal example of the bug fix or new feature

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.