### PR TITLE
Add Elasticipy to related projects list

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -61,7 +61,7 @@
       "orcid": "0000-0003-0465-504X"
     },
     {
-      "name": "Dorian Deprestier",
+      "name": "Dorian Depriester",
       "orcid": "0000-0002-2881-8942",
       "affiliation": "Arts et Métiers Institute of Technology"
     },

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -52,13 +52,18 @@
       "name": "Simon Høgås"
     },
     {
+      "name": "Ondrej Lexa",
+      "orcid": "0000-0003-4616-9154",
+      "affiliation": "Charles University, Prague"
+    },
+    {
       "name": "Alessandra da Silva",
       "orcid": "0000-0003-0465-504X"
     },
     {
-      "name": "Ondrej Lexa",
-      "orcid": "0000-0003-4616-9154",
-      "affiliation": "Charles University, Prague"
+      "name": "Dorian Deprestier",
+      "orcid": "0000-0002-2881-8942",
+      "affiliation": "Arts et Métiers Institute of Technology"
     },
     {
       "name": "Eric Prestat"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2025 the orix developers
+# Copyright 2018-2026 the orix developers
 #
 # This file is part of orix.
 #
@@ -73,6 +73,7 @@ intersphinx_mapping = {
     "defdap": ("https://defdap.readthedocs.io/en/latest", None),
     "diffpy.structure": ("https://www.diffpy.org/diffpy.structure", None),
     "diffsims": ("https://diffsims.readthedocs.io/en/latest", None),
+    "elasticipy": ("https://elasticipy.readthedocs.io/en/latest", None),
     "h5py": ("https://docs.h5py.org/en/stable", None),
     "kikuchipy": ("https://kikuchipy.org/en/latest", None),
     "matplotlib": ("https://matplotlib.org/stable", None),

--- a/doc/tutorials/clustering_misorientations.ipynb
+++ b/doc/tutorials/clustering_misorientations.ipynb
@@ -43,7 +43,6 @@
     "from orix.quaternion.symmetry import D6\n",
     "from orix.vector import Vector3d\n",
     "\n",
-    "\n",
     "plt.rcParams.update({\"font.size\": 20, \"figure.figsize\": (10, 10)})\n",
     "\n",
     "register_projections()"

--- a/doc/tutorials/clustering_orientations.ipynb
+++ b/doc/tutorials/clustering_orientations.ipynb
@@ -46,7 +46,6 @@
     "from orix.quaternion.symmetry import D6\n",
     "from orix.vector import AxAngle, Vector3d\n",
     "\n",
-    "\n",
     "plt.rcParams.update(\n",
     "    {\"font.size\": 20, \"figure.figsize\": (10, 10), \"figure.facecolor\": \"w\"}\n",
     ")"

--- a/doc/tutorials/crystal_directions.ipynb
+++ b/doc/tutorials/crystal_directions.ipynb
@@ -42,7 +42,6 @@
     "from orix.quaternion import Orientation, Rotation, symmetry\n",
     "from orix.vector import Miller, Vector3d\n",
     "\n",
-    "\n",
     "plt.rcParams.update(\n",
     "    {\n",
     "        \"figure.figsize\": (7, 7),\n",

--- a/doc/tutorials/crystal_map.ipynb
+++ b/doc/tutorials/crystal_map.ipynb
@@ -44,7 +44,6 @@
     "from orix.quaternion import Orientation, Rotation, symmetry\n",
     "from orix.vector import Vector3d\n",
     "\n",
-    "\n",
     "plt.rcParams.update({\"figure.figsize\": (7, 7), \"font.size\": 15})\n",
     "tempdir = tempfile.mkdtemp() + \"/\""
    ]

--- a/doc/tutorials/inverse_pole_figures.ipynb
+++ b/doc/tutorials/inverse_pole_figures.ipynb
@@ -61,7 +61,6 @@
     "from orix.quaternion import Orientation, symmetry\n",
     "from orix.vector import Vector3d\n",
     "\n",
-    "\n",
     "# We'll want our plots to look a bit larger than the default size\n",
     "new_params = {\n",
     "    \"figure.facecolor\": \"w\",\n",

--- a/doc/tutorials/point_groups.ipynb
+++ b/doc/tutorials/point_groups.ipynb
@@ -37,7 +37,6 @@
     "from orix.quaternion import Rotation, symmetry\n",
     "from orix.vector import Vector3d\n",
     "\n",
-    "\n",
     "plt.rcParams.update({\"font.size\": 15})"
    ]
   },

--- a/doc/tutorials/s2_sampling.ipynb
+++ b/doc/tutorials/s2_sampling.ipynb
@@ -38,7 +38,6 @@
     "from orix.quaternion import symmetry\n",
     "from orix.sampling import sample_S2_methods, sample_S2\n",
     "\n",
-    "\n",
     "plt.rcParams.update({\"font.size\": 20, \"lines.markersize\": 2})"
    ]
   },

--- a/doc/tutorials/stereographic_projection.ipynb
+++ b/doc/tutorials/stereographic_projection.ipynb
@@ -47,7 +47,6 @@
     "from orix import plot  # Register orix' projections with Matplotlib\n",
     "from orix.vector import Vector3d\n",
     "\n",
-    "\n",
     "# We'll want our plots to look a bit larger than the default size\n",
     "plt.rcParams.update(\n",
     "    {\n",

--- a/doc/tutorials/uniform_sampling_of_orientation_space.ipynb
+++ b/doc/tutorials/uniform_sampling_of_orientation_space.ipynb
@@ -80,7 +80,6 @@
     "from orix.sampling import get_sample_fundamental\n",
     "from orix.vector import Vector3d\n",
     "\n",
-    "\n",
     "plt.rcParams.update(\n",
     "    {\n",
     "        \"axes.grid\": True,\n",

--- a/doc/user/related_projects.rst
+++ b/doc/user/related_projects.rst
@@ -29,6 +29,6 @@ find useful:
 - `DREAM.3D <https://dream3d.io/>`_: C++ library to reconstruct, instatiate, quantify,
   mesh, handle and visualize multidimensional (3D), multimodal data (mainly EBSD
   orientation data).
-- `Elasticipy <https://elasticipy.readthedocs.io/>`_: A Python package designed to simplify 
-the integration and the manupulation of elastic properties and stress-strain calculations in 
-materials science workflows. 
+- :doc:`elasticipy <elasticipy:index>`: A Python package designed to simplify the
+  integration and the manipulation of elastic properties and stress-strain calculations
+  in materials science workflows.

--- a/doc/user/related_projects.rst
+++ b/doc/user/related_projects.rst
@@ -29,3 +29,6 @@ find useful:
 - `DREAM.3D <https://dream3d.io/>`_: C++ library to reconstruct, instatiate, quantify,
   mesh, handle and visualize multidimensional (3D), multimodal data (mainly EBSD
   orientation data).
+- `Elasticipy <https://elasticipy.readthedocs.io/>`_: A Python package designed to simplify 
+the integration and the manupulation of elastic properties and stress-strain calculations in 
+materials science workflows. 

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2025 the orix developers
+# Copyright 2018-2026 the orix developers
 #
 # This file is part of orix.
 #
@@ -34,8 +34,9 @@ __credits__ = [
     "Zhou Xu",
     "Carter Francis",
     "Simon Høgås",
-    "Alessandra da Silva",
     "Ondrej Lexa",
+    "Alessandra da Silva",
+    "Dorian Depriester",
     "Eric Prestat",
     "Alexander Clausen",
 ]

--- a/orix/sampling/S2_sampling.py
+++ b/orix/sampling/S2_sampling.py
@@ -573,8 +573,7 @@ for sampling_name, sampling_method in _sampling_method_registry.items():
     )
     _sampling_S2_method_names.add(f":func:`orix.sampling.{_func.__name__}`")
 
-_s2_sampling_docstring = (
-    """Return unit vectors that sample S2 with a specific angular
+_s2_sampling_docstring = ("""Return unit vectors that sample S2 with a specific angular
     resolution.
 
     Parameters
@@ -596,8 +595,7 @@ _s2_sampling_docstring = (
     See Also
     --------
     {}
-    """
-).format(
+    """).format(
     ", ".join(map(lambda x: f'``"{x}"``', sample_S2_methods)),
     "\n    ".join(_sampling_S2_method_names),
 )


### PR DESCRIPTION
Added Elasticipy project description to related projects.

#### Description of the change
The "related projects" web page has been modified to mention Elasticipy.

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] The PR title is short, concise, and will make sense 1 year later.
- [n/a] New functions are imported in corresponding `__init__.py`.
- [n/a] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [x] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.