### PR TITLE
update date and add setuptools to tagged_release workflow.

### DIFF
--- a/.github/workflows/perhaps_make_a_tagged_release_draft.yml
+++ b/.github/workflows/perhaps_make_a_tagged_release_draft.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install packaging outdated
+        pip install packaging outdated setuptools
 
     - name: Check whether a tagged release draft should be made
       run: |

--- a/.github/workflows/perhaps_make_a_tagged_release_draft.yml
+++ b/.github/workflows/perhaps_make_a_tagged_release_draft.yml
@@ -1,5 +1,5 @@
 ##
-## Copyright 2018-2025 the orix developers
+## Copyright 2018-2026 the orix developers
 ##
 ## This file is part of orix.
 ##
@@ -42,10 +42,12 @@ jobs:
       with:
         python-version: '3.x'
 
+    # TODO: Remove install of setuptools once
+    # https://github.com/pyxem/orix/issues/629 is resolved
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install packaging outdated setuptools
+        pip install packaging outdated setuptools<82
 
     - name: Check whether a tagged release draft should be made
       run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ All user facing changes to this project are documented in this file. The format 
 on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`__, and this project tries
 its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`__.
 
-2026-02-17 - version 0.14.2
+2026-02-23 - version 0.14.2
 ===========================
 
 Changed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ All user facing changes to this project are documented in this file. The format 
 on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`__, and this project tries
 its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`__.
 
-2026-02-14 - version 0.14.2
+2026-02-17 - version 0.14.2
 ===========================
 
 Changed

--- a/orix/plot/stereographic_plot.py
+++ b/orix/plot/stereographic_plot.py
@@ -1173,6 +1173,12 @@ class StereographicPlot(maxes.Axes):
             x += offset[0]
             y += offset[1]
 
+        # convert size 1 arrays to scalars to better agree with numpy>=2.4
+        if x.size == 1:
+            x = x[0]
+        if y.size == 1:
+            y = y[0]
+
         return x, y, visible
 
     def _set_label(self, x: float, y: float, label: str, **kwargs):


### PR DESCRIPTION
#### Description of the change

The "perhaps make tagged release draft" workflow does not complete currently, giving the following error:

```

Run cd .github/workflows
  
/opt/hostedtoolcache/Python/3.14.3/x64/lib/python3.14/site-packages/outdated/utils.py:14: OutdatedCheckFailedWarning: Failed to check for latest version of package.
Set the environment variable OUTDATED_RAISE_EXCEPTION=1 for a full traceback.
Set the environment variable OUTDATED_IGNORE=1 to disable these warnings.
  return warn(
Traceback (most recent call last):
  File "/home/runner/work/orix/orix/.github/workflows/perhaps_make_tagged_release_draft.py", line 36, in <module>
    make_release, pypi_version_str = check_outdated("orix", branch_version_str)
                                     ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.14.3/x64/lib/python3.14/site-packages/outdated/__init__.py", line 36, in check_outdated
    from pkg_resources import parse_version
ModuleNotFoundError: No module named 'pkg_resources'
```

Googling around, it appears in python 3.12+, setuptools is not automatically included in virtual environments (example error here: https://github.com/open-mmlab/mmcv/issues/3325)

adding setuptools to the pip install should fix this, but I don't think I can test this without pushing to main.
