### PR TITLE
Add manual trigger to build creating a tagged release

### DIFF
--- a/.github/workflows/perhaps_make_a_tagged_release_draft.yml
+++ b/.github/workflows/perhaps_make_a_tagged_release_draft.yml
@@ -28,6 +28,7 @@ on:
       - main
     paths:
       - "orix/__init__.py"
+  workflow_dispatch:
 
 jobs:
   make-tagged-release:


### PR DESCRIPTION
#### Description of the change

I've cherry-picked https://github.com/pyxem/orix/pull/631/commits/b76861a9f2a9bc83a35ea8f5cd2b5bef0176a049 to allow manually triggering the "Perhaps make a tagged release", as discussed in https://github.com/pyxem/orix/pull/631.

#### Progress of the PR
- [n/a] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [n/a] Unit tests with pytest for all lines
- [n/a] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.