### PR TITLE
Update broken Github Action for verion releases.

### DIFF
--- a/.github/workflows/perhaps_make_a_tagged_release_draft.yml
+++ b/.github/workflows/perhaps_make_a_tagged_release_draft.yml
@@ -34,21 +34,21 @@ jobs:
   make-tagged-release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - uses: r-lib/actions/setup-pandoc@v2
 
     - name: Set up Python ${{ runner.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
-        python-version: '3.x'
+        python-version: '3.13'
 
     # TODO: Remove install of setuptools once
     # https://github.com/pyxem/orix/issues/629 is resolved
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install packaging outdated setuptools<82
+        python -m pip install packaging outdated 'setuptools<82'
 
     - name: Check whether a tagged release draft should be made
       run: |


### PR DESCRIPTION
#### Description of the change
This should allow the tagged release workflow to run.

changing `setuptools<82` to `'setuptools<82'` was the important fix, the other fixes just silenced warnings about the [upcoming change to github actions](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
