### PR TITLE
Remove `outdated` package  causing dependency errors in github workflows

### DIFF
--- a/.github/workflows/perhaps_make_a_tagged_release_draft.yml
+++ b/.github/workflows/perhaps_make_a_tagged_release_draft.yml
@@ -43,12 +43,10 @@ jobs:
       with:
         python-version: '3.13'
 
-    # TODO: Remove install of setuptools once
-    # https://github.com/pyxem/orix/issues/629 is resolved
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install packaging outdated 'setuptools<82'
+        python -m pip install json re requests packaging 
 
     - name: Check whether a tagged release draft should be made
       run: |

--- a/.github/workflows/perhaps_make_a_tagged_release_draft.yml
+++ b/.github/workflows/perhaps_make_a_tagged_release_draft.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pypi-json re requests packaging 
+        python -m pip install pypi-json requests packaging 
 
     - name: Check whether a tagged release draft should be made
       run: |

--- a/.github/workflows/perhaps_make_a_tagged_release_draft.yml
+++ b/.github/workflows/perhaps_make_a_tagged_release_draft.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Set up Python ${{ runner.python-version }}
       uses: actions/setup-python@v6
       with:
-        python-version: '3.13'
+        python-version: '3.x'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/perhaps_make_a_tagged_release_draft.yml
+++ b/.github/workflows/perhaps_make_a_tagged_release_draft.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install json re requests packaging 
+        python -m pip install pypi-json re requests packaging 
 
     - name: Check whether a tagged release draft should be made
       run: |

--- a/.github/workflows/perhaps_make_a_tagged_release_draft.yml
+++ b/.github/workflows/perhaps_make_a_tagged_release_draft.yml
@@ -34,21 +34,21 @@ jobs:
   make-tagged-release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - uses: r-lib/actions/setup-pandoc@v2
 
     - name: Set up Python ${{ runner.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
-        python-version: '3.x'
+        python-version: '3.13'
 
     # TODO: Remove install of setuptools once
     # https://github.com/pyxem/orix/issues/629 is resolved
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install packaging outdated setuptools<82
+        python -m pip install packaging outdated 'setuptools<82'
 
     - name: Check whether a tagged release draft should be made
       run: |

--- a/.github/workflows/perhaps_make_tagged_release_draft.py
+++ b/.github/workflows/perhaps_make_tagged_release_draft.py
@@ -17,9 +17,10 @@
 # along with orix. If not, see <http://www.gnu.org/licenses/>.
 #
 
+import json
 import re
+import requests
 
-from outdated import check_outdated
 from packaging.version import Version
 
 with open("../../orix/__init__.py") as fid:
@@ -33,7 +34,11 @@ with open("../../orix/__init__.py") as fid:
 # version is different (hopefully always newer if different) from the
 # PyPI version
 try:
-    make_release, pypi_version_str = check_outdated("orix", branch_version_str)
+    current_version = Version(branch_version_str)
+    pypi_txt= requests.get('https://pypi.python.org/pypi/orix/json').text
+    pypi_version_str = json.loads(pypi_txt)['info']['version']
+    pypi_version = Version(pypi_version_str)
+    make_release = current_version>pypi_version
 except ValueError as err:
     pattern = re.compile(r"([\d.]+)")  # Any "word" with decimal digits and dots
     matches = []

--- a/.github/workflows/perhaps_make_tagged_release_draft.py
+++ b/.github/workflows/perhaps_make_tagged_release_draft.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2025 the orix developers
+# Copyright 2018-2026 the orix developers
 #
 # This file is part of orix.
 #
@@ -19,9 +19,9 @@
 
 import json
 import re
-import requests
 
 from packaging.version import Version
+import requests
 
 with open("../../orix/__init__.py") as fid:
     for line in fid:
@@ -29,16 +29,16 @@ with open("../../orix/__init__.py") as fid:
             branch_version_str = line.strip().split(" = ")[-1][1:-1]
             break
 
-# Within a try/except because we don't want to throw the error if a new
+# Within a try/except because we don't want to raise the error if a new
 # tagged release draft is to be made, we just want to know if the branch
 # version is different (hopefully always newer if different) from the
 # PyPI version
 try:
     current_version = Version(branch_version_str)
-    pypi_txt= requests.get('https://pypi.python.org/pypi/orix/json').text
-    pypi_version_str = json.loads(pypi_txt)['info']['version']
+    pypi_txt = requests.get("https://pypi.python.org/pypi/orix/json").text
+    pypi_version_str = json.loads(pypi_txt)["info"]["version"]
     pypi_version = Version(pypi_version_str)
-    make_release = current_version>pypi_version
+    make_release = current_version > pypi_version
 except ValueError as err:
     pattern = re.compile(r"([\d.]+)")  # Any "word" with decimal digits and dots
     matches = []

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ ENV/
 
 # MacOS
 .DS_Store
+
+# Temporary files in workflows/
+release_part_in_changelog.rst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,6 @@ dev = [
     "hatch",
     "isort                          >= 5.10",
     "licenseheaders",
-    "outdated",
     "pre-commit                     >= 1.16",
     "orix[doc,tests,coverage]",
 ]


### PR DESCRIPTION
#### Description of the change

Replaces `outdated.check_outdated` with a simplified logic that doesn't rely on the depreciated `pkg_resources` module.

@hakonanes, I believe this will fix the relevant github action, but in the interest of time, I went ahead with publishing 0.14.3. This might be worth fixing before 0.15.0 though.

This update also silences several github action warnings regarding this [upcoming change to github actions](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
