### PR TITLE
Patch 0.14.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,20 +7,8 @@ on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`__, and this project
 its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`__.
 
 
-Unreleased
-==========
-
-Added
------
-
-Changed
--------
-
-Removed
--------
-
-Deprecated
-----------
+2026-06-06 - version 0.14.3
+===========================
 
 Fixed
 -----

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -17,7 +17,7 @@
 # along with orix. If not, see <http://www.gnu.org/licenses/>.
 #
 
-__version__ = "0.14.3"
+__version__ = "0.15.dev3"
 
 # Sorted by line contributions (ideally excluding lines in notebook
 # files)

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -17,7 +17,7 @@
 # along with orix. If not, see <http://www.gnu.org/licenses/>.
 #
 
-__version__ = "0.15.dev2"
+__version__ = "0.14.3"
 
 # Sorted by line contributions (ideally excluding lines in notebook
 # files)

--- a/orix/io/_io.py
+++ b/orix/io/_io.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2025 the orix developers
+# Copyright 2018-2026 the orix developers
 #
 # This file is part of orix.
 #
@@ -27,6 +27,8 @@ from h5py import File, is_hdf5
 from orix.crystal_map.crystal_map import CrystalMap
 from orix.io.plugins import plugin_list
 from orix.io.plugins._h5ebsd import hdf5group2dict
+
+plugin_list: list[ModuleType]
 
 extensions = [plugin.file_extensions for plugin in plugin_list if plugin.writes]
 

--- a/orix/io/plugins/__init__.py
+++ b/orix/io/plugins/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2025 the orix developers
+# Copyright 2018-2026 the orix developers
 #
 # This file is part of orix.
 #
@@ -34,11 +34,9 @@
     orix_hdf5
 """
 
-from types import ModuleType
-
 from orix.io.plugins import ang, bruker_h5ebsd, ctf, emsoft_h5ebsd, orix_hdf5
 
-plugin_list: list[ModuleType] = [
+plugin_list = [
     ang,
     bruker_h5ebsd,
     ctf,


### PR DESCRIPTION
#### Description of the change
Merging main back into develop and updating version to `0.15.dev3`


#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.