### PR TITLE
Fix sign error in quaternion-to-Euler conversion at Phi = pi

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -72,6 +72,9 @@
       "name": "Alexander Clausen",
       "orcid": "0000-0002-9555-7455",
       "affiliation": "Jülich Research Centre, Ernst Ruska Centre"
+    },
+    {
+      "name": "Vincent Gao"
     }
   ]
 }

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,17 @@ on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`__, and this project
 its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`__.
 
 
+Unreleased
+==========
+
+Fixed
+-----
+- ``Rotation.to_euler()`` now returns correct Bunge Euler angles for 180 degree
+  rotations about an axis in the xy-plane not aligned with x or y. A sign error in
+  the singular branch of the quaternion-to-Euler conversion previously reflected the
+  reconstructed axis, so the angles did not round-trip back to the input rotation.
+
+
 2026-06-10 - version 0.15.0
 ===========================
 

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -39,4 +39,5 @@ __credits__ = [
     "Dorian Depriester",
     "Eric Prestat",
     "Alexander Clausen",
+    "Vincent Gao",
 ]

--- a/orix/quaternion/_conversions.py
+++ b/orix/quaternion/_conversions.py
@@ -1016,7 +1016,7 @@ def qu2eu_single(qu: np.ndarray) -> np.ndarray:
             a = -2 * qu[0] * qu[3]
             b = qu[0] * qu[0] - qu[3] * qu[3]
         else:
-            a = -2 * qu[1] * qu[2]
+            a = 2 * qu[1] * qu[2]
             b = qu[1] * qu[1] - qu[2] * qu[2]
             eu[1] = np.pi
         eu[0] = np.arctan2(a, b)

--- a/orix/tests/test_quaternion/test_conversions.py
+++ b/orix/tests/test_quaternion/test_conversions.py
@@ -20,7 +20,7 @@
 import numpy as np
 import pytest
 
-from orix.quaternion import Orientation
+from orix.quaternion import Orientation, Rotation
 from orix.quaternion._conversions import (
     ax2qu,
     ax2qu_2d,
@@ -104,6 +104,30 @@ class TestRotationConversions:
         ori = Orientation.from_euler(eu_64[-1], Oh)
         assert ori.symmetry == Oh
         assert np.allclose(ori.data[0], qu_64[-1], atol=1e-4)
+
+    def test_qu2eu_equatorial_twofold(self):
+        # 180 deg rotations about equatorial (xy-plane) axes hit the Phi = pi
+        # branch of qu2eu (Rowenhorst et al. (2015) Eq. A.14). Off-axis axes,
+        # with x and y both non-zero, must round-trip back to the rotation.
+        psi = np.linspace(0, np.pi, 19)
+        axes = np.column_stack([np.cos(psi), np.sin(psi), np.zeros_like(psi)])
+        qu = ax2qu(axes, np.full(psi.shape, np.pi))
+
+        # jit path: qu -> eu -> qu, compared as matrices to sidestep the
+        # quaternion double cover
+        assert np.allclose(qu2om(qu), qu2om(eu2qu(qu2eu(qu))), atol=1e-6)
+
+        # Pure-Python path
+        for q in qu:
+            q_rt = eu2qu_single.py_func(qu2eu_single.py_func(q))
+            assert np.allclose(
+                qu2om_single.py_func(q), qu2om_single.py_func(q_rt), atol=1e-6
+            )
+
+        # Public API round-trip
+        rot = Rotation.from_axes_angles(axes, np.pi)
+        rot_rt = Rotation.from_euler(rot.to_euler())
+        assert np.allclose(rot.to_matrix(), rot_rt.to_matrix(), atol=1e-6)
 
     def test_get_pyramid(self, cubochoric_coordinates):
         """Cubochoric coordinates situated in expected pyramid."""

--- a/orix/tests/test_sampling/test_sampling.py
+++ b/orix/tests/test_sampling/test_sampling.py
@@ -206,14 +206,15 @@ class TestSampleFundamental:
         v_Oh = R_Oh * vz
         assert np.all(v_Oh <= Oh.fundamental_sector)
 
-        # Some rotations have a phi1 Euler angle of multiples of pi,
-        # presumably due to rounding errors
+        # A few sampled rotations are 180 degree rotations about an axis in
+        # the xy-plane (Phi = pi), where phi1 is degenerate and lands on a
+        # multiple of pi / 2
         phi1_C1 = R_C1.to_euler()[:, 0].round(7)
         assert np.allclose(np.unique(phi1_C1), 0, atol=1e-7)
         phi1_C4 = R_C4.to_euler()[:, 0].round(7)
-        assert np.allclose(np.unique(phi1_C4), [0, np.pi / 2], atol=1e-7)
+        assert np.allclose(np.unique(phi1_C4), [0, np.pi / 2, 3 * np.pi / 2], atol=1e-7)
         phi1_C6 = R_C6.to_euler()[:, 0].round(7)
-        assert np.allclose(np.unique(phi1_C6), [0, np.pi / 2], atol=1e-7)
+        assert np.allclose(np.unique(phi1_C6), [0, np.pi / 2, 3 * np.pi / 2], atol=1e-7)
         phi1_Oh = R_Oh.to_euler()[:, 0].round(7)
         assert np.allclose(np.unique(phi1_Oh), [0, np.pi / 2], atol=1e-7)
 


### PR DESCRIPTION
#### Description of the change

`Rotation.to_euler()` returns wrong Bunge Euler angles for 180° rotations about an axis in the xy-plane that is not aligned with x or y (off-axis equatorial two-folds). `from_euler(to_euler(r))` then gives a *different* rotation (the axis is reflected).

The cause is a sign error in the `Φ = π` singular branch of `qu2eu_single` (`orix/quaternion/_conversions.py`), which handles `Φ = π ⇔ 180°` rotations with `w = z = 0`:

```python
else:  # Phi = pi
    a = -2 * qu[1] * qu[2]   # wrong sign
    b = qu[1] * qu[1] - qu[2] * qu[2]
```

Inverting `eu2qu` at `β = π` gives `qu[1] = -cos(δ)`, `qu[2] = -sin(δ)` with `δ = (α - γ)/2`, so `α = arctan2(2·qu[1]·qu[2], qu[1]² - qu[2]²)`, i.e. `a = +2·qu[1]·qu[2]`. Both quaternion components carry the minus sign here, so their product is positive — unlike the neighbouring `Φ = 0` branch, where only `qu[3]` is negated and `a = -2·qu[0]·qu[3]` is correct. This matches Rowenhorst et al. (2015) Eq. A.14. The bug is masked when `x` or `y` is zero (`2·qu[1]·qu[2] = 0`), which is the only equatorial case the existing tests covered.

I audited the other singular branches of the conversion suite (`ax2qu`/`qu2ax` at `ω = 0, π`, `om2qu` for 180° rotations, `ho2ax`, homochoric round-trips, and the `Φ = 0` branch of `qu2eu`) via round-trip consistency and found them clean — this is a single localized sign.

#### Minimal example of the bug fix

```python
>>> import numpy as np
>>> from orix.quaternion import Rotation
>>> r = Rotation.from_axes_angles([1, 1, 0], np.pi)   # 180° about [1, 1, 0]
>>> r2 = Rotation.from_euler(r.to_euler())
>>> np.allclose(r.to_matrix(), r2.to_matrix())
True    # was False before this fix
```

#### Notes

- Added a round-trip regression test for equatorial two-fold rotations in `test_conversions.py` (jit, pure-Python, and public-API paths).
- `test_get_sample_reduced_fundamental` asserted `unique(phi1) == [0, π/2]` for C4/C6. That held only because the wrong sign collapsed the affected two-fold's `phi1` onto `π/2`; on `develop` those sampled rotations do not actually round-trip (matrix error 2.0). With the fix `phi1` gains its correct degenerate value `3π/2` and the whole sample round-trips, so I updated that expectation.
- Full `pytest orix/tests` suite passes locally.

#### Progress of the PR
- [x] Unit tests with pytest for all lines
- [x] Clean code style by running black via pre-commit
- [x] New features, API changes, and deprecations are mentioned in the unreleased section in `CHANGELOG.rst`
