### PR TITLE
Set version to 0.15.0 and update changelog release to today

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`__, and this project
 its best to adhere to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`__.
 
 
-2026-06-10 - version 0.15.0
+2026-06-29 - version 0.15.0
 ===========================
 
 Added

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -17,7 +17,7 @@
 # along with orix. If not, see <http://www.gnu.org/licenses/>.
 #
 
-__version__ = "0.15.0rc1"
+__version__ = "0.15.0"
 
 # Sorted by line contributions (ideally excluding lines in notebook
 # files)


### PR DESCRIPTION
#### Description of the change

Conclusion of the discussion started in #660, accepting the  candidate release from #665 as the final minor release 0.15.0.


#### Progress of the PR
- [N/A] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [N/A] Unit tests with pytest for all lines
- [N/A] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.