### PR TITLE
Vector tensor product

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Unreleased
 
 Added
 -----
+- `orix.vector.Vector3d` now includes a `tensor` and 'tensor_outer` functions for
+  calculating tensor products.
 - Mean quaternion calculation now allows weighting each quaternion.
 - Function ``get_asymmetric_groups()`` to return two point groups for creating the
   fundamental zone for a set of two point groups.

--- a/orix/tests/test_vector3d/test_vector3d.py
+++ b/orix/tests/test_vector3d/test_vector3d.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2025 the orix developers
+# Copyright 2018-2026 the orix developers
 #
 # This file is part of orix.
 #
@@ -100,7 +100,7 @@ class TestVector3d:
         assert np.allclose(s1.data, s2.data)
         # check error messages
         with pytest.raises(TypeError):
-            _ = vector + 'dracula'
+            _ = vector + "dracula"
 
     @pytest.mark.parametrize(
         "vector, other, expected",
@@ -125,7 +125,7 @@ class TestVector3d:
         assert np.allclose(-s1.data, s2.data)
         # check error messages
         with pytest.raises(TypeError):
-            _ = vector - 'dracula'
+            _ = vector - "dracula"
 
     @pytest.mark.parametrize(
         "vector, other, expected",
@@ -147,7 +147,7 @@ class TestVector3d:
         with pytest.raises(ValueError):
             _ = vector * Vector3d([[1, 2, 3], [-3, -2, -1]])
         with pytest.raises(TypeError):
-            _ = vector * 'dracula'
+            _ = vector * "dracula"
 
     @pytest.mark.parametrize(
         "vector, other, expected",
@@ -175,7 +175,7 @@ class TestVector3d:
         with pytest.raises(ValueError):
             _ = vector * Vector3d([[1, 2, 3], [-3, -2, -1]])
         with pytest.raises(TypeError):
-            _ = vector * 'dracula'
+            _ = vector * "dracula"
         with pytest.raises(ValueError):
             _ = 1 / Vector3d.xvector()
 
@@ -200,7 +200,6 @@ class TestVector3d:
         assert np.allclose(vector.dot(something), something.dot(vector))
         with pytest.raises(ValueError):
             vector.dot(number)
-
 
     def test_dot_outer(self, vector, something, capsys):
         # Test dot_outer
@@ -232,17 +231,17 @@ class TestVector3d:
         a = Vector3d.random()
         b = Vector3d.random()
         c = Vector3d.random()
-        abc = np.dot((a.tensor(b)[0]),c.data[0])
-        bca = (b.dot(c)*a).data
-        assert np.allclose(abc,bca)
+        abc = np.dot((a.tensor(b)[0]), c.data[0])
+        bca = (b.dot(c) * a).data
+        assert np.allclose(abc, bca)
         # repeat test with tensor_outer method
-        abc_outer = np.dot((a.tensor_outer(b)[0]),c.data[0])
-        assert np.allclose(abc_outer,bca)
+        abc_outer = np.dot((a.tensor_outer(b)[0]), c.data[0])
+        assert np.allclose(abc_outer, bca)
         # test casting
         v1 = Vector3d.random((3, 4))
         v2 = Vector3d.random((3, 4))
         v3 = Vector3d.random((2, 3, 4))
-        v4 = Vector3d.random(( 3, 1, 4))
+        v4 = Vector3d.random((3, 1, 4))
         assert v1.tensor(v2).shape == (3, 4, 3, 3)
         assert v1.tensor(v3).shape == (2, 3, 4, 3, 3)
         assert v1.tensor(v4).shape == (3, 3, 4, 3, 3)
@@ -285,11 +284,11 @@ class TestVector3d:
     def test_angle_with(self, vector, something):
         a1 = vector.angle_with(vector)
         assert np.allclose(a1, 0)
-    
+
         a2 = vector.angle_with(something)
         assert np.all(a2 >= 0)
         assert np.all(a2 <= np.pi)
-    
+
         a3 = vector.angle_with(something, degrees=True)
         assert np.allclose(np.rad2deg(a2), a3)
 
@@ -345,16 +344,16 @@ class TestVector3d:
     )
     def test_assign_xyz(self, vector, change):
         array = vector.data
-        #test assignments to x
-        array[...,0] = change
+        # test assignments to x
+        array[..., 0] = change
         vector.x = change
         assert np.allclose(vector.data, array)
-        #test assignments to y
-        array[...,1] = change
+        # test assignments to y
+        array[..., 1] = change
         vector.y = change
         assert np.allclose(vector.data, array)
-        #test assignments to z
-        array[...,2] = change
+        # test assignments to z
+        array[..., 2] = change
         vector.z = change
         assert np.allclose(vector.data, array)
 
@@ -383,7 +382,7 @@ class TestVector3d:
     def test_transpose_1d(self):
         v1 = Vector3d.random(7)
         v2 = v1.transpose()
-    
+
         assert np.allclose(v1.data, v2.data)
 
     def test_transpose(self):
@@ -391,7 +390,7 @@ class TestVector3d:
         v_3d = Vector3d.random((2, 3, 4))
         v_4d = Vector3d.random((2, 1, 3, 4))
         # expected to work for 2D shapes
-        assert v_2d.transpose().shape == (6,4)
+        assert v_2d.transpose().shape == (6, 4)
         # should not work for generic 3d without guidance
         with pytest.raises(ValueError, match="Axes must be defined for more than"):
             _ = v_3d.transpose()
@@ -399,15 +398,15 @@ class TestVector3d:
         with pytest.raises(ValueError, match="Number of axes is ill-defined"):
             _ = v_3d.transpose(0, 2)
         # But will work for full axes reordering list
-        assert v_3d.transpose(0,2,1).shape == (2, 4, 3)
-        assert v_4d.transpose(0,2,1,3).shape == (2, 3, 1, 4)
+        assert v_3d.transpose(0, 2, 1).shape == (2, 4, 3)
+        assert v_4d.transpose(0, 2, 1, 3).shape == (2, 3, 1, 4)
 
     def test_get_nearest(self):
         v_ref = Vector3d.zvector()
         v = Vector3d([[0, 0, 0.9], [0, 0, 0.8], [0, 0, 1.1]])
         v_nearest = v_ref.get_nearest(v)
         assert np.allclose(v_nearest.data, [0, 0, 0.9])
-    
+
         with pytest.raises(AttributeError, match="`get_nearest` only works for "):
             v.get_nearest(v_ref)
 

--- a/orix/tests/test_vector3d/test_vector3d.py
+++ b/orix/tests/test_vector3d/test_vector3d.py
@@ -227,6 +227,33 @@ class TestVector3d:
         with pytest.raises(AttributeError):
             vector.cross(number)
 
+    def test_tensor(self, vector, number):
+        # test definition of tensor in orthonormal space
+        a = Vector3d.random()
+        b = Vector3d.random()
+        c = Vector3d.random()
+        abc = np.dot((a.tensor(b)[0]),c.data[0])
+        bca = (b.dot(c)*a).data
+        assert np.allclose(abc,bca)
+        # repeat test with tensor_outer method
+        abc_outer = np.dot((a.tensor_outer(b)[0]),c.data[0])
+        assert np.allclose(abc_outer,bca)
+        # test casting
+        v1 = Vector3d.random((3, 4))
+        v2 = Vector3d.random((3, 4))
+        v3 = Vector3d.random((2, 3, 4))
+        v4 = Vector3d.random(( 3, 1, 4))
+        assert v1.tensor(v2).shape == (3, 4, 3, 3)
+        assert v1.tensor(v3).shape == (2, 3, 4, 3, 3)
+        assert v1.tensor(v4).shape == (3, 3, 4, 3, 3)
+        assert v1.tensor_outer(v2).shape == (3, 4, 3, 4, 3, 3)
+        assert v1.tensor_outer(v3).shape == (3, 4, 2, 3, 4, 3, 3)
+        # For both functions, test errors
+        with pytest.raises(ValueError):
+            vector.tensor(number)
+        with pytest.raises(ValueError):
+            vector.tensor_outer(number)
+
     @pytest.mark.parametrize(
         "azimuth, polar, radial, expected",
         [

--- a/orix/tests/test_vector3d/test_vector3d.py
+++ b/orix/tests/test_vector3d/test_vector3d.py
@@ -73,436 +73,324 @@ def number(request):
     return request.param
 
 
-def test_neg(vector):
-    assert np.all((-vector).data == -(vector.data))
+class TestVector3d:
+    def test_neg(self, vector):
+        assert np.all((-vector).data == -(vector.data))
 
-
-@pytest.mark.parametrize(
-    "vector, other, expected",
-    [
-        (
-            [1, 2, 3],
-            Vector3d([[1, 2, 3], [-3, -2, -1]]),
-            [[2, 4, 6], [-2, 0, 2]],
-        ),
-        ([1, 2, 3], [4], [5, 6, 7]),
-        ([1, 2, 3], 0.5, [1.5, 2.5, 3.5]),
-        ([1, 2, 3], [-1, 2], [[0, 1, 2], [3, 4, 5]]),
-        ([1, 2, 3], np.array([-1, 1]), [[0, 1, 2], [2, 3, 4]]),
-    ],
-    indirect=["vector"],
-)
-def test_add(vector, other, expected):
-    s1 = vector + other
-    s2 = other + vector
-    assert np.allclose(s1.data, expected)
-    assert np.allclose(s1.data, s2.data)
-
-
-@pytest.mark.parametrize(
-    "vector, other",
-    [([1, 2, 3], "dracula")],
-    indirect=["vector"],
-)
-def test_add_raises(vector, other):
-    with pytest.raises(TypeError):
-        _ = vector + other
-
-
-@pytest.mark.parametrize(
-    "vector, other, expected",
-    [
-        (
-            [1, 2, 3],
-            Vector3d([[1, 2, 3], [-3, -2, -1]]),
-            [[0, 0, 0], [4, 4, 4]],
-        ),
-        ([1, 2, 3], [4], [-3, -2, -1]),
-        ([1, 2, 3], 0.5, [0.5, 1.5, 2.5]),
-        ([1, 2, 3], [-1, 2], [[2, 3, 4], [-1, 0, 1]]),
-        ([1, 2, 3], np.array([-1, 1]), [[2, 3, 4], [0, 1, 2]]),
-    ],
-    indirect=["vector"],
-)
-def test_sub(vector, other, expected):
-    s1 = vector - other
-    s2 = other - vector
-    assert np.allclose(s1.data, expected)
-    assert np.allclose(-s1.data, s2.data)
-
-
-@pytest.mark.parametrize(
-    "vector, other",
-    [
-        ([1, 2, 3], "dracula"),
-    ],
-    indirect=["vector"],
-)
-def test_sub_raises(vector, other):
-    with pytest.raises(TypeError):
-        _ = vector - other
-
-
-@pytest.mark.parametrize(
-    "vector, other, expected",
-    [
-        ([1, 2, 3], [4], [4, 8, 12]),
-        ([1, 2, 3], 0.5, [0.5, 1.0, 1.5]),
-        ([1, 2, 3], [-1, 2], [[-1, -2, -3], [2, 4, 6]]),
-        ([1, 2, 3], np.array([-1, 1]), [[-1, -2, -3], [1, 2, 3]]),
-    ],
-    indirect=["vector"],
-)
-def test_mul(vector, other, expected):
-    s1 = vector * other
-    s2 = other * vector
-    assert np.allclose(s1.data, expected)
-    assert np.allclose(s1.data, s2.data)
-
-
-@pytest.mark.parametrize(
-    "vector, other, error_type",
-    [
-        ([1, 2, 3], Vector3d([[1, 2, 3], [-3, -2, -1]]), ValueError),
-        ([1, 2, 3], "dracula", TypeError),
-    ],
-    indirect=["vector"],
-)
-def test_mul_raises(vector, other, error_type):
-    with pytest.raises(error_type):
-        _ = vector * other
-
-
-@pytest.mark.parametrize(
-    "vector, other, expected",
-    [
-        ([4, 8, 12], [4], [1, 2, 3]),
-        ([0.5, 1.0, 1.5], 0.5, [1, 2, 3]),
-        (
-            [1, 2, 3],
-            [-1, 2],
-            [[-1, -2, -3], [1 / 2, 1, 3 / 2]],
-        ),
-        (
-            [1, 2, 3],
-            np.array([-1, 1]),
-            [[-1, -2, -3], [1, 2, 3]],
-        ),
-    ],
-    indirect=["vector"],
-)
-def test_div(vector, other, expected):
-    s1 = vector / other
-    assert np.allclose(s1.data, expected)
-
-
-@pytest.mark.parametrize(
-    "vector, other, error_type",
-    [
-        ([1, 2, 3], Vector3d([[1, 2, 3], [-3, -2, -1]]), ValueError),
-        ([1, 2, 3], "dracula", TypeError),
-    ],
-    indirect=["vector"],
-)
-def test_div_raises(vector, other, error_type):
-    with pytest.raises(error_type):
-        _ = vector / other
-
-
-def test_rdiv_raises():
-    with pytest.raises(ValueError):
-        _ = 1 / Vector3d.xvector()
-
-
-def test_eq():
-    v = Vector3d.zvector()
-    s1 = symmetry.D3
-    s2 = symmetry.C6
-    s3 = symmetry.O
-    # check element-wise comparison
-    assert np.all((v == s1.axis) == [True, True, False, False, False, False])
-    assert np.all((v == s2.axis) == [True, True, False, True, False, True])
-    # check that two lists compare per-row
-    assert np.all((s1.axis == s2.axis) == [1, 1, 1, 0, 0, 0])
-    # check incorrectly sized things compare as a flat falsse
-    assert not (s1 == s3)
-    # check that things that aren't vectors treat vector comparison as array
-    # comparison.
-    assert np.all((v == 1) == [0, 0, 1])
-
-
-def test_dot(vector, something):
-    assert np.allclose(vector.dot(vector), (vector.data**2).sum(axis=-1))
-    assert np.allclose(vector.dot(something), something.dot(vector))
-
-
-def test_dot_error(vector, number):
-    with pytest.raises(ValueError):
-        vector.dot(number)
-
-
-def test_dot_outer(vector, something):
-    d = vector.dot_outer(something)
-    assert d.shape == vector.shape + something.shape
-    for i in np.ndindex(vector.shape):
-        for j in np.ndindex(something.shape):
-            assert np.allclose(d[i + j], vector[i].dot(something[j]))
-    d_lazy = vector.dot_outer(something, lazy=True)
-    assert isinstance(d_lazy, np.ndarray)
-    assert np.allclose(d, d_lazy)
-    d_lazy_no_pb = vector.dot_outer(
-        something, lazy=True, progressbar=False, chunk_size=25
+    @pytest.mark.parametrize(
+        "vector, other, expected",
+        [
+            (
+                [1, 2, 3],
+                Vector3d([[1, 2, 3], [-3, -2, -1]]),
+                [[2, 4, 6], [-2, 0, 2]],
+            ),
+            ([1, 2, 3], [4], [5, 6, 7]),
+            ([1, 2, 3], 0.5, [1.5, 2.5, 3.5]),
+            ([1, 2, 3], [-1, 2], [[0, 1, 2], [3, 4, 5]]),
+            ([1, 2, 3], np.array([-1, 1]), [[0, 1, 2], [2, 3, 4]]),
+        ],
+        indirect=["vector"],
     )
-    assert np.allclose(d_lazy, d_lazy_no_pb)
+    def test_add(self, vector, other, expected):
+        # test vector addition
+        s1 = vector + other
+        s2 = other + vector
+        assert np.allclose(s1.data, expected)
+        assert np.allclose(s1.data, s2.data)
+        # check error messages
+        with pytest.raises(TypeError):
+            _ = vector + 'dracula'
 
-
-def test_dot_outer_progressbar(vector, something, capsys):
-    d = vector.dot_outer(something, lazy=True, progressbar=True)
-    out, _ = capsys.readouterr()
-    assert "Completed" in out
-    assert d.shape == vector.shape + something.shape
-
-
-def test_cross(vector, something):
-    assert isinstance(vector.cross(something), Vector3d)
-
-
-def test_cross_error(vector, number):
-    with pytest.raises(AttributeError):
-        vector.cross(number)
-
-
-@pytest.mark.parametrize(
-    "azimuth, polar, radial, expected",
-    [
-        (np.pi / 4, np.pi / 4, 1, Vector3d((0.5, 0.5, 0.707107))),
-        (7 * np.pi / 6, 2 * np.pi / 3, 1, Vector3d((-0.75, -0.433013, -0.5))),
-    ],
-)
-def test_polar(azimuth, polar, radial, expected):
-    v1 = Vector3d.from_polar(azimuth, polar, radial)
-    v2 = Vector3d.from_polar(
-        np.rad2deg(azimuth), np.rad2deg(polar), radial, degrees=True
+    @pytest.mark.parametrize(
+        "vector, other, expected",
+        [
+            (
+                [1, 2, 3],
+                Vector3d([[1, 2, 3], [-3, -2, -1]]),
+                [[0, 0, 0], [4, 4, 4]],
+            ),
+            ([1, 2, 3], [4], [-3, -2, -1]),
+            ([1, 2, 3], 0.5, [0.5, 1.5, 2.5]),
+            ([1, 2, 3], [-1, 2], [[2, 3, 4], [-1, 0, 1]]),
+            ([1, 2, 3], np.array([-1, 1]), [[2, 3, 4], [0, 1, 2]]),
+        ],
+        indirect=["vector"],
     )
-    assert np.allclose(v1.data, expected.data, atol=1e-5)
-    assert np.allclose(v2.data, v1.data, atol=1e-5)
+    def test_sub(self, vector, other, expected):
+        # test vector subtraction
+        s1 = vector - other
+        s2 = other - vector
+        assert np.allclose(s1.data, expected)
+        assert np.allclose(-s1.data, s2.data)
+        # check error messages
+        with pytest.raises(TypeError):
+            _ = vector - 'dracula'
+
+    @pytest.mark.parametrize(
+        "vector, other, expected",
+        [
+            ([1, 2, 3], [4], [4, 8, 12]),
+            ([1, 2, 3], 0.5, [0.5, 1.0, 1.5]),
+            ([1, 2, 3], [-1, 2], [[-1, -2, -3], [2, 4, 6]]),
+            ([1, 2, 3], np.array([-1, 1]), [[-1, -2, -3], [1, 2, 3]]),
+        ],
+        indirect=["vector"],
+    )
+    def test_mul(self, vector, other, expected):
+        # test vector multiplication
+        s1 = vector * other
+        s2 = other * vector
+        assert np.allclose(s1.data, expected)
+        assert np.allclose(s1.data, s2.data)
+        # check for appropriate error messages
+        with pytest.raises(ValueError):
+            _ = vector * Vector3d([[1, 2, 3], [-3, -2, -1]])
+        with pytest.raises(TypeError):
+            _ = vector * 'dracula'
+
+    @pytest.mark.parametrize(
+        "vector, other, expected",
+        [
+            ([4, 8, 12], [4], [1, 2, 3]),
+            ([0.5, 1.0, 1.5], 0.5, [1, 2, 3]),
+            (
+                [1, 2, 3],
+                [-1, 2],
+                [[-1, -2, -3], [1 / 2, 1, 3 / 2]],
+            ),
+            (
+                [1, 2, 3],
+                np.array([-1, 1]),
+                [[-1, -2, -3], [1, 2, 3]],
+            ),
+        ],
+        indirect=["vector"],
+    )
+    def test_div(self, vector, other, expected):
+        # test vector division
+        s1 = vector / other
+        assert np.allclose(s1.data, expected)
+        # check for appropriate error messages
+        with pytest.raises(ValueError):
+            _ = vector * Vector3d([[1, 2, 3], [-3, -2, -1]])
+        with pytest.raises(TypeError):
+            _ = vector * 'dracula'
+        with pytest.raises(ValueError):
+            _ = 1 / Vector3d.xvector()
+
+    def test_eq(self):
+        v = Vector3d.zvector()
+        s1 = symmetry.D3
+        s2 = symmetry.C6
+        s3 = symmetry.O
+        # check element-wise comparison
+        assert np.all((v == s1.axis) == [True, True, False, False, False, False])
+        assert np.all((v == s2.axis) == [True, True, False, True, False, True])
+        # check that two lists compare per-row
+        assert np.all((s1.axis == s2.axis) == [1, 1, 1, 0, 0, 0])
+        # check incorrectly sized things compare as a flat falsse
+        assert not (s1 == s3)
+        # check that things that aren't vectors treat vector comparison as array
+        # comparison.
+        assert np.all((v == 1) == [0, 0, 1])
+
+    def test_dot(self, vector, something, number):
+        assert np.allclose(vector.dot(vector), (vector.data**2).sum(axis=-1))
+        assert np.allclose(vector.dot(something), something.dot(vector))
+        with pytest.raises(ValueError):
+            vector.dot(number)
 
 
-@pytest.mark.parametrize(
-    "shape",
-    [
-        (1,),
-        (2, 2),
-        (5, 4, 3),
-    ],
-)
-def test_zero(shape):
-    v = Vector3d.zero(shape)
-    assert v.shape == shape
-    assert v.data.shape[-1] == v.dim
+    def test_dot_outer(self, vector, something, capsys):
+        # Test dot_outer
+        d = vector.dot_outer(something)
+        assert d.shape == vector.shape + something.shape
+        for i in np.ndindex(vector.shape):
+            for j in np.ndindex(something.shape):
+                assert np.allclose(d[i + j], vector[i].dot(something[j]))
+        d_lazy = vector.dot_outer(something, lazy=True)
+        assert isinstance(d_lazy, np.ndarray)
+        assert np.allclose(d, d_lazy)
+        d_lazy_no_pb = vector.dot_outer(
+            something, lazy=True, progressbar=False, chunk_size=25
+        )
+        assert np.allclose(d_lazy, d_lazy_no_pb)
+        # Test progressbar
+        d = vector.dot_outer(something, lazy=True, progressbar=True)
+        out, _ = capsys.readouterr()
+        assert "Completed" in out
+        assert d.shape == vector.shape + something.shape
 
+    def test_cross(self, vector, something, number):
+        assert isinstance(vector.cross(something), Vector3d)
+        with pytest.raises(AttributeError):
+            vector.cross(number)
 
-def test_angle_with(vector, something):
-    a1 = vector.angle_with(vector)
-    assert np.allclose(a1, 0)
+    @pytest.mark.parametrize(
+        "azimuth, polar, radial, expected",
+        [
+            (np.pi / 4, np.pi / 4, 1, Vector3d((0.5, 0.5, 0.707107))),
+            (7 * np.pi / 6, 2 * np.pi / 3, 1, Vector3d((-0.75, -0.433013, -0.5))),
+        ],
+    )
+    def test_polar(self, azimuth, polar, radial, expected):
+        v1 = Vector3d.from_polar(azimuth, polar, radial)
+        v2 = Vector3d.from_polar(
+            np.rad2deg(azimuth), np.rad2deg(polar), radial, degrees=True
+        )
+        assert np.allclose(v1.data, expected.data, atol=1e-5)
+        assert np.allclose(v2.data, v1.data, atol=1e-5)
 
-    a2 = vector.angle_with(something)
-    assert np.all(a2 >= 0)
-    assert np.all(a2 <= np.pi)
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            (1,),
+            (2, 2),
+            (5, 4, 3),
+        ],
+    )
+    def test_zero(self, shape):
+        v = Vector3d.zero(shape)
+        assert v.shape == shape
+        assert v.data.shape[-1] == v.dim
 
-    a3 = vector.angle_with(something, degrees=True)
-    assert np.allclose(np.rad2deg(a2), a3)
+    def test_angle_with(self, vector, something):
+        a1 = vector.angle_with(vector)
+        assert np.allclose(a1, 0)
+    
+        a2 = vector.angle_with(something)
+        assert np.all(a2 >= 0)
+        assert np.all(a2 <= np.pi)
+    
+        a3 = vector.angle_with(something, degrees=True)
+        assert np.allclose(np.rad2deg(a2), a3)
 
+    def test_mul_array(self, vector):
+        array = np.random.rand(*vector.shape)
+        m1 = vector * array
+        m2 = array * vector
+        assert isinstance(m1, Vector3d)
+        assert isinstance(m2, Vector3d)
+        assert np.all(m1.data == m2.data)
 
-def test_mul_array(vector):
-    array = np.random.rand(*vector.shape)
-    m1 = vector * array
-    m2 = array * vector
-    assert isinstance(m1, Vector3d)
-    assert isinstance(m2, Vector3d)
-    assert np.all(m1.data == m2.data)
+    @pytest.mark.parametrize(
+        "vector, x, y, z",
+        [
+            ([1, 2, 3], 1, 2, 3),
+            ([[0, 2, 3], [2, 2, 3]], [0, 2], [2, 2], [3, 3]),
+        ],
+        indirect=["vector"],
+    )
+    def test_xyz(self, vector, x, y, z):
+        vx, vy, vz = vector.xyz
+        assert np.allclose(vx, x)
+        assert np.allclose(vy, y)
+        assert np.allclose(vz, z)
 
+    @pytest.mark.parametrize(
+        "vector, rotation, expected",
+        [
+            ((1, 0, 0), np.pi / 2, (0, 1, 0)),
+            ((1, 1, 0), np.pi / 2, (-1, 1, 0)),
+            (
+                (1, 1, 0),
+                [np.pi / 2, np.pi, 3 * np.pi / 2, 2 * np.pi],
+                [(-1, 1, 0), (-1, -1, 0), (1, -1, 0), (1, 1, 0)],
+            ),
+            ((1, 1, 1), -np.pi / 2, (1, -1, 1)),
+        ],
+        indirect=["vector"],
+    )
+    def test_rotate(self, vector, rotation, expected):
+        r = Vector3d(vector).rotate(Vector3d.zvector(), rotation)
+        assert isinstance(r, Vector3d)
+        assert np.allclose(r.data, expected)
 
-@pytest.mark.parametrize(
-    "vector, x, y, z",
-    [
-        ([1, 2, 3], 1, 2, 3),
-        ([[0, 2, 3], [2, 2, 3]], [0, 2], [2, 2], [3, 3]),
-    ],
-    indirect=["vector"],
-)
-def test_xyz(vector, x, y, z):
-    vx, vy, vz = vector.xyz
-    assert np.allclose(vx, x)
-    assert np.allclose(vy, y)
-    assert np.allclose(vz, z)
+    @pytest.mark.parametrize(
+        "vector, change",
+        [
+            ([1, 2, 3], 3),
+            ([[0, 2, 3], [2, 2, 3]], 1),
+            ([[0, 2, 3], [2, 2, 3]], [-1, 1]),
+        ],
+        indirect=["vector"],
+    )
+    def test_assign_xyz(self, vector, change):
+        array = vector.data
+        #test assignments to x
+        array[...,0] = change
+        vector.x = change
+        assert np.allclose(vector.data, array)
+        #test assignments to y
+        array[...,1] = change
+        vector.y = change
+        assert np.allclose(vector.data, array)
+        #test assignments to z
+        array[...,2] = change
+        vector.z = change
+        assert np.allclose(vector.data, array)
 
+    @pytest.mark.parametrize(
+        "vector",
+        [
+            [(1, 0, 0)],
+            [(0.5, 0.5, 1.25), (-1, -1, -1)],
+        ],
+        indirect=["vector"],
+    )
+    def test_perpendicular(self, vector: Vector3d):
+        # return perpendicular axis for nomral vector
+        assert np.allclose(vector.dot(vector.perpendicular), 0)
+        # return error for vector of zeros
+        with pytest.raises(ValueError):
+            _ = Vector3d.zero((1,)).perpendicular
 
-@pytest.mark.parametrize(
-    "vector, rotation, expected",
-    [
-        ((1, 0, 0), np.pi / 2, (0, 1, 0)),
-        ((1, 1, 0), np.pi / 2, (-1, 1, 0)),
-        (
-            (1, 1, 0),
-            [np.pi / 2, np.pi, 3 * np.pi / 2, 2 * np.pi],
-            [(-1, 1, 0), (-1, -1, 0), (1, -1, 0), (1, 1, 0)],
-        ),
-        ((1, 1, 1), -np.pi / 2, (1, -1, 1)),
-    ],
-    indirect=["vector"],
-)
-def test_rotate(vector, rotation, expected):
-    r = Vector3d(vector).rotate(Vector3d.zvector(), rotation)
-    assert isinstance(r, Vector3d)
-    assert np.allclose(r.data, expected)
+    def test_mean_xyz(self):
+        x = Vector3d.xvector()
+        y = Vector3d.yvector()
+        z = Vector3d.zvector()
+        t = Vector3d([3 * x.data, 3 * y.data, 3 * z.data])
+        np.allclose(t.mean().data, 1)
 
+    def test_transpose_1d(self):
+        v1 = Vector3d.random(7)
+        v2 = v1.transpose()
+    
+        assert np.allclose(v1.data, v2.data)
 
-@pytest.mark.parametrize(
-    "vector, data, expected",
-    [
-        ([1, 2, 3], 3, [3, 2, 3]),
-        ([[0, 2, 3], [2, 2, 3]], 1, [[1, 2, 3], [1, 2, 3]]),
-        ([[0, 2, 3], [2, 2, 3]], [-1, 1], [[-1, 2, 3], [1, 2, 3]]),
-    ],
-    indirect=["vector"],
-)
-def test_assign_x(vector, data, expected):
-    vector.x = data
-    assert np.allclose(vector.data, expected)
+    def test_transpose(self):
+        v_2d = Vector3d.random((4, 6))
+        v_3d = Vector3d.random((2, 3, 4))
+        v_4d = Vector3d.random((2, 1, 3, 4))
+        # expected to work for 2D shapes
+        assert v_2d.transpose().shape == (6,4)
+        # should not work for generic 3d without guidance
+        with pytest.raises(ValueError, match="Axes must be defined for more than"):
+            _ = v_3d.transpose()
+        # should also not work for incomplete axes information
+        with pytest.raises(ValueError, match="Number of axes is ill-defined"):
+            _ = v_3d.transpose(0, 2)
+        # But will work for full axes reordering list
+        assert v_3d.transpose(0,2,1).shape == (2, 4, 3)
+        assert v_4d.transpose(0,2,1,3).shape == (2, 3, 1, 4)
 
+    def test_get_nearest(self):
+        v_ref = Vector3d.zvector()
+        v = Vector3d([[0, 0, 0.9], [0, 0, 0.8], [0, 0, 1.1]])
+        v_nearest = v_ref.get_nearest(v)
+        assert np.allclose(v_nearest.data, [0, 0, 0.9])
+    
+        with pytest.raises(AttributeError, match="`get_nearest` only works for "):
+            v.get_nearest(v_ref)
 
-@pytest.mark.parametrize(
-    "vector, data, expected",
-    [
-        ([1, 2, 3], 3, [1, 3, 3]),
-        ([[0, 2, 3], [2, 2, 3]], 1, [[0, 1, 3], [2, 1, 3]]),
-        ([[0, 2, 3], [2, 2, 3]], [-1, 1], [[0, -1, 3], [2, 1, 3]]),
-    ],
-    indirect=["vector"],
-)
-def test_assign_y(vector, data, expected):
-    vector.y = data
-    assert np.allclose(vector.data, expected)
-
-
-@pytest.mark.parametrize(
-    "vector, data, expected",
-    [
-        ([1, 2, 3], 1, [1, 2, 1]),
-        ([[0, 2, 3], [2, 2, 3]], 1, [[0, 2, 1], [2, 2, 1]]),
-        ([[0, 2, 3], [2, 2, 3]], [-1, 1], [[0, 2, -1], [2, 2, 1]]),
-    ],
-    indirect=["vector"],
-)
-def test_assign_z(vector, data, expected):
-    vector.z = data
-    assert np.allclose(vector.data, expected)
-
-
-@pytest.mark.parametrize(
-    "vector",
-    [
-        [(1, 0, 0)],
-        [(0.5, 0.5, 1.25), (-1, -1, -1)],
-    ],
-    indirect=["vector"],
-)
-def test_perpendicular(vector: Vector3d):
-    assert np.allclose(vector.dot(vector.perpendicular), 0)
-
-
-def test_mean_xyz():
-    x = Vector3d.xvector()
-    y = Vector3d.yvector()
-    z = Vector3d.zvector()
-    t = Vector3d([3 * x.data, 3 * y.data, 3 * z.data])
-    np.allclose(t.mean().data, 1)
-
-
-def test_transpose_1d():
-    v1 = Vector3d.random(7)
-    v2 = v1.transpose()
-
-    assert np.allclose(v1.data, v2.data)
-
-
-@pytest.mark.parametrize(
-    "shape, expected_shape",
-    [
-        ((6, 4), (4, 6)),
-        ((11, 5), (5, 11)),
-    ],
-)
-def test_transpose_2d_data_shape(shape, expected_shape):
-    v1 = Vector3d.random(shape)
-    assert v1.transpose().shape == expected_shape
-
-
-def test_transpose_3d_no_axes():
-    v1 = Vector3d.random((5, 4, 2))
-    with pytest.raises(ValueError, match="Axes must be defined for more than"):
-        _ = v1.transpose()
-
-
-def test_transpose_3d_wrong_number_of_axes():
-    v1 = Vector3d.random((5, 4, 2))
-    with pytest.raises(ValueError, match="Number of axes is ill-defined"):
-        _ = v1.transpose(0, 2)
-
-
-@pytest.mark.parametrize(
-    "shape, expected_shape",
-    [
-        ((6, 4), (4, 6)),
-        ((11, 5), (5, 11)),
-    ],
-)
-def test_transpose_2d_shape(shape, expected_shape):
-    v1 = Vector3d.random(shape)
-    assert v1.transpose().shape == expected_shape
-
-
-@pytest.mark.parametrize(
-    "shape, expected_shape, axes",
-    [((6, 4, 5), (4, 5, 6), (1, 2, 0)), ((6, 4, 5), (5, 4, 6), (2, 1, 0))],
-)
-def test_transpose_3d_data_shape(shape, expected_shape, axes):
-    v1 = Vector3d.random(shape)
-    assert v1.transpose(*axes).shape == expected_shape
-
-
-@pytest.mark.parametrize(
-    "shape, expected_shape, axes",
-    [((6, 4, 5), (4, 5, 6), (1, 2, 0)), ((6, 4, 5), (5, 4, 6), (2, 1, 0))],
-)
-def test_transpose_3d_shape(shape, expected_shape, axes):
-    v1 = Vector3d.random(shape)
-    assert v1.transpose(*axes).shape == expected_shape
-
-
-def test_zero_perpendicular():
-    with pytest.raises(ValueError):
-        _ = Vector3d.zero((1,)).perpendicular
-
-
-def test_get_nearest():
-    v_ref = Vector3d.zvector()
-    v = Vector3d([[0, 0, 0.9], [0, 0, 0.8], [0, 0, 1.1]])
-    v_nearest = v_ref.get_nearest(v)
-    assert np.allclose(v_nearest.data, [0, 0, 0.9])
-
-    with pytest.raises(AttributeError, match="`get_nearest` only works for "):
-        v.get_nearest(v_ref)
-
-
-def test_tuples():
-    v = Vector3d(np.zeros([10, 3]))
-    tup = v._tuples
-    assert len(tup) == 1
-    v = Vector3d(np.arange(30).reshape([10, 3]))
-    tup = v._tuples
-    assert len(tup) == 10
+    def test_tuples(self):
+        v = Vector3d(np.zeros([10, 3]))
+        tup = v._tuples
+        assert len(tup) == 1
+        v = Vector3d(np.arange(30).reshape([10, 3]))
+        tup = v._tuples
+        assert len(tup) == 10
 
 
 class TestSpareNotImplemented:

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -608,6 +608,95 @@ class Vector3d(Object3d):
         """
         return other.__class__(np.cross(self.data, other.data))
 
+    def tensor(self, other:Vector3d) -> Vector3d:
+        r"""Return the tensor product of a vector with another vector.
+
+        For multi-dimensional arrays of vectors, casting is done the
+        same as in  :func:`numpy.einsum`, removing length 1 dimensions
+        and combining dimensions with matching lengths. See Notes
+        section for further details.
+
+        Parameters
+        ----------
+        other
+            Another Vector3d
+        
+        Returns
+        -------
+        tensor
+            Numpy array of tensor products with shape (...,3,3)
+        
+        Notes
+        -----
+
+        The tensor product operation in linear algebra is typically
+        represented by the symbol $\otimes$, and is the linear
+        transformation defined by
+
+        .. math::
+
+            (a \otimes b)c = (b \cdot c)a
+
+        for two 3d vectors in orthonormal space, this can be rewritten
+        in Einstein notation as
+
+        .. math::
+
+            (a \otimes b)c = a_ib_jc_j = b_ic_ia_j = (b \cdot c)a
+        
+        and $\otimes$ can be explicitly rewritten as
+
+        .. math::
+ 
+            (a \otimes b) = [a_1,a_2,a_3] \otimes [b_1, a_2, a_3]
+            =\begin{bmatrix}
+            a_1b_1 & a_1b_2 & a_1b_3 \\
+            a_2b_1 & a_2b_2 & a_2b_3 \\
+            a_3b_1 & a_3b_2 & a_3b_3 \\
+            \end{bmatrix}
+
+        For multi-dimensional arrays, two Vector3ds of length n and m,
+        respectively, would produce an n-by-m array of
+        3-by-3 tensors. However, two Vector3ds of length n would
+        produce a n-by-3-by-3 array, in accortance with numpy's rules
+        for array casting. To force orix to explicitly cast along all
+        dimensions of both Vector3d objects, use 
+        :func:`Vector3d.tensor_outer`.
+    """
+        if not isinstance(other,Vector3d):
+            raise ValueError(f"{other} is not a vector")
+        return np.einsum('...i,...j->...ij', self.data, other.data)
+
+    def tensor_outer(self, other: Vector3d) -> Vector3d:
+        r"""Return the outer tensor product of a vector with another
+        vector.
+
+        Works identically to :func:`Vector3d.tensor`, but applied to
+        every axis regardless of size. See that function for further
+        details.
+
+        Parameters
+        ----------
+        other
+            Another Vector3d
+
+        Returns
+        -------
+        tensor
+            Numpy array of tensor products with shape
+            (self.shape, other.shape, 3, 3)
+        """
+        return np.stack(
+            [
+                np.stack(
+                    [np.tensordot(a, b, axes=-1) for a in self.xyz],
+                    axis=-1,
+                )
+                for b in other.xyz
+            ],
+            axis=-1,
+        )
+
     def angle_with(self, other: Vector3d, degrees: bool = False) -> np.ndarray:
         """Return the angles between these vectors in other vectors.
 

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -608,7 +608,7 @@ class Vector3d(Object3d):
         """
         return other.__class__(np.cross(self.data, other.data))
 
-    def tensor(self, other:Vector3d) -> Vector3d:
+    def tensor(self, other: Vector3d) -> Vector3d:
         r"""Return the tensor product of a vector with another vector.
 
         For multi-dimensional arrays of vectors, casting is done the
@@ -663,9 +663,9 @@ class Vector3d(Object3d):
         dimensions of both Vector3d objects, use 
         :func:`Vector3d.tensor_outer`.
     """
-        if not isinstance(other,Vector3d):
+        if not isinstance(other, Vector3d):
             raise ValueError(f"{other} is not a vector")
-        return np.einsum('...i,...j->...ij', self.data, other.data)
+        return np.einsum("...i,...j->...ij", self.data, other.data)
 
     def tensor_outer(self, other: Vector3d) -> Vector3d:
         r"""Return the outer tensor product of a vector with another
@@ -686,7 +686,7 @@ class Vector3d(Object3d):
             Numpy array of tensor products with shape
             (self.shape, other.shape, 3, 3)
         """
-        if not isinstance(other,Vector3d):
+        if not isinstance(other, Vector3d):
             raise ValueError(f"{other} is not a vector")
         return np.stack(
             [

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -686,6 +686,8 @@ class Vector3d(Object3d):
             Numpy array of tensor products with shape
             (self.shape, other.shape, 3, 3)
         """
+        if not isinstance(other,Vector3d):
+            raise ValueError(f"{other} is not a vector")
         return np.stack(
             [
                 np.stack(


### PR DESCRIPTION
#### Description of the change

1) Adds `Vector3d.tensor` and `Vector3d.tensor_outer` 
2) Updates test_vector3d.py to better match the class-level organization of other test files and increases overage. 

NOTE: this looks like a large update, but 300+ lines are just reformatting existing tests.

I would like to add this to the  0.16 release if possible.

#### Progress of the PR
- [x] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### Minimal example of the bug fix or new feature
```
# Using the definition of the tensor product as verification:
a = Vector3d.random()
b = Vector3d.random()
c = Vector3d.random()
abc = np.dot((a.tensor(b)[0]), c.data[0])
bca = (b.dot(c) * a).data
abc_outer = np.dot((a.tensor_outer(b)[0]), c.data[0])

# printing an example
print(a,'\n\n',b,'\n\n',a.tensor(b)[0])

>>> Vector3d (1,)
          [[ 0.8429 -0.3101  0.4398]] 
>>> Vector3d (1,)
           [[0.4767 0.1299 0.8694]] 
>>>  [[ 0.40181049  0.10951157  0.73277669]
          [-0.14782216 -0.04028824 -0.26958139]
          [ 0.20967513  0.05714598  0.38238187]]
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.