### PR TITLE
Retain miller symmetry information

### DIFF
--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -222,7 +222,7 @@ class Quaternion(Object3d):
                 )
             else:  # pragma: no cover
                 v = qu_rotate_vec(self.unit.data, other.data)
-            if isinstance(other, Miller):
+            if hasattr(object, 'phase'):
                 m = other.__class__(xyz=v, phase=other.phase)
                 m.coordinate_format = other.coordinate_format
                 return m

--- a/orix/vector/miller.py
+++ b/orix/vector/miller.py
@@ -366,6 +366,51 @@ class Miller(Vector3d):
         m.coordinate_format = self.coordinate_format
         return m
 
+    def __neg__(self) -> Vector3d:
+        out = self.__class__(-self.data,phase=self.phase)
+        out.coordinate_format = self.coordinate_format
+        return out
+
+    def __add__(
+        self, other: int | float | list | tuple | np.ndarray | Vector3d | Miller
+    ) -> Miller:
+        data = None
+        if isinstance(other, Vector3d):
+            data =self.data + other.data
+        elif isinstance(other, (int, float)):
+            data =self.data + other
+        elif isinstance(other, (list, tuple)):
+            other = np.array(other)
+        if isinstance(other, np.ndarray):
+            data = self.data - other[..., np.newaxis]
+
+        if data is None:
+            return NotImplemented
+
+        out = self.__class__(data, self.phase)
+        out.coordinate_format = self.coordinate_format
+        return out
+
+    def __sub__(
+        self, other: int | float | list | tuple | np.ndarray | Vector3d | Miller
+    ) -> Miller:
+        data = None
+        if isinstance(other, Vector3d):
+            data =self.data - other.data
+        elif isinstance(other, (int, float)):
+            data =self.data - other
+        elif isinstance(other, (list, tuple)):
+            other = np.array(other)
+        if isinstance(other, np.ndarray):
+            data = self.data - other[..., np.newaxis]
+
+        if data is None:
+            return NotImplemented
+
+        out = self.__class__(data, self.phase)
+        out.coordinate_format = self.coordinate_format
+        return out
+
     # ------------------------ Class methods ------------------------- #
 
     @classmethod

--- a/orix/vector/miller.py
+++ b/orix/vector/miller.py
@@ -367,7 +367,7 @@ class Miller(Vector3d):
         return m
 
     def __neg__(self) -> Vector3d:
-        out = self.__class__(-self.data,phase=self.phase)
+        out = self.__class__(-self.data, phase=self.phase)
         out.coordinate_format = self.coordinate_format
         return out
 
@@ -376,9 +376,9 @@ class Miller(Vector3d):
     ) -> Miller:
         data = None
         if isinstance(other, Vector3d):
-            data =self.data + other.data
+            data = self.data + other.data
         elif isinstance(other, (int, float)):
-            data =self.data + other
+            data = self.data + other
         elif isinstance(other, (list, tuple)):
             other = np.array(other)
         if isinstance(other, np.ndarray):
@@ -396,9 +396,9 @@ class Miller(Vector3d):
     ) -> Miller:
         data = None
         if isinstance(other, Vector3d):
-            data =self.data - other.data
+            data = self.data - other.data
         elif isinstance(other, (int, float)):
-            data =self.data - other
+            data = self.data - other
         elif isinstance(other, (list, tuple)):
             other = np.array(other)
         if isinstance(other, np.ndarray):

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 _logger = logging.getLogger(__name__)
 
+
 class Vector3d(Object3d):
     r"""Three-dimensional vectors.
 
@@ -247,7 +248,7 @@ class Vector3d(Object3d):
         if isinstance(other, Vector3d):
             # Vector + Miller = Miller
             self._check_for_symmetry_mismatch(other)
-            if hasattr(other,'phase'):
+            if hasattr(other, "phase"):
                 return other + self
             else:
                 return self.__class__(self.data + other.data)
@@ -272,8 +273,8 @@ class Vector3d(Object3d):
         if isinstance(other, Vector3d):
             # Vector - Miller = Miller
             self._check_for_symmetry_mismatch(other)
-            if hasattr(other,'phase'):
-                return - other + self
+            if hasattr(other, "phase"):
+                return -other + self
             else:
                 return self.__class__(self.data - other.data)
         elif isinstance(other, (int, float)):
@@ -341,7 +342,6 @@ class Vector3d(Object3d):
 
     def __hash__(self) -> int:
         return id(self)
-
 
     # ------------------------ Class methods ------------------------- #
 
@@ -1628,10 +1628,14 @@ class Vector3d(Object3d):
         # subclasses (most importantly, Miller) do, and adding the checks
         # in Vector3D allows for checking regardless of order ie, (v+m vs m+v)
         # as well as identical messages in all subclasses.
-        phase_checks = [hasattr(self,'phase'), hasattr(other,'phase')]
+        phase_checks = [hasattr(self, "phase"), hasattr(other, "phase")]
         if np.all(phase_checks):
             if self.phase.point_group != other.phase.point_group:
-                _logger.warning("WARNING: Point group mismatch detected between crystal vectors.")
+                _logger.warning(
+                    "WARNING: Point group mismatch detected between crystal vectors."
+                )
         elif np.any(phase_checks):
-            _logger.warning("WARNING: This operation is between a crystal and real space vector.")
+            _logger.warning(
+                "WARNING: This operation is between a crystal and real space vector."
+            )
         return None

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+import logging
 from typing import TYPE_CHECKING, Any
 
 import dask.array as da
@@ -35,6 +36,7 @@ from orix.utils import _constants
 if TYPE_CHECKING:  # pragma: no cover
     from orix.quaternion.symmetry import Symmetry
 
+_logger = logging.getLogger(__name__)
 
 class Vector3d(Object3d):
     r"""Three-dimensional vectors.
@@ -244,6 +246,7 @@ class Vector3d(Object3d):
     ) -> Vector3d:
         if isinstance(other, Vector3d):
             # Vector + Miller = Miller
+            self._check_for_symmetry_mismatch(other)
             if hasattr(other,'phase'):
                 return other + self
             else:
@@ -268,6 +271,7 @@ class Vector3d(Object3d):
     ) -> Vector3d:
         if isinstance(other, Vector3d):
             # Vector - Miller = Miller
+            self._check_for_symmetry_mismatch(other)
             if hasattr(other,'phase'):
                 return - other + self
             else:
@@ -330,12 +334,14 @@ class Vector3d(Object3d):
 
     def __eq__(self, other: Any) -> np.ndarray:
         if isinstance(other, Vector3d):
+            self._check_for_symmetry_mismatch(other)
             return np.all(self.data == other.data, axis=-1)
         else:
             return self.data == other
 
     def __hash__(self) -> int:
         return id(self)
+
 
     # ------------------------ Class methods ------------------------- #
 
@@ -1616,3 +1622,16 @@ class Vector3d(Object3d):
         v2 = da.from_array(other.data, chunks=chunks2)
 
         return da.tensordot(v1, v2, axes=(v1.ndim - 1, v2.ndim - 1))
+
+    def _check_for_symmetry_mismatch(self, other) -> None:
+        # NOTE: Vector3D does not include phase information, but some of its
+        # subclasses (most importantly, Miller) do, and adding the checks
+        # in Vector3D allows for checking regardless of order ie, (v+m vs m+v)
+        # as well as identical messages in all subclasses.
+        phase_checks = [hasattr(self,'phase'), hasattr(other,'phase')]
+        if np.all(phase_checks):
+            if self.phase.point_group != other.phase.point_group:
+                _logger.warning("WARNING: Point group mismatch detected between crystal vectors.")
+        elif np.any(phase_checks):
+            _logger.warning("WARNING: This operation is between a crystal and real space vector.")
+        return None

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -255,14 +255,8 @@ class Vector3d(Object3d):
         return NotImplemented
 
     def __radd__(self, other: int | float | list | tuple | np.ndarray) -> Vector3d:
-        if isinstance(other, (int, float)):
-            return self.__class__(other + self.data)
-        elif isinstance(other, (list, tuple)):
-            other = np.array(other)
-
-        if isinstance(other, np.ndarray):
-            return self.__class__(other[..., np.newaxis] + self.data)
-
+        if isinstance(other, (int, float, list, tuple, np.ndarray, Vector3d)):
+            return self + other
         return NotImplemented
 
     def __sub__(
@@ -281,14 +275,8 @@ class Vector3d(Object3d):
         return NotImplemented
 
     def __rsub__(self, other: int | float | list | tuple | np.ndarray) -> Vector3d:
-        if isinstance(other, (int, float)):
-            return self.__class__(other - self.data)
-        elif isinstance(other, (list, tuple)):
-            other = np.array(other)
-
-        if isinstance(other, np.ndarray):
-            return self.__class__(other[..., np.newaxis] - self.data)
-
+        if isinstance(other, (int, float, list, tuple, np.ndarray, Vector3d)):
+            return -self + other
         return NotImplemented
 
     def __mul__(

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -243,7 +243,11 @@ class Vector3d(Object3d):
         self, other: int | float | list | tuple | np.ndarray | Vector3d
     ) -> Vector3d:
         if isinstance(other, Vector3d):
-            return self.__class__(self.data + other.data)
+            # Vector + Miller = Miller
+            if hasattr(other,'phase'):
+                return other + self
+            else:
+                return self.__class__(self.data + other.data)
         elif isinstance(other, (int, float)):
             return self.__class__(self.data + other)
         elif isinstance(other, (list, tuple)):
@@ -263,7 +267,11 @@ class Vector3d(Object3d):
         self, other: int | float | list | tuple | np.ndarray | Vector3d
     ) -> Vector3d:
         if isinstance(other, Vector3d):
-            return self.__class__(self.data - other.data)
+            # Vector - Miller = Miller
+            if hasattr(other,'phase'):
+                return - other + self
+            else:
+                return self.__class__(self.data - other.data)
         elif isinstance(other, (int, float)):
             return self.__class__(self.data - other)
         elif isinstance(other, (list, tuple)):
@@ -298,14 +306,8 @@ class Vector3d(Object3d):
         return NotImplemented
 
     def __rmul__(self, other: int | float | list | tuple | np.ndarray) -> Vector3d:
-        if isinstance(other, (int, float)):
-            return self.__class__(other * self.data)
-        elif isinstance(other, (list, tuple)):
-            other = np.array(other)
-
-        if isinstance(other, np.ndarray):
-            return self.__class__(other[..., np.newaxis] * self.data)
-
+        if isinstance(other, (int, float, list, tuple, np.ndarray, Vector3d)):
+            return self * other
         return NotImplemented
 
     def __truediv__(


### PR DESCRIPTION
#### Description of the change
Solves #501. @hakonanes and/or @viljarjf , let me know what you think of this approach. if we like it, I will address the failing unit tests add some new ones, and include documentation.

Main features of this PR:
- The Miller dunder methods `__neg__`, `__add__`, and `__sub__` no longer discard phase information or coordinate preference
- A warning has been added with the new logger feature that alerts users when a symmetry mismatch occurs during vector operations
- Slight simplification of `Vector3d._radd__`, `Vector3d._rsub__` , and `Vector3d.__rmul__` to avoid repeating code and work as expected when inherited by `Miller`


#### Progress of the PR
- [ ] [Docstrings for all functions](https://numpydoc.readthedocs.io/en/latest/example.html)
- [ ] Unit tests with pytest for all lines
- [ ] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/dev/code_style.html)

#### Minimal example of the bug fix or new feature
```
from orix.vector import Miller, Vector3d
from orix.crystal_map import Phase

p = Phase(point_group="m-3m")
m = Miller([1, 0, 0], phase=p)
v = Vector3d([1,2,3])

print(m)
>>> Miller (1,), point group m-3m, xyz
>>> [[1 0 0]]

print(-m)
>>> Miller (1,), point group None, xyz
>>> [[-1 0 0]]

print(v)
>>> Vector3d (1,)
>>> [[1 2 3]]

x = v+m
y = m+v

print(x)
>>> Miller (1,), point group m-3m, xyz
>>> [[2 2 3]]

print(y)
>>> Miller (1,), point group m-3m, xyz
>>> [[2 2 3]]
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.